### PR TITLE
Adds easy mode.

### DIFF
--- a/gamedata/configs/text/eng/ui_st_mcm_soulslite.xml
+++ b/gamedata/configs/text/eng/ui_st_mcm_soulslite.xml
@@ -50,6 +50,9 @@
     <string id="ui_mcm_soulslike_items_title">
         <text>Item Settings</text>
     </string>
+    <string id="ui_mcm_soulslike_items_allow_basic_items_lost_on_death">
+        <text>If you prefer easier mode, imo closer to pure DarkSouls expierience you can disable weapon, armour and ammo loss on death.</text>
+    </string>
     <string id="ui_mcm_soulslike_items_allow_weapon_loss">
         <text>Allow Weapon Loss</text>
     </string>

--- a/gamedata/scripts/soulslike_mcm.script
+++ b/gamedata/scripts/soulslike_mcm.script
@@ -124,6 +124,13 @@ function on_mcm_load()
                 def = 0.05
             },
             {
+                id = "do_not_allow_basic_items_lost_on_death",
+                type = "check",
+                text = "ui_mcm_soulslike_items_allow_basic_items_lost_on_death",
+                val = 1,
+                def = false
+            },
+            {
                 id = "allow_weapon_loss",
                 type = "check",
                 val = 1,
@@ -515,6 +522,10 @@ end
 function allow_weapon_loss()
     return get_config("items/allow_weapon_loss", true)
 end 
+
+function get_do_not_allow_basic_items_lost_on_death()
+    return get_config("items/do_not_allow_basic_items_lost_on_death", false)
+end
 
 -- Ambush
 function mutant_ambush_chance()

--- a/gamedata/scripts/soulslike_scenarios.script
+++ b/gamedata/scripts/soulslike_scenarios.script
@@ -19,6 +19,11 @@ local ignore_list = {
     ["wpn_axe3"] = true,
 }
 
+local additional_ignore_list = { -- used by easier soulslike mod
+    ["medkit"] = true,
+    ["bandage"] = true,
+}
+
 local obj_to_spawn_classes = {
     -- kind
     ["AI_STL_S"]    = "NPC (Stalker)",
@@ -897,6 +902,35 @@ end
 function SoulslikeScenarioLogic:TransferItem(item, container, looter)
     local sec = item:section()
     local to_id = container:id()
+    local do_not_allow_basic_items_lost = self.logic_state.do_not_allow_basic_items_lost_on_death
+
+    if do_not_allow_basic_items_lost then
+        soulslike.debug("Do not allow basic items lost was true")
+        if IsWeapon(item) then
+            soulslike.debug("Item is weapon and wont be transfered: "..sec)
+            return false
+        end
+
+        if IsHeadgear(item) then
+            soulslike.debug("Item is headgear and wont be transfered: "..sec)
+            return false
+        end
+
+        if IsOutfit(item) then
+            soulslike.debug("Item is outfit and wont be transfered: "..sec)
+            return false
+        end
+        
+        if IsAmmo(item) then
+            soulslike.debug("Item is ammo and wont be transfered: "..sec)
+            return false
+        end
+
+        if additional_ignore_list[sec] then
+            soulslike.debug("Item is in additional ignore list: "..sec)
+            return false
+        end
+    end
 
     if ignore_list[sec] then
         soulslike.debug("Item is in ignore list: "..sec)


### PR DESCRIPTION
Adds easy mode for soulsilke game mode.
In case of death player wont loose his weapons, armor, ammunition and basic healing items that include bandage and medkit.
Player can choose this mode from MCM, by default it is disabled