### PR TITLE
Add LuaJIT test suite (820 specs); fix 20 gamedata defects

### DIFF
--- a/.claude/skills/ste/SKILL.md
+++ b/.claude/skills/ste/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: ste
+description: Write documentation, READMEs, PR and commit descriptions, release notes, error messages, code comments, and chat replies in plain, direct prose modeled on ASD-STE100 Simplified Technical English. Use short sentences, active voice, one name for one thing, and no marketing adjectives or jargon-stacking. Use this skill when the user writes or edits a README, PR description, changelog, error message, or code comment, and when answering the user in chat. Also use it when the user asks for "simplified English," "plain language," "STE," or a "simple, direct writing style," or says prior writing sounded like corporate fluff, hedge-stacked, or like AI slop. This skill does not apply to code, identifiers, or command syntax. It also does not apply to marketing copy or writing that needs a distinct voice.
+---
+
+# STE Writing
+
+This skill produces plain, direct technical prose, modeled on ASD-STE100. ASD-STE100
+is the Simplified Technical English standard used in the aerospace industry. The
+goal is a reader who is tired, in a hurry, or reading in a second language. This
+reader must get the point on the first pass.
+
+## The point of the rules, so you can judge when they don't apply
+
+Each rule below removes one specific kind of friction. Some examples: a word with
+two meanings, a sentence doing three jobs at once, or a hedge buried in a
+subordinate clause. No rule exists for its own sake.
+
+Sometimes a rule would delete or hide something the reader needs, such as a caveat,
+an uncertainty, or a precise technical distinction. When a rule does this, it
+defeats its own purpose. Do not follow it in that case.
+
+Almost always, the fix is to restructure the sentence, not to drop plain writing. A
+sentence that seems to need a hedge word or a semicolon is often two ideas welded
+into one. Split it into two sentences instead.
+
+For example, take this sentence: "this likely works but I have not verified it in
+this environment." This is not a case where the words "likely" and "but" carry the
+real point. It states two separate claims. Split them like this: "This should work.
+I have not verified it in this environment." This keeps the same information in a
+plainer form. The caveat now has its own sentence, instead of hiding inside a
+dependent clause.
+
+Keep a jargon word, a longer sentence, or an unusual construction only when
+restructuring cannot keep the meaning. Three real cases fit this:
+
+1. A domain term with no plain synonym. Do not rename a race condition a "timing
+   hiccup."
+2. A number or legal qualifier, where any paraphrase changes what is actually true.
+3. A named identifier that must match the code exactly.
+
+When you keep something non-plain, keep the rest of the sentence as plain as you
+can. This keeps the deviation small and isolated. Do not let one exception open the
+door to hedge-stacked prose in the rest of the paragraph.
+
+## Scope
+
+This skill applies to:
+- Documentation, READMEs, PR and commit descriptions, error messages, release
+  notes, and code comments.
+- Chat replies to the user. Answers, explanations, and summaries of work get the
+  same plain style as the docs.
+
+This skill does not apply to:
+- Code, identifiers, or command syntax. Write those in their normal form.
+- Marketing copy, essays, or writing that needs a distinct voice.
+
+## Two registers, same underlying habit
+
+Procedures, runbooks, and error messages carry a real cost when a reader misreads
+them. Lean tighter here. Use shorter sentences. Give one instruction per step. Use
+a numbered list for anything sequential. State the condition before the command.
+For example, write "If the file is missing, create it," not "Create the file if it
+is missing."
+
+READMEs, PR descriptions, general docs, and chat replies can breathe more. Keep the
+plain-word and active-voice habit. Do not force a natural explanation into a rigid
+template just to hit a word count. The point is clarity, not a checklist.
+
+Chat sits in this looser register. Plain style is not a flat monotone. Answer the
+question, keep a normal conversational shape, and drop the hedge-stacking and the
+filler.
+
+Do not treat these as two separate rulebooks. They share one instinct: say one
+thing per sentence, use the plain word, and make the actor visible. Apply this
+instinct with more or less pressure, based on how costly a misread would be.
+
+## Habits that do the actual work
+
+**Lead with the point.** Open with the single most important fact. Do not warm up
+with context, background, or scene-setting before it. Cut any sentence whose only
+job is to lead into the real sentence. If the reader stops after the first
+sentence, they should already have the point.
+
+**Naming.** Use one name for one thing across a document. Do not call the same
+function, flag, or concept by two different names, even to avoid repeating a word.
+Repetition is fine. Ambiguity is not.
+
+**Word choice.** Reach for the short, common word before the formal one:
+- Use "start," not "commence."
+- Use "use," not "utilize."
+- Use "help," not "facilitate."
+- Use "before," not "prior to."
+- Use "about," not "regarding."
+- Use "get," not "obtain."
+- Use "show," not "demonstrate."
+
+Skip marketing adjectives entirely: seamless, robust, powerful, cutting-edge,
+effortless, world-class, next-generation, revolutionary. These words do not
+describe anything a reader can check.
+
+**Active voice, real verbs.** Write "the parser reads the file," not "the file is
+read by the parser." Write "analyze the log," not "perform an analysis of the log."
+Skip stacked hedging, such as "it is important to note that this may help to
+improve." Write "this improves X" instead.
+
+**Sentence shape.** Write one instruction or one claim per sentence. If a sentence
+does two jobs, it is probably two sentences. Do not use contractions. Write "does
+not," not "doesn't." Do not use semicolons. A semicolon almost always means the
+text needs two sentences instead of one.
+
+**Structure.** Keep one topic per paragraph. For anything sequential, use a
+numbered list. Give one action per item, in the imperative. Write "Run the
+migration," not "the migration should be run." State a condition before the action
+it triggers.
+
+## Before you hand back the text
+
+Skim the text once for these habits. This is not a pass-or-fail gate. It is the
+fastest way to catch old habits slipping back in.
+
+1. A sentence that welds two ideas together with "and," "but," or a semicolon.
+   Split it.
+2. A contraction. Expand it.
+3. Passive voice, where you know who does the action. Make that actor the subject.
+4. A word doing a job a plainer word could do just as well.
+5. The same thing named two different ways in two places.
+6. An opening sentence that is wind-up, not the point. Move the key fact to the
+   front.
+
+Some items on this list may be there on purpose, when splitting or simplifying
+would lose the real point. In that case, leave the text as is. Judgment matters
+more than mechanical compliance here.
+
+## Quick before/after
+
+Before: "It should be noted that the utilization of this endpoint may potentially
+facilitate a reduction in latency, although this has not been comprehensively
+validated across all production environments."
+
+After: "This endpoint may reduce latency. We have not fully tested this across all
+production environments."
+
+Before: "In the event that the configuration file cannot be parsed, an error will
+be surfaced to the user indicating the nature of the malformed input."
+
+After: "If the config file has invalid JSON, the app shows an error. The error
+names the invalid field."

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: tdd
+display_name: "Test-Driven Development (TDD)"
+description: "Drive implementation through failing tests. Red → Green → Refactor."
+---
+
+# Test-Driven Development (TDD)
+
+## What this skill does
+
+Test-Driven Development is an implementation discipline where tests are written before
+the code they verify. Each unit of new behavior is specified as a failing test first.
+The implementation is then written to satisfy that test — nothing more. The cycle repeats
+for each unit of behavior.
+
+**Red → Green → Refactor:**
+1. **Red** — Write a failing test that defines the expected behavior
+2. **Green** — Write the minimal implementation to make the test pass
+3. **Refactor** — Clean up the implementation without changing behavior; tests remain green
+
+The test is not documentation of code that already exists. It is a specification of
+behavior that does not yet exist. This distinction is the discipline.
+
+## Who writes the tests — separate, untainted authorship
+
+The tests for a unit of work are authored by a **different agent than the one that implements
+it** — the `test-author` agent. This is mandatory whenever this skill is active. When the same
+agent writes both, the tests drift toward confirming the implementation it just built (and the
+shortcuts it took) instead of independently specifying required behavior — the exact
+anti-pattern above. A separate author that never sees the implementation cannot rubber-stamp
+it. This mirrors the pipeline's existing untainted-payload pattern (Step 2 research, the
+drift guard): the test-author receives the slice's **specification**, never the implementer's
+code or reasoning.
+
+## Contract → Red → Green (making test-first possible in any language)
+
+Pure test-first can stall in statically-typed languages: a test cannot compile against a
+foundational type that does not exist yet, producing a *compile*-red instead of a *behavioral*
+red. The resolution is to let the test phase bootstrap the contract:
+
+1. **Contract + Red** — the `test-author` writes **just-enough contract stubs** (the public
+   signatures/types this slice introduces, each throwing the not-implemented equivalent) so the
+   tests compile, then writes the failing tests. The stubs are structural scaffolding only — no
+   logic — so they are not "the code under test." The result is a true behavioral red: tests
+   compile and fail on assertions.
+2. **Green** — the implementer fills the logic to satisfy the tests, and **never edits the
+   tests**.
+3. **Refactor** — clean up against the green suite, as below.
+
+### Per-slice decision tree — pure test-first when able, degrade when not
+
+```
+For each unit of work where this skill is active:
+  1. Structural/wiring only, no logic?  → this skill does not apply (see "When to apply"). No test-author.
+  2. Can the contract be declared before the logic?
+     • Yes → Contract+Red (test-author) → Green (implementer).   [pure TDD — the default]
+     • No  → the contract is itself the unknown (a spike). Degrade to BLIND TEST-AFTER:
+             the implementer builds the slice, then the SAME separate test-author writes tests
+             from the spec only (reading the public surface to compile, never the implementation
+             logic to derive assertions). Record the slice as test-after so the degradation is visible.
+```
+
+The separate, untainted authorship never degrades — only the test-first *ordering* does, and
+only when the contract genuinely cannot precede the code.
+
+## When to apply this skill
+
+Apply when:
+- New business logic, rules, or algorithms are being introduced
+- Data transformation, computation, or validation behavior is being defined
+- The expected inputs and outputs of new code can be stated before writing it
+- Correctness must be verifiable and regress-proof over time
+
+Do not apply when:
+- The work is purely structural: wiring, configuration, or scaffolding with no logic
+- Behavior is genuinely unknown until after an exploratory implementation (spike)
+- A black-box dependency must be understood before tests can be meaningful — use
+  Learning Tests first, then return to TDD for the code built around it
+
+## What this skill requires
+
+- Tests are authored by the separate `test-author` agent, not the implementer (see above)
+- Tests are written and committed before the implementation they verify
+- The test must fail before any implementation is written — a test that passes immediately
+  is not verifying new behavior
+- Test commits and implementation commits are kept separate
+- The full suite stays green at every commit; regressions are resolved immediately
+- Refactoring happens only against a green suite, never while tests are failing
+
+## Language and framework agnosticism
+
+This skill imposes no requirement on language, framework, or toolchain. Detect the
+project's existing test framework from its configuration files, existing test files, build
+manifests, and conventions. Use whatever is already in place. If no test framework exists,
+surface that as a blocking question before proceeding — do not assume one.
+
+## Relationship with Learning Tests
+
+If Learning Tests are also active, they run first. Learning tests establish what external
+or black-box code actually does; that knowledge informs what the TDD tests should assert
+about the code being built around it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,133 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Writing style
+
+Use the `ste` skill for every response to this user, including chat replies.
+
+## What this is
+
+A gameplay mod for S.T.A.L.K.E.R. Anomaly, written in Lua. On death the player is
+rescued and wakes at a chosen spawn bed. Their gear stays where they died, degraded
+or partly lost depending on MCM settings.
+
+Only `gamedata/` ships. `deploy.bat` copies it into a local GAMMA mods folder. The
+paths in `deploy.bat` are hard-coded to one machine.
+
+Two directories are reference material, not part of the mod, and are gitignored:
+
+- `_scripts/` — stock Anomaly scripts. Read these to learn the base-game API.
+- `_items/` — stock item configs.
+
+The mod overwrites no stock script or ltx file. Keep it that way. Conflict-free
+loading is a stated feature.
+
+## Commands
+
+```
+tests\run.bat                     all specs (self-tests gate unit and e2e)
+tests\run.bat self|unit|e2e       one suite
+tests\run.bat --file ambush       spec files whose path contains "ambush"
+tests\run.bat -t "keep roll"      tests whose full name contains "keep roll"
+tests\locals.bat                  localisation spec, then the report (strict;
+                                  --lax to not fail on untranslated strings)
+tests\tools\luajit.exe probe.lua  reachability check
+deploy.bat                        copy gamedata\ to the local GAMMA mods folder
+```
+
+Exit codes: 0 pass, 1 fail, 2 no Lua runtime or no match.
+
+The suite needs LuaJIT 2.x or Lua 5.1. Lua 5.2 and later do not work, because the
+module loader uses `setfenv`. `run.bat` looks for `luajit.exe` on PATH, then
+`tests\tools\luajit.exe`. `tools\` is gitignored. `tests/README.md` gives the build
+steps.
+
+There is no build step, no linter, and no CI.
+
+## Architecture
+
+### Script modules
+
+The engine loads every file in `gamedata/scripts/` as a module named after the
+file. A module reads another module through its global name, such as
+`soulslike.debug(...)`.
+
+| File | Role |
+|---|---|
+| `soulslike.script` | Entry point. Registers every callback in `on_game_start()`. Holds shared state, enums, helpers, and the hit queue. |
+| `soulslike_scenarios.script` | `SoulslikeScenarioLogic` base class and its four subclasses. Almost all death and respawn behaviour lives here. |
+| `soulslike_scenario_logic_factory.script` | Reads the fatal hit, picks a scenario, and builds the logic object. |
+| `soulslike_mcm.script` | The whole option tree, plus one `get_config` accessor every getter funnels through. |
+| `soulslike_classes.script` | `TimedQueue`, used for the hit pool. |
+| `soulslike_message_factory.script` | Picks a random rescuer message string id per beat. |
+| `soulslike_note.script` | The note item the rescuer leaves. |
+| `soulslike_sleep_dialog.script` | Sleep-to-save dialog for hardcore save mode. |
+| `souslike_gamemode_injector_mcm.script` | Monkey-patches `ui_mm_faction_select.UINewGame` to add the Soulslike checkbox to new game. Note the typo in the filename. It is load-bearing. |
+
+### The death flow
+
+1. `actor_on_before_hit` pushes each hit into a `TimedQueue`. The queue expires
+   entries after `MAX_HIT_TIME` (30 s) and holds `MAX_HIT_POOL_COUNT` (30).
+2. `actor_on_before_death` asks the factory for a scenario.
+3. The factory aggregates the queued hits, weights later hits more heavily, doubles
+   the fatal one, and picks the strongest `entity_type`. That drives which
+   `SCENARIOS` variant runs.
+4. The scenario object runs the sequence: move items to a stash, roll condition
+   loss and item loss, apply rank and reputation loss, spawn an ambush, advance
+   time, respawn the actor, and send the wakeup message.
+
+`SCENARIOS` (`Default`, `RFDetectorStash`, `HiddenStash`, `NoLoss`) and
+`entity_type` (`Stalker`, `Monster`, `Anomaly`, `Self`, `Other`) are both defined
+near the top of `soulslike.script`.
+
+### State
+
+All mod state lives in one table reached through
+`soulslike.get_soulslike_state()`, saved and loaded through the `save_state` and
+`load_state` callbacks. The getter creates any missing top-level collection, so it
+is safe on an old save.
+
+### MCM
+
+Two contracts break silently. Both have specs.
+
+**Storage.** The key is the path, `"soulslike/<group>/<option>"`. `val` is a type
+code, not an initial value: `0` string, `1` boolean, `2` float. A wrong `val` reads
+and writes through the wrong type and never persists. Nothing fails loudly.
+
+**Labels.** A node with no `text` derives its string id as
+`"ui_mcm_" .. <path with / replaced by _>`. A missing translation renders the raw
+string id on the settings screen. Run `tests\locals.bat` after adding, renaming, or
+moving any option.
+
+### Localisation
+
+`gamedata/configs/text/eng/` and `gamedata/configs/text/rus/`.
+
+The Russian files are **windows-1251**, one byte per Cyrillic letter, and must stay
+that way. A file re-saved as UTF-8 still parses and every string id still resolves,
+so every label spec stays green while every Russian string renders as mojibake.
+This has already happened once across ten commits. VS Code guesses the encoding
+wrong on open and rewrites the file on save. `tests/unit/text_encoding.spec.lua` is
+the guard. Do not edit the Russian files unless asked to.
+
+## Tests
+
+`tests/CLAUDE.md` is the full brief. Read it before touching anything under
+`tests/`. The key points:
+
+- The suite reimplements the parts of the engine the mod touches, in pure Lua. It
+  runs the mod scripts unmodified.
+- Anything the engine decides gets a citation to
+  [xray-monolith](https://github.com/themrdemonized/xray-monolith) or the
+  [MCM repo](https://github.com/RAX-Anomaly/Anomaly-Mod-Configuration-Menu), or it
+  is marked `GUESS`. A wrong fake makes a spec permanently green while it asserts
+  something the game would never do.
+- Self-tests gate unit and e2e. A self failure aborts the run.
+- Never leave a spec red to mark a known bug. Use the baseline tables in
+  `harness/mcm_labels.lua` instead, and never baseline anything a player can see.
+- A fix needs a spec that went red first.
+- `H.tick()` before asserting item placement. Item moves are deferred by one frame
+  on purpose, because the real `transfer_item` emits a network event.
+- `math.random` raises unless pinned.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,8 +125,10 @@ the guard. Do not edit the Russian files unless asked to.
   is marked `GUESS`. A wrong fake makes a spec permanently green while it asserts
   something the game would never do.
 - Self-tests gate unit and e2e. A self failure aborts the run.
-- Never leave a spec red to mark a known bug. Use the baseline tables in
-  `harness/mcm_labels.lua` instead, and never baseline anything a player can see.
+- Never leave a spec red to mark a known bug, and never write a data table that
+  turns a failure into a pass. `harness/mcm_labels.lua` used to hold four such
+  tables and they are gone; do not add them back. An exception that must be
+  tolerated is written in the spec, in prose, beside the assertion.
 - A fix needs a spec that went red first.
 - `H.tick()` before asserting item placement. Item moves are deferred by one frame
   on purpose, because the real `transfer_item` emits a network event.

--- a/gamedata/configs/text/eng/ui_st_mcm_soulslite.xml
+++ b/gamedata/configs/text/eng/ui_st_mcm_soulslite.xml
@@ -141,13 +141,13 @@ You can tweak this scalar to reflect your desired level of item condition loss. 
     <string id="ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight">
         <text>Hidden Stash Scenario Weight.</text>
      </string>
-    <string id="ui_mcm_soulslike_scenarios_rf_detector_scenario_weight_desc">
+    <string id="ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight_desc">
         <text>As an extra layer of difficulty and to just mix things up a bit, when this scenario is used it your rescuer will move all your items to a hidden stash and mark it on your PDA.</text>
      </string>
     <string id="ui_mcm_soulslike_scenarios_looter_npcs_marked">
         <text>Mark looting NPCs on the PDA</text>
     </string>
-    <string id="ui_mcm_soulslike_scenarios_rf_detector_scenario_weight_desc">
+    <string id="ui_mcm_soulslike_scenarios_looter_npcs_marked_desc">
         <text>When your gear is looted by an NPC, this option will allow you to track them on your PDA.</text>
      </string>
 

--- a/gamedata/configs/text/eng/ui_st_mcm_soulslite.xml
+++ b/gamedata/configs/text/eng/ui_st_mcm_soulslite.xml
@@ -132,18 +132,6 @@ You can tweak this scalar to reflect your desired level of item condition loss. 
     <string id="ui_mcm_soulslike_scenarios_description">
         <text>Soulslike scenarios are dynamic by nature.  Respawn events occur based on who killed you, how you were killed, where, how close to your spawn you are when you died, whether you are inside or outside, just to name a few.  These settings exist to allow you to customize the ways you want to try and recover your gear.  The default scenario's that always exist are that you may end up having all of your items on you on respawn (again, based on events), or you may find that your items are in a backpack on the ground where your body was found.  The options below are in addition to those and weight can be changed to make them more or less frequent.</text>
      </string>
-    <string id="ui_mcm_soulslike_scenarios_rf_detector_scenario_weight">
-        <text>RF Detector Scenario Weight.</text>
-     </string>
-    <string id="ui_mcm_soulslike_scenarios_rf_detector_scenario_weight_desc">
-        <text>As an extra layer of difficulty and to just mix things up a bit, when this scenario is used it your rescuer will move all your items to a hidden stash on the same map where you were found.  They will tell you the RF freqency to listen to to track down your gear, and also leave you a note in your inventory as a reminder.</text>
-     </string>
-    <string id="ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight">
-        <text>Hidden Stash Scenario Weight.</text>
-     </string>
-    <string id="ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight_desc">
-        <text>As an extra layer of difficulty and to just mix things up a bit, when this scenario is used it your rescuer will move all your items to a hidden stash and mark it on your PDA.</text>
-     </string>
     <string id="ui_mcm_soulslike_scenarios_looter_npcs_marked">
         <text>Mark looting NPCs on the PDA</text>
     </string>
@@ -246,9 +234,6 @@ You can tweak this scalar to reflect your desired level of item condition loss. 
     <string id="ui_mcm_soulslike_debug_enable_tips">
         <text>Show PDA Messages</text>
     </string>    
-    <string id="ui_mcm_soulslike_debug_debug_hidden_stashes">
-        <text>Debug Hidden Stashes</text>
-    </string>
     <string id="ui_mcm_soulslike_debug_debug_item_loss">
         <text>Debug Item Loss</text>
     </string>
@@ -260,12 +245,6 @@ You can tweak this scalar to reflect your desired level of item condition loss. 
     </string>
     <string id="ui_mcm_soulslike_debug_debug_the_default_scenario">
         <text>Debug Default Loss Scenario</text>
-    </string>
-    <string id="ui_mcm_soulslike_debug_debug_the_rf_scenario">
-        <text>Debug RF Detector Scenario</text>
-    </string>
-    <string id="ui_mcm_soulslike_debug_debug_the_hidden_stash_scenario">
-        <text>Debug Hidden Stash Scenario</text>
     </string>
     <string id="ui_mcm_soulslike_debug_debug_squad_spawns">
         <text>Debug Squad Spawns</text>

--- a/gamedata/configs/text/eng/ui_st_mcm_soulslite.xml
+++ b/gamedata/configs/text/eng/ui_st_mcm_soulslite.xml
@@ -267,6 +267,21 @@ You can tweak this scalar to reflect your desired level of item condition loss. 
     <string id="ui_mcm_soulslike_debug_debug_the_hidden_stash_scenario">
         <text>Debug Hidden Stash Scenario</text>
     </string>
+    <string id="ui_mcm_soulslike_debug_debug_squad_spawns">
+        <text>Debug Squad Spawns</text>
+    </string>
+    <string id="ui_mcm_soulslike_debug_debug_squad_spawns_desc">
+        <text>Marks spawned ambush squads and their members on the map.</text>
+    </string>
+    <string id="ui_mcm_soulslike_debug_debug_always_spawn_ambush">
+        <text>Always Spawn Ambush</text>
+    </string>
+    <string id="ui_mcm_soulslike_debug_debug_always_spawn_ambush_desc">
+        <text>Skips the ambush chance roll so an ambush is spawned on every death.</text>
+    </string>
+    <string id="ui_mcm_soulslike_debug_debug_remove_default_scenario">
+        <text>Remove Default Scenario</text>
+    </string>
     <string id="ui_mcm_soulslike_items_outfit_loss_chance">
         <text>Outfit Loss Chance</text>
     </string>
@@ -421,6 +436,9 @@ You can tweak this scalar to reflect your desired level of item condition loss. 
     </string>
     <string id="ui_mcm_soulslike_ignored_items_medkit">
         <text>Medkit</text>
+    </string>
+    <string id="ui_mcm_soulslike_ignored_items_other">
+        <text>Other Items</text>
     </string>
     <string id="ui_mcm_soulslike_ignored_items_other_desc">
         <text>This is a comma separated list of item IDs that will be ignored.</text>

--- a/gamedata/configs/text/rus/ui_st_mcm_soulslite.xml
+++ b/gamedata/configs/text/rus/ui_st_mcm_soulslite.xml
@@ -132,13 +132,13 @@
     <string id="ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight">
         <text>Шанс сценария с тайником</text>
      </string>
-    <string id="ui_mcm_soulslike_scenarios_rf_detector_scenario_weight_desc">
+    <string id="ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight_desc">
         <text>В качестве дополнительного затруднения и для разнообразия, при выборе этого сценария ваш спаситель оставит ваши вещи в тайнике и пометит его на карте вашего КПК.</text>
      </string>
      <string id="ui_mcm_soulslike_scenarios_looter_npcs_marked">
         <text>Помечать мародёров на КПК</text>
     </string>
-    <string id="ui_mcm_soulslike_scenarios_rf_detector_scenario_weight_desc">
+    <string id="ui_mcm_soulslike_scenarios_looter_npcs_marked_desc">
         <text>Если ваши вещи заберёт мародёр, эта опция позволит вам его отслеживать по метке в КПК.</text>
     </string>
 

--- a/gamedata/configs/text/rus/ui_st_mcm_soulslite.xml
+++ b/gamedata/configs/text/rus/ui_st_mcm_soulslite.xml
@@ -123,18 +123,6 @@
     <string id="ui_mcm_soulslike_scenarios_description">
         <text>Сценарии мода по своей натуре динамичны. Обстоятельства вашего возрождения зависят от того, кто вас убил, как вас убили, где и насколько далеко от вашего спавна вы погибли, были ли вы в тот момент во внутренней локации, и многих других факторов. Эти опции позволят вам настроить как вам придётся доставать ваши вещи. Сценарий по умолчанию оставляет все предметы с вами (в зависимости от обстоятельств), но может быть вам придётся идти к месту смерти, где будет рюкзак с вашим снаряжением. Опции ниже будут добавлены к этим двум, и их вероятность настраиваема.</text>
      </string>
-    <string id="ui_mcm_soulslike_scenarios_rf_detector_scenario_weight">
-        <text>Шанс сценария с RF-ресивером</text>
-     </string>
-    <string id="ui_mcm_soulslike_scenarios_rf_detector_scenario_weight_desc">
-        <text>В качестве дополнительного затруднения и для разнообразия, при выборе этого сценария ваш спаситель оставит ваши вещи в непомеченном тайнике на той же локации, где вы чуть не погибли. Он сообщит вам частоту для RF-ресивера, по которой можно будет найти этот тайник, а также оставит в вашем инвентаре записку с этой частотой в качестве напоминания.</text>
-     </string>
-    <string id="ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight">
-        <text>Шанс сценария с тайником</text>
-     </string>
-    <string id="ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight_desc">
-        <text>В качестве дополнительного затруднения и для разнообразия, при выборе этого сценария ваш спаситель оставит ваши вещи в тайнике и пометит его на карте вашего КПК.</text>
-     </string>
      <string id="ui_mcm_soulslike_scenarios_looter_npcs_marked">
         <text>Помечать мародёров на КПК</text>
     </string>
@@ -236,9 +224,6 @@
     <string id="ui_mcm_soulslike_debug_enable_tips">
         <text>Показывать сообщения КПК</text>
     </string>    
-    <string id="ui_mcm_soulslike_debug_debug_hidden_stashes">
-        <text>Отладка скрытых тайников</text>
-    </string>
     <string id="ui_mcm_soulslike_debug_debug_item_loss">
         <text>Отладка потери предметов</text>
     </string>
@@ -250,12 +235,6 @@
     </string>
     <string id="ui_mcm_soulslike_debug_debug_the_default_scenario">
         <text>Отладка сценария по умолчанию</text>
-    </string>
-    <string id="ui_mcm_soulslike_debug_debug_the_rf_scenario">
-        <text>Отладка сценария с RF-ресивером</text>
-    </string>
-    <string id="ui_mcm_soulslike_debug_debug_the_hidden_stash_scenario">
-        <text>Отладка сценария со скрытым тайником</text>
     </string>
     <string id="ui_mcm_soulslike_items_outfit_loss_chance">
         <text>Шанс потери брони</text>
@@ -414,5 +393,65 @@
     </string>
     <string id="ui_mcm_soulslike_items_money_loss_chance_desc">
         <text>Шанс потерять деньги при смерти. 1.0 = потеря гарантирована, 0.5 = шанс 50%, и так далее.</text>
+    </string>
+    <string id="ui_mcm_soulslike_debug_debug_squad_spawns">
+        <text>Отладка спавна групп</text>
+    </string>
+    <string id="ui_mcm_soulslike_debug_debug_squad_spawns_desc">
+        <text>Отмечает на карте созданные группы засады и их бойцов.</text>
+    </string>
+    <string id="ui_mcm_soulslike_debug_debug_always_spawn_ambush">
+        <text>Всегда создавать засаду</text>
+    </string>
+    <string id="ui_mcm_soulslike_debug_debug_always_spawn_ambush_desc">
+        <text>Пропускает проверку шанса засады, поэтому засада создаётся при каждой смерти.</text>
+    </string>
+    <string id="ui_mcm_soulslike_debug_debug_remove_default_scenario">
+        <text>Убрать сценарий по умолчанию</text>
+    </string>
+    <string id="ui_mcm_soulslike_ignored_items_device_pda_0">
+        <text>КПК 0</text>
+    </string>
+    <string id="ui_mcm_soulslike_ignored_items_device_pda_4">
+        <text>КПК 4</text>
+    </string>
+    <string id="ui_mcm_soulslike_ignored_items_device_pda_getac">
+        <text>КПК GETAC</text>
+    </string>
+    <string id="ui_mcm_soulslike_ignored_items_device_pda_milspec">
+        <text>Армейский КПК</text>
+    </string>
+    <string id="ui_mcm_soulslike_ignored_items_device_pda_kulon">
+        <text>КПК Кулон</text>
+    </string>
+    <string id="ui_mcm_soulslike_ignored_items_other">
+        <text>Другие предметы</text>
+    </string>
+    <string id="ui_mcm_soulslike_ignored_items_other_desc">
+        <text>Список ID предметов через запятую, которые будут проигнорированы.</text>
+    </string>
+    <string id="ui_mcm_soulslike_items_outfit_keep_chance">
+        <text>Шанс сохранить броню при смерти</text>
+    </string>
+    <string id="ui_mcm_soulslike_items_outfit_keep_chance_desc">
+        <text>Если включена опция «Разрешить потерю брони», этот ползунок задаёт шанс, что броня останется у вас при возрождении. 0 = всегда терять, 1 = всегда сохранять.</text>
+    </string>
+    <string id="ui_mcm_soulslike_items_headgear_keep_chance">
+        <text>Шанс сохранить шлем при смерти</text>
+    </string>
+    <string id="ui_mcm_soulslike_items_headgear_keep_chance_desc">
+        <text>Если включена опция «Разрешить потерю шлема», этот ползунок задаёт шанс, что шлем останется у вас при возрождении. 0 = всегда терять, 1 = всегда сохранять.</text>
+    </string>
+    <string id="ui_mcm_soulslike_items_weapon_keep_chance">
+        <text>Шанс сохранить оружие при смерти</text>
+    </string>
+    <string id="ui_mcm_soulslike_items_weapon_keep_chance_desc">
+        <text>Если включена опция «Разрешить потерю оружия», этот ползунок задаёт шанс, что оружие останется у вас при возрождении. 0 = всегда терять, 1 = всегда сохранять.</text>
+    </string>
+    <string id="ui_mcm_soulslike_items_artifact_keep_chance">
+        <text>Шанс сохранить артефакт при смерти</text>
+    </string>
+    <string id="ui_mcm_soulslike_items_artifact_keep_chance_desc">
+        <text>Если включена опция «Разрешить потерю артефактов», этот ползунок задаёт шанс, что артефакт останется у вас при возрождении. 0 = всегда терять, 1 = всегда сохранять.</text>
     </string>
 </string_table>

--- a/gamedata/scripts/soulslike.script
+++ b/gamedata/scripts/soulslike.script
@@ -4,7 +4,7 @@
 	Jabbers' Soulslike Anomaly Mod
 --]]
 
-local version = "0.47-beta"
+local version = "0.48-beta"
 
 local tools_list = {
     ["itm_basickit"] = true,

--- a/gamedata/scripts/soulslike.script
+++ b/gamedata/scripts/soulslike.script
@@ -4,7 +4,7 @@
 	Jabbers' Soulslike Anomaly Mod
 --]]
 
-local version = "0.46-beta"
+local version = "0.47-beta"
 
 local tools_list = {
     ["itm_basickit"] = true,
@@ -830,19 +830,17 @@ local function on_game_load()
                     se_box:switch_online()
                 end
                 
-                for i=1,65534 do 
+                for i=1,65534 do
                     local se_obj = sim:object(i)
-                    if (se_obj and se_obj.parent_id == id) then 
-                        debug("Moving "..se_obj.section.." id:"..tostring(value.stash_id))
-                        sim:teleport_object(value.stash_id, se_box.m_game_vertex_id, se_box.m_level_vertex_id, se_box.position)
-                        if se_obj then 
-                            if not se_obj.online then
-                                debug("Setting "..se_obj.section.." online")
-                                se_obj:switch_online()
-                            end
+                    if (se_obj and se_obj.parent_id == value.stash_id) then
+                        debug("Moving "..se_obj.section.." id:"..tostring(i))
+                        sim:teleport_object(i, se_box.m_game_vertex_id, se_box.m_level_vertex_id, se_box.position)
+                        if not se_obj.online then
+                            debug("Setting "..se_obj.section.." online")
+                            se_obj:switch_online()
                         end
                     end
-                end                            
+                end
 
             end 
         end 

--- a/gamedata/scripts/soulslike.script
+++ b/gamedata/scripts/soulslike.script
@@ -226,13 +226,18 @@ function get_soulslike_state()
                     game_vertex_id = nil,
                 },
             note_message_data = {},
-            hidden_stashes = {}
+            hidden_stashes = {},
+            tracked_ambushers = {}
         }
     end
 
     -- Backward save compatibility
     if not game_state.soulslike.note_message_data then
         game_state.soulslike.note_message_data = {}
+    end
+
+    if not game_state.soulslike.tracked_ambushers then
+        game_state.soulslike.tracked_ambushers = {}
     end
 
     if not game_state.soulslike.hidden_stashes then
@@ -921,24 +926,44 @@ local function npc_on_net_spawn(npc, se_obj)
     end
 
     local state = get_soulslike_state()
-    if npc and IsStalker(npc) and state.tracked_ambushers and state.tracked_ambushers[npc:id()] then
-        debug("Setting up ambushers "..tostring(npc:id()))
-        local ambusher_state = state.tracked_ambushers[npc:id()]
-        local position = vector():set(ambusher_state.position.x, ambusher_state.position.y, ambusher_state.position.z)
-           
+
+    if not (npc and state.tracked_ambushers) then
+        return
+    end
+
+    local id = npc:id()
+    local ambusher_state = state.tracked_ambushers[id]
+
+    if not ambusher_state then
+        return
+    end
+
+    -- The stance setters below are stalker-only, but SpawnAmbush tracks
+    -- whatever it spawned, mutants included. Consume the entry either way:
+    -- leaving mutant entries behind is what made tracked_ambushers grow
+    -- without bound in every save.
+    if IsStalker(npc) then
+        debug("Setting up ambusher "..tostring(id))
+
         npc:set_mental_state(ambusher_state.mental_state)
         npc:set_body_state(ambusher_state.body_state)
         npc:set_movement_type(ambusher_state.movement_type)
         npc:set_sight(ambusher_state.sight_type, nil, 0)
-        npc:set_desired_position(position)
-        npc:set_desired_direction()
 
-        if soulslike_mcm.debug_squad_spawns() then
-            level.map_add_object_spot_ser(npc:id(), "secondary_task_location", "DEBUG: Ambush NPC") 
+        -- Squad members are tracked without a position of their own; the
+        -- simulation board places them, so only pose the ones we located.
+        local pos = ambusher_state.position
+        if pos and pos.x and pos.y and pos.z then
+            npc:set_desired_position(vector():set(pos.x, pos.y, pos.z))
+            npc:set_desired_direction()
         end
 
-        state.tracked_ambushers[npc:id()] = nil
+        if soulslike_mcm.debug_squad_spawns() then
+            level.map_add_object_spot_ser(id, "secondary_task_location", "DEBUG: Ambush NPC")
+        end
     end
+
+    state.tracked_ambushers[id] = nil
 end
 
 local function actor_on_first_update()
@@ -961,5 +986,5 @@ function on_game_start()
 	RegisterScriptCallback("on_console_execute", on_console_execute)
     RegisterScriptCallback("actor_on_before_hit", actor_on_before_hit)
 	RegisterScriptCallback("physic_object_on_use_callback", physic_object_on_use_callback)
-    --RegisterScriptCallback("npc_on_net_spawn", npc_on_net_spawn)
+    RegisterScriptCallback("npc_on_net_spawn", npc_on_net_spawn)
 end

--- a/gamedata/scripts/soulslike.script
+++ b/gamedata/scripts/soulslike.script
@@ -4,7 +4,7 @@
 	Jabbers' Soulslike Anomaly Mod
 --]]
 
-local version = "0.48-beta"
+local version = "0.49-beta"
 
 local tools_list = {
     ["itm_basickit"] = true,

--- a/gamedata/scripts/soulslike_mcm.script
+++ b/gamedata/scripts/soulslike_mcm.script
@@ -887,6 +887,12 @@ function on_mcm_load()
                 def = false
             },
             {
+                id = "debug_remove_default_scenario",
+                type = "check",
+                val = 1,
+                def = false
+            },
+            {
                 id = "debug_the_tarkov_looter",
                 type = "check",
                 val = 1,
@@ -1176,8 +1182,8 @@ function get_headgear_condition_loss_chance()
 end
 
 -- Getter functions for ignored items
-function get_ignored_other() 
-    return get_config("ignored_items/ignored_other", '')
+function get_ignored_other()
+    return get_config("ignored_items/other", '')
  end
 
 function is_ignored(id) 

--- a/gamedata/scripts/soulslike_mcm.script
+++ b/gamedata/scripts/soulslike_mcm.script
@@ -610,9 +610,15 @@ function on_mcm_load()
                 text = "ui_mcm_soulslike_ignored_items_medkit"
             },
             {
+                -- val is MCM's stored-value TYPE CODE, not an initial value:
+                -- 0 = string, 1 = boolean, 2 = float. This was val = '', which
+                -- is not a recognised code, so the box could not round-trip
+                -- through axr_options.ltx and get_ignored_other() always saw
+                -- its '' default -- the free-text ignore list never protected
+                -- anything the player typed into it.
                 id = 'other',
                 type = "input",
-                val = '',
+                val = 0,
                 def = '',
             },
             {

--- a/gamedata/scripts/soulslike_mcm.script
+++ b/gamedata/scripts/soulslike_mcm.script
@@ -829,13 +829,12 @@ function on_mcm_load()
                 id = "lose_all_items_on_death",
                 type = "check",
                 val = 1,
-                def = false,
-                text = "Lose all items on death",
+                def = false
             },
             {
                 id = "lose_all_items_on_death_desc",
                 type = "desc",
-                text = "If enabled, you will lose ALL items on death. This setting overrides all other settings in the Items category.",
+                text = "ui_mcm_soulslike_hardcore_lose_all_items_on_death_desc",
                 clr = {255, 255 ,255 ,0},
             },
             {

--- a/gamedata/scripts/soulslike_message_factory.script
+++ b/gamedata/scripts/soulslike_message_factory.script
@@ -176,7 +176,7 @@ function create(rescuer, params)
             msg = msg.." " ..game.translate_string("st_soulslike_rescuer_pda_generic")
         end
         if params.radio_freq then
-            msg = msg.." "..game.translate_string(strformat("st_soulslike_rescuer_radio_generic", params.radio_freq))
+            msg = msg.." "..strformat(game.translate_string("st_soulslike_rescuer_radio_generic"), params.radio_freq)
         end
         return msg
     end  

--- a/gamedata/scripts/soulslike_scenario_logic_factory.script
+++ b/gamedata/scripts/soulslike_scenario_logic_factory.script
@@ -157,9 +157,23 @@ function create_new(hits)
     local scenario_loot_scalar = 1.0
     local available_scenarios = {}    
     local game_state = soulslike.get_soulslike_state()
-    local spawn_position = vector():set(game_state.spawn_location.position.x, game_state.spawn_location.position.y, game_state.spawn_location.position.z)   
-    local distance_sqr = spawn_position:distance_to_sqr(db.actor:position())
-    local distance_from_spawn = math.sqrt(distance_sqr)
+    local spawn_loc = game_state.spawn_location
+    local se_actor  = alife():actor()
+    local distance_from_spawn
+
+    if spawn_loc.level and se_actor and spawn_loc.game_vertex_id
+       and spawn_loc.level == level.name() then
+        -- Same level: local coords are valid and the most precise.
+        local spawn_position = vector():set(spawn_loc.position.x, spawn_loc.position.y, spawn_loc.position.z)
+        distance_from_spawn = spawn_position:distance_to(db.actor:position())
+    elseif spawn_loc.game_vertex_id and se_actor then
+        -- Different level (or unknown): use the global game-graph frame for a true cross-level distance.
+        distance_from_spawn = utils_obj.graph_distance(spawn_loc.game_vertex_id, se_actor.m_game_vertex_id)
+    else
+        -- Spawn never recorded a game vertex; fall back to local so behavior degrades gracefully.
+        local spawn_position = vector():set(spawn_loc.position.x, spawn_loc.position.y, spawn_loc.position.z)
+        distance_from_spawn = spawn_position:distance_to(db.actor:position())
+    end
     
     if soulslike_mcm.debug_the_noloss_scenario() then
         soulslike.debug("Debugging noloss scenario.")
@@ -191,14 +205,14 @@ function create_new(hits)
 
         table.insert(available_scenarios, {id = soulslike.SCENARIOS.HiddenStash, min = 0, max = 0, weight = 1.0})
     elseif distance_from_spawn <= 50 then
-        soulslike.debug("Player was killed "..string.format("%.2f", distance_from_spawn).." meters their spawn point.")
+        soulslike.debug("Player was killed "..string.format("%.2f", distance_from_spawn).." meters from their spawn point.")
 
         rescuer = soulslike.find_closest_friendly_stalker()
         scenario_loot_scalar = 0
       
         table.insert(available_scenarios, {id = soulslike.SCENARIOS.NoLoss, min = 0, max = 0, weight = 1.0})  
     elseif distance_from_spawn <= 200 then
-        soulslike.debug("Player was killed "..string.format("%.2f", distance_from_spawn).." meters their spawn point.")
+        soulslike.debug("Player was killed "..string.format("%.2f", distance_from_spawn).." meters from their spawn point.")
 
         rescuer = soulslike.find_closest_friendly_stalker()
         looter = soulslike.find_closest_enemy()

--- a/gamedata/scripts/soulslike_scenario_logic_factory.script
+++ b/gamedata/scripts/soulslike_scenario_logic_factory.script
@@ -227,9 +227,10 @@ function create_new(hits)
 
         -- table.insert(available_scenarios, {id = soulslike.SCENARIOS.RFDetectorStash, min = 0, max = 0, weight = soulslike_mcm.rf_detector_scenario_weight()})
         -- table.insert(available_scenarios, {id = soulslike.SCENARIOS.HiddenStash, min = 0, max = 0, weight = soulslike_mcm.hidden_stash_scenario_weight()})
-    elseif hit and 
-           hit.draftsman_type == soulslike.entity_type.Stalker and 
+    elseif hit and
+           hit.draftsman_type == soulslike.entity_type.Stalker and
            hit.fatal_hit and
+           hit.fatal_hit.draftsman and
            hit.fatal_hit.draftsman:general_goodwill(db.actor) >= soulslike.RELATIONS.NEUTRALS then
         soulslike.debug("Friendly/Neutral Stalker killed the player.")
 
@@ -342,17 +343,17 @@ function create_new(hits)
         weight_sum = weight_sum + value.weight
     end
 
-    local min = 0
+    local cumulative = 0
     for _, value in pairs(available_scenarios) do
-        value.min = min + 1
-        value.max = math.floor(min + (100 * (value.weight / weight_sum)))
-        min = value.max
+        value.min = cumulative
+        cumulative = cumulative + value.weight
+        value.max = cumulative
     end
-    
-    local roll = math.random(1, 100)    
+
+    local roll = math.random() * weight_sum
     local scenario_id = nil
-    for id, value in pairs(available_scenarios) do
-        if(roll >= value.min and roll <= value.max) then
+    for _, value in pairs(available_scenarios) do
+        if roll >= value.min and roll < value.max then
             scenario_id = value.id
             break
         end

--- a/gamedata/scripts/soulslike_scenario_logic_factory.script
+++ b/gamedata/scripts/soulslike_scenario_logic_factory.script
@@ -161,18 +161,31 @@ function create_new(hits)
     local se_actor  = alife():actor()
     local distance_from_spawn
 
+    -- A spawn point with no coordinates cannot be measured against. Building a
+    -- vector out of nils is not a catchable error in a release build: NDEBUG
+    -- compiles out luabind's no-matching-overload guard, so the call runs off
+    -- the end of the overload table and takes the process with it.
+    local has_spawn_position = spawn_loc.position
+        and spawn_loc.position.x and spawn_loc.position.y and spawn_loc.position.z
+
     if spawn_loc.level and se_actor and spawn_loc.game_vertex_id
-       and spawn_loc.level == level.name() then
+       and spawn_loc.level == level.name() and has_spawn_position then
         -- Same level: local coords are valid and the most precise.
         local spawn_position = vector():set(spawn_loc.position.x, spawn_loc.position.y, spawn_loc.position.z)
         distance_from_spawn = spawn_position:distance_to(db.actor:position())
     elseif spawn_loc.game_vertex_id and se_actor then
         -- Different level (or unknown): use the global game-graph frame for a true cross-level distance.
         distance_from_spawn = utils_obj.graph_distance(spawn_loc.game_vertex_id, se_actor.m_game_vertex_id)
-    else
-        -- Spawn never recorded a game vertex; fall back to local so behavior degrades gracefully.
+    elseif has_spawn_position then
+        -- No game vertex recorded; fall back to local so behavior degrades gracefully.
         local spawn_position = vector():set(spawn_loc.position.x, spawn_loc.position.y, spawn_loc.position.z)
         distance_from_spawn = spawn_position:distance_to(db.actor:position())
+    else
+        -- Nothing was ever recorded. Treat the death as far from spawn: that
+        -- runs the normal death scenario, where the alternative would silently
+        -- gift a no-loss death on the strength of missing data.
+        soulslike.warn("No spawn location recorded; treating death as distant.")
+        distance_from_spawn = math.huge
     end
     
     if soulslike_mcm.debug_the_noloss_scenario() then
@@ -248,7 +261,13 @@ function create_new(hits)
            hit.fatal_hit.draftsman:general_goodwill(db.actor) >= soulslike.RELATIONS.NEUTRALS then
         soulslike.debug("Friendly/Neutral Stalker killed the player.")
 
-        rescuer = hit.draftsman
+        -- The killer stands over the body and patches the player up. Read from
+        -- fatal_hit, not from the aggregate: compute_fatal_hit_info builds each
+        -- bucket as {draftsman_type, power, fatal_hit} (:59-65, :81-83) and
+        -- never puts `draftsman` on it, so hit.draftsman was always nil and
+        -- this arm produced no rescuer at all. Same expression SetKiller uses
+        -- correctly at :398.
+        rescuer = hit.fatal_hit.draftsman
         looter = nil
         scenario_loot_scalar = 0.0
 

--- a/gamedata/scripts/soulslike_scenarios.script
+++ b/gamedata/scripts/soulslike_scenarios.script
@@ -1194,19 +1194,16 @@ function SoulslikeScenarioLogic:TransferItem(item, container, looter)
                 return false
             end
 
-            local is_ammo = IsAmmo(item)
-            local is_medical = SYS_GetParam(0, sec, "kind") == "i_medical"
-            local is_food = SYS_GetParam(0, sec, "kind") == "i_food"
-
-            if is_ammo or is_food or is_medical then
-                soulslike.debug("Item lost "..sec)  
-                if stash_data and stash_data.lost_items then
-                    table.insert(stash_data.lost_items, sec)
-                end
-                alife_release(item)
-                self.logic_state.story.items_were_lost = true 
-                return false 
-            end 
+            -- The loss roll succeeded and the item already cleared every
+            -- protection check (quest/ignore-list/equipped/allow-loss/keep-roll)
+            -- and any looter handling above. Destroy it regardless of type.
+            soulslike.debug("Item lost "..sec)
+            if stash_data and stash_data.lost_items then
+                table.insert(stash_data.lost_items, sec)
+            end
+            alife_release(item)
+            self.logic_state.story.items_were_lost = true
+            return false
         end
     end
 

--- a/gamedata/scripts/soulslike_scenarios.script
+++ b/gamedata/scripts/soulslike_scenarios.script
@@ -124,11 +124,15 @@ local mutant_spawn_type = {
     Controller = 9
 }
 
+-- Distinct values, one per rank. These were previously Advanced = Veteran =
+-- Sniper = 2, and the eligibility filter tests `== Advanced` first, so
+-- enabling any one of the three admitted all three -- the veteran and sniper
+-- MCM toggles could never gate anything on their own.
 local stalker_spawn_type = {
     Novice = 1,
     Advanced = 2,
-    Veteran = 2,
-    Sniper = 2,
+    Veteran = 3,
+    Sniper = 4,
 }
 
 local mutant_spawns = {
@@ -666,12 +670,16 @@ end
 
 function SoulslikeScenarioLogic:SpawnAmbush()
     soulslike.debug("Checking ambush chance.")
-    local loss_chance_dice_roll = math.random(0, 100)
+    -- Float roll in [0,1) compared directly against the configured chance, as
+    -- every other chance roll in this file does. It was math.random(0, 100) --
+    -- 101 discrete outcomes -- compared against chance*100, so a configured
+    -- 0.25 actually meant 25/101.
+    local loss_chance_dice_roll = math.random()
     local spawns = {}
     local sim = alife()
 
     if not sim then return end
-    
+
     local debug_spawn = soulslike_mcm.debug_always_spawn_ambush()
 
     if debug_spawn then
@@ -689,7 +697,7 @@ function SoulslikeScenarioLogic:SpawnAmbush()
 
     if self.logic_state.killer_type == soulslike.entity_type.Monster and 
        self.logic_state.has_mutant_bait and
-       loss_chance_dice_roll < self.logic_state.mutant_ambush_chance * 100 then 
+       loss_chance_dice_roll < self.logic_state.mutant_ambush_chance then
         soulslike.debug("Setting up mutant spawn table.")
         for _, spawn in pairs(mutant_spawns) do
             if (spawn.type == mutant_spawn_type.Boar and self.logic_state.allow_boar_ambush) or
@@ -705,7 +713,7 @@ function SoulslikeScenarioLogic:SpawnAmbush()
             end
         end
     elseif self.logic_state.killer_type == soulslike.entity_type.Stalker and
-           loss_chance_dice_roll < self.logic_state.stalker_ambush_chance * 100 then 
+           loss_chance_dice_roll < self.logic_state.stalker_ambush_chance then
         local killer = self.logic_state.killer_id and sim:object(self.logic_state.killer_id) or nil
         
         if killer then
@@ -743,17 +751,39 @@ function SoulslikeScenarioLogic:SpawnAmbush()
         weight_sum = weight_sum + value.weight
     end
 
-    local min = 0
+    -- Float, half-open cumulative buckets over [0, weight_sum), matching the
+    -- weighted scenario pick in soulslike_scenario_logic_factory.script:355-374.
+    --
+    -- This previously accumulated a FLOORED integer max out of 100 slots, which
+    -- had two consequences. Truncation compounded, so the final bucket ended
+    -- below 100 -- at the shipped defaults it ended at 96, and rolls 97-100
+    -- matched no bucket at all, silently producing no ambush. And any entry
+    -- whose share fell below one whole slot got min > max, making it
+    -- unreachable: at the defaults that was every rare mutant, so their
+    -- configured weights never did anything.
+    --
+    -- Bounds are computed inline rather than written onto `value`, because the
+    -- entries in `spawns` are references into the module-scope mutant_spawns /
+    -- stalker_spawns tables. Assigning to them mutated shared state that is
+    -- meant to be constant.
+    local roll = math.random() * weight_sum
+    local section = nil
+    local cumulative = 0
+
     for _, value in pairs(spawns) do
-        value.min = min + 1
-        value.max = math.floor(min + (100 * (value.weight / weight_sum)))
-        min = value.max
+        local lower = cumulative
+        cumulative = cumulative + value.weight
+        if roll >= lower and roll < cumulative then
+            section = value.section
+            break
+        end
     end
 
-    local roll = math.random(1, 100)    
-    local section = nil
-    for _, value in pairs(spawns) do
-        if(roll >= value.min and roll <= value.max) then
+    -- math.random() is [0,1) so roll < weight_sum always holds and the loop
+    -- above matches. This only catches a degenerate table of zero-weight
+    -- entries, which would otherwise spawn nothing at all.
+    if not section then
+        for _, value in pairs(spawns) do
             section = value.section
             break
         end

--- a/gamedata/scripts/soulslike_scenarios.script
+++ b/gamedata/scripts/soulslike_scenarios.script
@@ -317,12 +317,20 @@ function SoulslikeScenarioLogic:__init(state)
     self.game_state = soulslike.get_soulslike_state()
 end
 
+-- Both flags live in two places on purpose. IsItemLossAllowed reads the
+-- top-level copy (:945), while SendWakeupMessage hands `story` to the message
+-- factory as its params (:935), and the factory keys the indoor rescue text off
+-- params.player_died_indoor (soulslike_message_factory.script:135). Writing
+-- only the top-level field left `story` declaring both keys and never getting
+-- either, so the indoor message set could never be selected.
 function SoulslikeScenarioLogic:SetIsInDoor(player_is_indoor)
     self.logic_state.player_died_indoor = player_is_indoor
+    self.logic_state.story.player_died_indoor = player_is_indoor
 end
 
 function SoulslikeScenarioLogic:SetIsInWater(is_in_water)
     self.logic_state.player_died_in_water = is_in_water
+    self.logic_state.story.player_died_in_water = is_in_water
 end
 
 function SoulslikeScenarioLogic:SetLevelName(name)
@@ -899,10 +907,24 @@ function SoulslikeScenarioLogic:RespawnActor()
         end
     end
     
-    local position = vector():set(self.game_state.spawn_location.position.x, self.game_state.spawn_location.position.y, self.game_state.spawn_location.position.z)   
-    local level_vertex_id = self.game_state.spawn_location.level_vertex_id
-    local game_vertex_id = self.game_state.spawn_location.game_vertex_id  
-    
+    local spawn = self.game_state.spawn_location
+    local spawn_position = spawn and spawn.position
+
+    -- Same guard SpawnAmbush already applies before its own vector():set
+    -- (:770). Without it, a save that never recorded a spawn point turns the
+    -- respawn into an access violation: nil arguments match no overload of
+    -- vector:set, and a release build compiles out luabind's guard for that
+    -- (config.hpp:81-91), so the call runs off the end of the overload table.
+    if not (spawn_position and spawn_position.x and spawn_position.y and spawn_position.z) then
+        soulslike.error("No spawn location recorded; cannot respawn the actor.")
+        self:StopSurgeAndStorm()
+        return
+    end
+
+    local position = vector():set(spawn_position.x, spawn_position.y, spawn_position.z)
+    local level_vertex_id = spawn.level_vertex_id
+    local game_vertex_id = spawn.game_vertex_id
+
     level.add_pp_effector("black_infinite.ppe", 5606, true)
     
 

--- a/gamedata/scripts/soulslike_scenarios.script
+++ b/gamedata/scripts/soulslike_scenarios.script
@@ -205,9 +205,16 @@ local stalker_spawns = {
     { section = "ecolog_sim_squad_veteran",     community = "ecolog",       weight = 0.10,  type = stalker_spawn_type.Veteran },
 }
 
-local function is_equipped(id) 
+-- Slot 0 is NO_ACTIVE_SLOT and the engine rejects it, so the scan starts at 1.
+-- LAST_SLOT is CUSTOM_SLOT_5 = 18 in this build: MORE_INVENTORY_SLOTS is
+-- defined, which adds BACKPACK(13) and CUSTOM_1..5(14-18) past HELMET(12).
+-- Stopping at 12 left items in those slots looking unequipped, so they were
+-- eligible for loss even with keep_equipped_items_on_death enabled.
+local LAST_INVENTORY_SLOT = 18
+
+local function is_equipped(id)
     local is_equipped = false
-    for i=1,12 do
+    for i=1,LAST_INVENTORY_SLOT do
         local slot = db.actor:item_in_slot(i)
         if (slot and slot:id() == id) then
             is_equipped = true
@@ -388,11 +395,18 @@ function SoulslikeScenarioLogic:ApplyRankLoss()
 
     local rank = db.actor:character_rank()
     local loss_percent = self.logic_state.rank_loss_percent
-    local rank_loss = math.abs(rank * loss_percent)
 
-    soulslike.debug("Player has lost "..tostring(rank_loss).." rank.")
+    -- No math.abs: it made the deduction positive regardless of sign, so a
+    -- negative rank was driven further negative without bound instead of
+    -- losing a percentage. Floor and clamp here rather than leaving it to the
+    -- engine, which stores an int via a static_cast that truncates toward zero
+    -- (asymmetric across the sign) and applies no clamp of its own.
+    local rank_loss = math.floor(rank * loss_percent)
+    local new_rank = math.max(rank - rank_loss, 0)
 
-    db.actor:set_character_rank(db.actor:character_rank() + (-rank_loss or 0))
+    soulslike.debug("Player has lost "..tostring(rank - new_rank).." rank.")
+
+    db.actor:set_character_rank(new_rank)
     game_statistics.check_for_rank_change()
 end
 
@@ -404,11 +418,24 @@ function SoulslikeScenarioLogic:ApplyReputationLoss()
 
     local rep = db.actor:character_reputation()
     local loss_percent = self.logic_state.rep_loss_percent
-    local rep_loss = math.abs(rep * loss_percent)
 
-    soulslike.debug("Player has lost "..tostring(rep_loss).." repuation.")
+    -- Reputation legitimately runs negative for a hated actor, so this decays
+    -- TOWARD zero rather than clamping there: dying costs you standing in
+    -- whichever direction you earned it, and never overshoots past neutral.
+    -- The old math.abs form always subtracted, which drove a negative
+    -- reputation further negative every death, without bound.
+    local rep_loss = math.floor(math.abs(rep) * loss_percent)
+    local new_rep = rep
 
-    db.actor:set_character_reputation(db.actor:character_reputation() + (-rep_loss or 0))
+    if rep > 0 then
+        new_rep = math.max(rep - rep_loss, 0)
+    elseif rep < 0 then
+        new_rep = math.min(rep + rep_loss, 0)
+    end
+
+    soulslike.debug("Player has lost "..tostring(math.abs(rep - new_rep)).." reputation.")
+
+    db.actor:set_character_reputation(new_rep)
     game_statistics.check_for_reputation_change()
 end
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,9 @@
+# LuaJIT is a build artifact, not source. Rebuild it from the engine repo:
+#   xray-monolith/src/3rd party/luajit-2/src/msvcbuild.bat static
+# See README.md in this directory.
+tools/
+
+# The root .gitignore excludes *.bat repo-wide (it exists to keep deploy.bat
+# out). run.bat is the documented entry point for this suite, so re-include it
+# -- without this the harness arrives unrunnable for anyone who clones.
+!run.bat

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -4,6 +4,7 @@
 tools/
 
 # The root .gitignore excludes *.bat repo-wide (it exists to keep deploy.bat
-# out). run.bat is the documented entry point for this suite, so re-include it
-# -- without this the harness arrives unrunnable for anyone who clones.
+# out). These are the documented entry points for this suite, so re-include
+# them -- without this the harness arrives unrunnable for anyone who clones.
 !run.bat
+!locals.bat

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,249 @@
+# tests/ — orientation for an agent
+
+Read this before touching anything under `tests/`. `README.md` next to it is the
+human-facing reference (matchers, helper signatures, worked examples); this file
+is the *why*, and the rules that are not obvious from the code.
+
+---
+
+## What this is
+
+A BDD suite that runs the mod's Lua **unmodified**, outside the game. No
+Anomaly install, no dying repeatedly to check a change. It works by
+reimplementing the parts of the engine the mod actually touches, in pure Lua.
+
+```
+tests\run.bat                     all specs        (self gates unit + e2e)
+tests\run.bat self|unit|e2e       one suite
+tests\run.bat --file ambush       spec files matching a substring
+tests\run.bat -t "keep roll"      tests matching a substring
+tests\locals.bat                  MCM localisation report + its spec
+tests\tools\luajit.exe probe.lua  reachability check
+```
+
+Exit 0 pass, 1 fail, 2 no runtime / nothing matched.
+
+Nothing here ships: `deploy.bat` packages `gamedata/` only.
+
+### Runtime
+
+**LuaJIT 2.x or Lua 5.1 — not 5.2+.** The module loader uses `setfenv`, removed
+in 5.2. `run.bat` finds `luajit.exe` on PATH, else `tools\luajit.exe`.
+
+`tools/` is gitignored: it is a build artifact, and the whole point is that it
+comes from the same source tree as the game.
+
+```
+copy  xray-monolith\src\3rd party\luajit-2  somewhere\
+call  "…\VC\Auxiliary\Build\vcvars64.bat"
+cd    somewhere\src
+set   PATH=%CD%;%PATH%          REM msvcbuild invokes the minilua it just built
+call  msvcbuild.bat static
+copy  luajit.exe  <mod>\tests\tools\
+```
+
+---
+
+## The core bargain, and the standing risk
+
+These specs validate **mod logic against our model of the engine**. When the
+model is wrong, the spec is not merely useless — it is *permanently green*
+while asserting something the game would never do. That is the single failure
+mode to design against.
+
+So the rule is: **anything the engine decides gets a citation, or it does not
+go in.**
+
+Two upstreams:
+
+| What | Source |
+|---|---|
+| Engine behaviour — bindings, types, clamping, lifetimes | <https://github.com/themrdemonized/xray-monolith> |
+| MCM option schema, storage paths, label derivation | <https://github.com/RAX-Anomaly/Anomaly-Mod-Configuration-Menu> |
+
+Anomaly's own gamedata scripts (`_g.script`, `utils_item.script`, …) are a
+third: several things that *look* like engine behaviour are Lua, and the
+difference matters. `CreateTimeEvent` and `alife_create` are Lua; `iterate_inventory`
+and `transfer_item` are C++.
+
+### How to add a fake faithfully
+
+1. Find the real thing. Grep the engine repo for the binding
+   (`script_game_object_*.cpp`, `alife_simulator_script.cpp`,
+   `xrServer_Objects_script.cpp`), or the MCM repo for UI contracts.
+2. Copy the *semantics*, not a plausible guess — return type, whether it
+   clamps, whether it is deferred, what it does on nil.
+3. Cite `file.cpp:line` in a comment at the fake.
+4. If you cannot verify it, mark it `GUESS` explicitly. `harness/fakes.lua`
+   opens with this convention; keep it.
+
+Facts already established this way are tabulated in `README.md` under
+*Standing caveat*. Consult it before assuming — several are counter-intuitive:
+
+- Inventory slots run **1..18**, not 1..12. Slot 0 is `NO_ACTIVE_SLOT`.
+- `iterate_inventory` stops on **any truthy** return; `CreateTimeEvent`
+  re-queues on anything **not literally `true`**. Opposite conventions, easy
+  to conflate.
+- Server objects expose `id`/`position` as **fields**; client objects as
+  **methods**. Conflating them yields a table keyed by a function.
+- `give_money(-N)` does **not** clamp — it underflows u32.
+- `set_character_rank` truncates **toward zero**, not floor, and never clamps.
+- Grenades are **not** weapons at either layer.
+- `vector():set(nil,…)` is **UB in release** — `NDEBUG` compiles out luabind's
+  no-overload guard. Not catchable. The harness raises so it stays visible;
+  call sites are guarded instead.
+
+---
+
+## How the pieces fit
+
+```
+harness/spec.lua        describe / it / expect, the runner
+harness/loader.lua      reproduces the engine's script-module namespacing
+harness/class.lua       luabind class / super
+harness/dispatch.lua    RegisterScriptCallback / SendScriptCallback
+harness/fakes.lua       engine globals: level, db, ui_mcm, alife, …
+harness/builders.lua    fixtures: actors, npcs, items, logic_state, scenarios
+harness/world.lua       item/container model + the alife simulator
+harness/timeevents.lua  CreateTimeEvent queue and pump
+harness/mods.lua        base-Anomaly and third-party script registry
+harness/mcm_labels.lua  MCM label derivation, analysis, and its baselines
+harness/init.lua        H.boot / H.tick / H.reboot — start here
+```
+
+### The loader is the load-bearing piece
+
+The engine textually wraps every `.script` before compiling it
+(`script_storage.cpp:608`). That produces semantics plain `require` does not,
+and the mod depends on all of them:
+
+| In a module | Lands as |
+|---|---|
+| `RELATIONS = {...}` | `soulslike.RELATIONS` — module-local, not global |
+| `function debug(o)` | `soulslike.debug`, shadowing the stdlib `debug` table |
+| `function math.clamp(…)` | mutates the **shared** `math` table |
+| `function _G.IsSoulslikeMode()` | a true global |
+| reading an undefined global | `nil`, **not** an error |
+
+If this drifts, every unit spec keeps passing while testing something the game
+would never run. That is why **self-tests gate unit and e2e**: a self failure
+aborts before the rest.
+
+To confirm the gate still bites, break one semantic — remove the
+`setmetatable(this, {__index = _G})` line from `loader.build_prologue` — and
+check the run fails loudly rather than passing quietly.
+
+### Deferred mutation is deliberate
+
+`iterate_inventory` walks the live container with raw iterators while the mod
+calls `alife_release` and `transfer_item` from inside that loop. That is only
+safe because `transfer_item` emits network events processed on a later frame.
+So `world.lua` queues too:
+
+- Inside `iterate_inventory`, an item you just released is **still present**.
+- `TransferItems` returning does **not** mean anything moved.
+- **`H.tick()` before asserting placement.** `H.tick{ passes = 1 }` runs one
+  frame and leaves retries queued, which is how you observe a wait mid-flight.
+
+Snapshotting instead would give the same loop coverage for the wrong reason.
+
+---
+
+## Rules for writing specs
+
+**Assert correct behaviour.** The suite ends green. A defect found while
+writing a spec gets *fixed*, with the spec failing first to prove it caught
+something. Three markers flag exceptions:
+
+| Marker | Meaning |
+|---|---|
+| `FIXES: Dn` | This spec caught a defect. It went red, then the fix landed. |
+| `CHARACTERIZATION:` | Behaviour deliberately left alone, pinned so a change is deliberate. |
+| `DEAD CODE:` | Unreachable branch, with the gate that disables it cited. |
+
+**Never leave a spec red to represent a known bug.** A permanently failing
+suite destroys the signal for every future change. Where current breakage must
+be tolerated, record it in an explicit **baseline table** with a guard
+asserting the baseline itself is still accurate — see `harness/mcm_labels.lua`.
+A stale baseline is worse than a plain break: it masks the next one in that slot.
+
+**But do not baseline something a player can see.** This is the failure mode
+that actually happened here: four MCM labels had no translation and rendered as
+literal `ui_mcm_soulslike_debug_debug_squad_spawns` text in the shipped
+settings menu. They were baselined, so `run.bat` reported PASS — green while
+visibly broken, which is precisely what this suite exists to prevent. The
+`MISSING_ENG` table is empty now and should stay empty.
+
+Before baselining anything, ask: *would a player notice this?* If yes, it is a
+defect, and the fix belongs in the same change as the spec that caught it.
+
+**Separate defects from debt.** Untranslated strings are outstanding work, not
+bugs. They are reported on every run so the count cannot quietly grow, but they
+do not fail a build unless `--strict` is passed. Conflating the two either
+blocks work on translation or hides real breakage in a pile of it.
+
+**Determinism.** `math.random` raises unless pinned. Budgets matter — assert
+them with `H.fakes.random_count()`. Some functions spend rolls of different
+call forms wanting opposite values (`TransferItem` wants a high `math.random()`
+and a low `math.random(0,100)`); use a predicate on the call form, not a
+constant.
+
+**Reaching file-locals.** A `local function` becomes an *upvalue* of any
+exported function referencing it, so no mod edit is needed:
+
+```lua
+local f = H.loader.upvalue(_G.SoulslikeScenarioLogic.TransferItem, "ignore_list")
+```
+
+Pick the anchor that genuinely closes over it. Anchoring on the wrong function
+resolves nil and the spec silently tests nothing — that exact bug lived in
+`probe.lua` for a while.
+
+**Naming.** `describe("<unit>") > describe("<method()>") > describe("given
+<context>") > it("<observable behaviour>")`. `it` names complete the sentence
+"it …".
+
+**Adding a file.** Drop it in `self/`, `unit/` or `e2e/`; discovery picks it
+up. Discovery sorts alphabetically, so specs must not depend on load order.
+
+---
+
+## MCM specifically
+
+Two independent contracts, both from the MCM repo, both silently breakable.
+
+**Storage.** The key is the path: `"<root>/<group>/<option>"`, resolved by
+`ui_mcm.get`. `val` is a required **type code** — `0` string, `1` boolean,
+`2` float — *not* an initial value. A mismatch does not fail loudly; the option
+reads and writes through the wrong type and never persists. `unit/mcm_options.spec.lua`
+walks the tree asserting this, and cross-references it against the keys the
+getters actually read — discovered by driving each getter through a recording
+`ui_mcm`, never by restating them.
+
+**Labels.** A node with no `text` derives `"ui_mcm_" .. <path with / → _>`, so
+`allow_weapon_loss` in group `items` needs
+`ui_mcm_soulslike_items_allow_weapon_loss`. A miss renders the raw string id on
+screen and nothing else reports it. Tooltips are looked up at `<key>_desc` and
+are optional.
+
+`locals.bat` reports this in both directions. Checking both is what makes a
+rename obvious: the new id has no translation **and** the old translation is
+orphaned, so one mistake fails two assertions pointing at each other.
+
+Because the whole MCM module funnels through one accessor, faking `ui_mcm.get`
+alone makes the **real** 1200-line module run. Unset keys exercise each
+getter's declared default.
+
+---
+
+## Before you claim it works
+
+- `tests\run.bat` exits 0.
+- `probe.lua` still reports 0 unreachable.
+- A fix has a spec that **went red first**. If it never failed, it proves
+  nothing — delete it or make it meaningful.
+- Engine-derived constants carry citations.
+- `git diff gamedata/` reviewed on its own. The mod changes are the risky half;
+  they should read as targeted fixes, not incidental churn.
+- Say plainly what was *not* verified. None of this runs the actual game — a
+  green suite is evidence about logic, not about Anomaly.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -17,7 +17,8 @@ tests\run.bat                     all specs        (self gates unit + e2e)
 tests\run.bat self|unit|e2e       one suite
 tests\run.bat --file ambush       spec files matching a substring
 tests\run.bat -t "keep roll"      tests matching a substring
-tests\locals.bat                  MCM localisation report + its spec
+tests\locals.bat                  localisation spec, then the report (strict)
+tests\locals.bat --lax            same, without failing on untranslated strings
 tests\tools\luajit.exe probe.lua  reachability check
 ```
 
@@ -108,6 +109,7 @@ harness/world.lua       item/container model + the alife simulator
 harness/timeevents.lua  CreateTimeEvent queue and pump
 harness/mods.lua        base-Anomaly and third-party script registry
 harness/mcm_labels.lua  MCM label derivation, analysis, and its baselines
+harness/encoding.lua    byte-level inspection of the localisation XML
 harness/init.lua        H.boot / H.tick / H.reboot — start here
 ```
 
@@ -178,9 +180,12 @@ Before baselining anything, ask: *would a player notice this?* If yes, it is a
 defect, and the fix belongs in the same change as the spec that caught it.
 
 **Separate defects from debt.** Untranslated strings are outstanding work, not
-bugs. They are reported on every run so the count cannot quietly grow, but they
-do not fail a build unless `--strict` is passed. Conflating the two either
-blocks work on translation or hides real breakage in a pile of it.
+bugs. Conflating the two either blocks work on translation or hides real
+breakage in a pile of it. So the two entry points answer different questions:
+`run.bat` gates the build and **passes** with translation outstanding;
+`locals.bat` is the translation tool and **fails** while any string is
+untranslated (`--lax` opts out). Reporting alone proved too quiet — the count
+sat mid-output and the closing line said `PASS`.
 
 **Determinism.** `math.random` raises unless pinned. Budgets matter — assert
 them with `H.fakes.random_count()`. Some functions spend rolls of different
@@ -229,6 +234,43 @@ are optional.
 `locals.bat` reports this in both directions. Checking both is what makes a
 rename obvious: the new id has no translation **and** the old translation is
 orphaned, so one mistake fails two assertions pointing at each other.
+
+**Parity is whole-table, not label-derived.** The label scan only sees ids the
+option tree asks for — 112 of 220 strings. Every message, item name and
+main-menu string was outside its reach, so a gap in `soulslike_messages.xml`
+was invisible to the entire suite: `locals.bat` printed it and no assertion
+ever read the result. `M.parity` compares the two tables outright, and both
+directions are asserted. eng-with-no-rus is debt, baselined in `M.MISSING_RUS`.
+rus-with-no-eng is **not** baselined — it cannot be translation work, because
+there is nothing left to translate; it is a rename applied to one table only.
+
+**A repeated `<string id>` is invisible to everything else.** The engine keeps
+one `<text>` and drops the rest, and every check here reads a *set*, where the
+repeat has already collapsed and the id still resolves. So a copy-pasted block
+that was never renamed silently takes the place of the string it was meant to
+become, and nothing goes red. `loader.load_string_table` returns the repeat
+counts alongside the set for exactly this reason. This is not hypothetical
+either: three consecutive `<string>` blocks shared
+`ui_mcm_soulslike_scenarios_rf_detector_scenario_weight_desc` in **both**
+languages, so the live `looter_npcs_marked` option had no tooltip in game at
+all. Treat a duplicate as a defect, never as debt.
+
+**Encoding.** `gamedata/configs/text/rus/*.xml` is stored as **windows-1251**,
+one byte per Cyrillic letter, and must stay that way. The engine's XML reader
+takes the bytes as they are and hands them to cp1251 font tables, so a file
+re-saved as UTF-8 still parses, every `<string id>` still resolves, and the
+label specs stay green while every Russian string renders as mojibake. The
+declaration keeps saying `windows-1251` throughout, so the diff looks innocent
+— it can only be caught at the byte level.
+
+This is not hypothetical: the rus tables were committed as UTF-8 across ten
+revisions before `e5494dc` put them back. The cause is an editor, not a person — VS Code
+guesses an encoding on open, guesses wrong on cp1251, and rewrites the file on
+save. `unit/text_encoding.spec.lua` is the guard, on two independent signals
+(the file must not decode as valid UTF-8; every high byte must exist in
+cp1251), plus a BOM check and a declaration check. Line endings are
+deliberately *not* asserted — stock files use LF, ours CRLF, `core.autocrlf`
+rewrites them on checkout, and the engine reads both.
 
 Because the whole MCM module funnels through one accessor, faking `ui_mcm.get`
 alone makes the **real** 1200-line module run. Unset keys exercise each

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -108,7 +108,7 @@ harness/builders.lua    fixtures: actors, npcs, items, logic_state, scenarios
 harness/world.lua       item/container model + the alife simulator
 harness/timeevents.lua  CreateTimeEvent queue and pump
 harness/mods.lua        base-Anomaly and third-party script registry
-harness/mcm_labels.lua  MCM label derivation, analysis, and its baselines
+harness/mcm_labels.lua  MCM label derivation and analysis
 harness/encoding.lua    byte-level inspection of the localisation XML
 harness/init.lua        H.boot / H.tick / H.reboot — start here
 ```
@@ -164,20 +164,25 @@ something. Three markers flag exceptions:
 | `DEAD CODE:` | Unreachable branch, with the gate that disables it cited. |
 
 **Never leave a spec red to represent a known bug.** A permanently failing
-suite destroys the signal for every future change. Where current breakage must
-be tolerated, record it in an explicit **baseline table** with a guard
-asserting the baseline itself is still accurate — see `harness/mcm_labels.lua`.
-A stale baseline is worse than a plain break: it masks the next one in that slot.
+suite destroys the signal for every future change. Fix the defect in the same
+change as the spec that caught it.
 
-**But do not baseline something a player can see.** This is the failure mode
-that actually happened here: four MCM labels had no translation and rendered as
-literal `ui_mcm_soulslike_debug_debug_squad_spawns` text in the shipped
-settings menu. They were baselined, so `run.bat` reported PASS — green while
-visibly broken, which is precisely what this suite exists to prevent. The
-`MISSING_ENG` table is empty now and should stay empty.
+**Never write a data table that turns a failure into a pass.** This one was
+learned the hard way here. `harness/mcm_labels.lua` used to carry four tables
+of "known broken" string ids, and every localisation assertion filtered its
+findings through them. Adding an id made the suite green. The tables needed
+their own staleness guard, so the mechanism grew a mechanism. And the failure
+it was built to prevent happened anyway: four MCM labels rendered as literal
+`ui_mcm_soulslike_debug_debug_squad_spawns` in the shipped settings menu while
+`run.bat` reported PASS, because they had been baselined.
 
-Before baselining anything, ask: *would a player notice this?* If yes, it is a
-defect, and the fix belongs in the same change as the spec that caught it.
+All four tables are gone. Every localisation assertion now expects an empty
+list, and the only way to reach green is to fix the localisation.
+
+If some finding genuinely has to be tolerated, write the reason **in the spec,
+in prose, next to the assertion that tolerates it** — so a reader meets the
+exception and the reason for it at the same moment. Never move the exception
+into data that silences findings from a distance.
 
 **Separate defects from debt.** Untranslated strings are outstanding work, not
 bugs. Conflating the two either blocks work on translation or hides real
@@ -236,13 +241,14 @@ rename obvious: the new id has no translation **and** the old translation is
 orphaned, so one mistake fails two assertions pointing at each other.
 
 **Parity is whole-table, not label-derived.** The label scan only sees ids the
-option tree asks for — 112 of 220 strings. Every message, item name and
+option tree asks for — 112 of 213 strings. Every message, item name and
 main-menu string was outside its reach, so a gap in `soulslike_messages.xml`
 was invisible to the entire suite: `locals.bat` printed it and no assertion
 ever read the result. `M.parity` compares the two tables outright, and both
-directions are asserted. eng-with-no-rus is debt, baselined in `M.MISSING_RUS`.
-rus-with-no-eng is **not** baselined — it cannot be translation work, because
-there is nothing left to translate; it is a rename applied to one table only.
+directions are asserted. eng-with-no-rus is debt: `run.bat` passes with it
+outstanding, `locals.bat` fails. rus-with-no-eng is a defect either way — it
+cannot be translation work, because there is nothing left to translate; it is a
+rename applied to one table only.
 
 **A repeated `<string id>` is invisible to everything else.** The engine keeps
 one `<text>` and drops the rest, and every check here reads a *set*, where the

--- a/tests/README.md
+++ b/tests/README.md
@@ -436,6 +436,32 @@ MCM getters hard-return `false`/`0.0` · `debug/debug_hidden_stashes`, whose tre
 entry is commented out · `scenarios/nearby_dead_stalker_scenario_weight`, a
 getter nothing calls.
 
+## Known-broken baselines
+
+`unit/mcm_localization.spec.lua` checks MCM option labels against the string
+tables **in both directions**, and the things it currently finds are recorded
+as baseline tables inside that spec rather than fixed. The suite stays green, so
+a *new* break fails immediately — which is the point, since MCM resolves a
+missing label to the raw string id on screen and nothing else signals it.
+
+Shrinking a baseline table is the fix. Growing one should be deliberate.
+
+| Baseline | What it holds | Now |
+|---|---|---|
+| `MISSING_ENG` | Node exists, translation does not — renders as the raw id | 4 |
+| `LITERAL_TEXT` | Node hardcodes an English sentence instead of a string id | 2 |
+| `ORPHAN_ENG` | Translation exists, node does not | 8 |
+| `MISSING_RUS` | English present, Russian absent | 14 |
+
+Each table also has a guard asserting its own entries are still accurate, so a
+stale baseline fails rather than quietly masking a real regression.
+
+The derivation the spec relies on: a node with no `text` gets
+`"ui_mcm_" .. <path with "/" → "_">`, so `allow_weapon_loss` in group `items`
+under root `soulslike` needs `ui_mcm_soulslike_items_allow_weapon_loss`.
+Renaming an option id moves its label key — which shows up here as a missing
+key *and* an orphan at the same time.
+
 ## Not covered
 
 Out of scope by decision: the two UI modules (`soulslike_sleep_dialog`,

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,327 @@
+# Soulslike test harness
+
+Runs the mod's Lua **unmodified**, outside the game engine, so scenario logic can
+be exercised without launching Anomaly and dying repeatedly.
+
+Specs are BDD — nested `describe` / `it` with a Jest-style `expect`, the same
+shape as a TS suite.
+
+```
+run.bat          all specs (self-tests gate the unit specs)
+run.bat self     harness self-tests only
+run.bat unit     unit specs only
+
+tools\luajit.exe probe.lua    reachability check -- see "Reachability probe"
+```
+
+Exit code is 0 on success, 1 on failure, 2 if no Lua runtime was found.
+
+Nothing here ships to players: `deploy.bat` packages only `gamedata/`.
+
+## Output
+
+Results print as a tree, green `✓` for a pass, red `✗` for a failure, yellow `○`
+for a pending `xit`:
+
+```
+compute_fatal_hit_info()
+  power weighting
+    given hits spread over time
+      ✓ weights later hits more heavily
+      ✗ gives the earliest hit zero weight
+        expected 1000 to be 2
+```
+
+| Flag / variable | Effect |
+|---|---|
+| `--no-color` | plain output, no ANSI |
+| `NO_COLOR` / `SPEC_NO_COLOR` | same, via the environment ([no-color.org](https://no-color.org)) |
+| `FORCE_COLOR` | colour on even when `NO_COLOR` is set |
+| `--ascii` or `SPEC_ASCII` | `ok` / `XX` / `--` instead of the symbols |
+
+`run.bat` switches the console to code page 65001 for the duration of the run
+and restores the previous one on exit, since the symbols are UTF-8. If you
+invoke `luajit run.lua` directly from a legacy code page, pass `--ascii`.
+
+## Runtime
+
+Requires **LuaJIT 2.x or Lua 5.1**. Not 5.2+ — the module loader uses `setfenv`,
+which was removed in 5.2.
+
+`run.bat` looks for `luajit.exe` on PATH, then falls back to `tools\luajit.exe`.
+`tools/` is gitignored; build it from the engine repo's vendored source:
+
+```
+copy  xray-monolith\src\3rd party\luajit-2  somewhere\
+call  "…\VC\Auxiliary\Build\vcvars64.bat"
+cd    somewhere\src
+set   PATH=%CD%;%PATH%          REM msvcbuild invokes the minilua it just built
+call  msvcbuild.bat static
+copy  luajit.exe  <mod>\tests\tools\
+```
+
+## Layout
+
+| Path | What |
+|---|---|
+| `harness/spec.lua` | BDD runner: `describe`/`it`/`beforeEach` + `expect` |
+| `harness/loader.lua` | Reproduces the engine's script-module namespacing |
+| `harness/class.lua` | Shim for luabind's `class` / `super` |
+| `harness/dispatch.lua` | `RegisterScriptCallback` / `SendScriptCallback` registry |
+| `harness/fakes.lua` | Fake engine globals (`level`, `db`, `ui_mcm`, …) |
+| `harness/builders.lua` | Fixture builders (`make_actor`, `make_hit`, …) |
+| `harness/world.lua` | Item/container model + the alife simulator |
+| `harness/timeevents.lua` | `CreateTimeEvent` queue and pump |
+| `harness/mods.lua` | Base-Anomaly and third-party script registry |
+| `self/*.spec.lua` | Harness self-tests — these gate everything else |
+| `unit/*.spec.lua` | Unit specs against the real mod scripts |
+| `probe.lua` | Reachability check, not a test suite |
+
+## Writing a spec
+
+`describe` / `it` / `beforeEach` / `afterEach` / `expect` are ambient globals,
+installed by `harness.init`.
+
+```lua
+local H = require("harness.init")
+
+describe("soulslike.get_soulslike_state()", function()
+
+  beforeEach(function()
+    H.boot{ load = { "soulslike_classes", "soulslike" } }
+  end)
+
+  describe("given a save with no soulslike data at all", function()
+    it("creates every top-level collection", function()
+      expect(soulslike.get_soulslike_state().created_stashes).toBeDefined()
+    end)
+  end)
+end)
+
+return true
+```
+
+Then add the file to `SELF` or `UNIT` in `run.lua`.
+
+### Naming
+
+Follow the nesting the existing specs use:
+
+```
+describe("<unit under test>")
+  describe("<method()>")
+    describe("given <context>")
+      it("<observable behavior>")
+```
+
+`it` names complete the sentence "it …" — `returns nil`, `does not raise`,
+`falls back to Other`. Not `test nil return`.
+
+### Matchers
+
+`expect(x)` uses TS call syntax (a dot, not a colon). Prefix any matcher with
+`.never` to negate it.
+
+| | |
+|---|---|
+| `.toBe(v)` | identity / `==` |
+| `.toEqual(v)` | deep structural equality |
+| `.toBeNil()` / `.toBeDefined()` | nil checks |
+| `.toBeTruthy()` / `.toBeFalsy()` | truthiness |
+| `.toBeType("function")` | `type()` check |
+| `.toContain(v)` | substring, or table membership |
+| `.toHaveLength(n)` | `#` of a string or table |
+| `.toBeCloseTo(n, tol)` | float compare, default tol `1e-9` |
+| `.toBeGreaterThan(n)` / `.toBeLessThan(n)` | ordering |
+| `.toThrow()` / `.toThrow("substr")` | wrap the call: `expect(function() … end).toThrow()` |
+
+`xit("...")` marks a spec pending — reported with `○`, never run.
+
+One gotcha: `expect()`'s argument is evaluated **before** the matcher call, so
+build state first rather than inlining the call that creates it.
+
+```lua
+local s = state()                       -- do this
+expect(fakes.game_state.soulslike).toBe(s)
+
+expect(fakes.game_state.soulslike).toBe(state())   -- not this: captures nil
+```
+
+### The world model, and why you must tick
+
+Items live in named containers. Assert final placement, not call sequences:
+
+```lua
+local ak = H.world.give("actor", "wpn_ak74", { kind = "weapon", condition = 0.8 })
+local stash = H.world.container("stash")
+H.world.spawn_npc("looter", { kind = "stalker", community = "bandit" })
+
+scenario:TransferItems(stash:id())
+H.tick()                                   -- REQUIRED before asserting
+
+expect(H.world.where(ak)).toBe("stash")
+expect(H.world.contents("looter")).toEqual({ "medkit" })
+expect(H.world.destroyed()).toEqual({})
+```
+
+**Inventory mutations are deferred, and that is deliberate.** The engine walks
+the live `m_all` container with raw iterators (`IterateInventory`,
+`script_game_object_inventory_owner.cpp:266`) while the mod calls
+`alife_release` and `transfer_item` from inside that loop. That is only safe
+because `transfer_item` sends `GE_TRADE_SELL`/`GE_TRADE_BUY` network events
+processed on a later frame. So the model queues too. Two rules follow:
+
+- Inside `iterate_inventory`, an item you just released is **still present**.
+- `TransferItems` returning does **not** mean anything moved. Tick first.
+
+`H.tick()` drains time events and then applies the world mutations they caused.
+
+Server and client objects are distinct, as in the engine: `alife_create` /
+`alife_object` return a **server** object where `.id` is a *field*;
+`level.object_by_id` returns a **client** object where `:id()` is a *method*.
+`H.world.hide(id)` makes an object invisible to `level.object_by_id`, which is
+how you exercise the "stash is not online yet" retry.
+
+### Optional and base scripts
+
+```lua
+H.boot{ mods    = { "magazine_binder" } }   -- add a third-party integration
+H.boot{ without = { "item_parts" } }        -- test an absent-dependency guard
+```
+
+`H.mods.BASE` (`actor_status_thirst`, `arszi_psy`, `item_parts`, `item_radio`,
+`treasure_manager`) ship with Anomaly and are installed by default — two are
+called unguarded, so "absent" is not a state the mod survives.
+`H.mods.OPTIONAL` (`magazine_binder`, `grok_actor_damage_balancer`,
+`demonized_time_events`) are third-party and absent by default.
+
+`H.mods.patched(name)` lists fields replaced since `enable()` — use it to catch
+an unrestored monkey-patch, e.g. `treasure_manager.box_in_same_map`
+(soulslike_scenarios.script:1335).
+
+### Strict globals
+
+```lua
+H.boot{ strict = true }
+```
+
+Raises on a global that resolved to nil instead of silently returning nil, so a
+missing fake fails where it happens. Off by default, because nil-tolerance is
+the engine's real behavior and the mod relies on it. Registered optional mods
+are always exempt.
+
+### Faking config
+
+Every one of `soulslike_mcm`'s 60+ getters funnels through one accessor
+(`soulslike_mcm.script:939`), so the **real** MCM module runs against a single
+fake. Unset keys exercise each getter's declared default.
+
+```lua
+H.fakes.set_mcm("hardcore/is_enabled", true)   -- key omits the "soulslike/" prefix
+```
+
+### Determinism
+
+`math.random` raises unless a spec pins it first — an unseeded roll is a bug,
+not a default.
+
+```lua
+H.fakes.set_random_const(1)          -- always 1
+H.fakes.set_random_sequence{1, 5, 3} -- in order; errors past the end
+H.fakes.set_time(5000)               -- backs time_global()
+```
+
+### Testing a file-local function
+
+`local function` at file scope is not exported, but it becomes an *upvalue* of
+any exported function that references it — so it is reachable without editing
+the mod:
+
+```lua
+local compute = H.loader.upvalue(
+  soulslike_scenario_logic_factory.create_new, "compute_fatal_hit_info")
+```
+
+Call this from the spec, never from inside a module's environment
+(`soulslike.script` shadows `debug`).
+
+## Why self-tests gate unit specs
+
+The harness re-implements three pieces of engine behavior. If any drifts, unit
+specs keep passing while testing something the game would never execute. So a
+self-test failure aborts the run before `unit/`.
+
+The one that matters most is the module loader. The engine textually wraps every
+`.script` file (`script_storage.cpp:608`), producing semantics plain `require`
+does not:
+
+| In a module | Lands as |
+|---|---|
+| `RELATIONS = {...}` | `soulslike.RELATIONS` (module-local) |
+| `function debug(o)` | `soulslike.debug` — shadows the stdlib `debug` table |
+| `function math.clamp(…)` | mutates the **shared** global `math` table |
+| `function _G.IsSoulslikeMode()` | a true global |
+| reading an undefined global | `nil`, **not** an error |
+
+To confirm the harness is still load-bearing, break one semantic and check that
+the run fails loudly rather than passing quietly. Removing the
+`setmetatable(this, {__index = _G})` line from `loader.build_prologue` should
+produce 9 self-test failures and skip `unit/` entirely.
+
+The same applies to the world model. This must hold, and would not if the model
+ever started snapshotting or applying immediately:
+
+```lua
+world.give("actor", "a"); world.give("actor", "b")
+db.actor:iterate_inventory(function(_, item) alife_release(item) end)
+expect(world.contents("actor")).toHaveLength(2)   -- still there
+H.tick()
+expect(world.contents("actor")).toHaveLength(0)   -- now gone
+```
+
+## Reachability probe
+
+```
+tools\luajit.exe probe.lua
+```
+
+Calls every non-UI mod function once and reports reachable / unreachable. It
+asserts nothing about correctness — it answers "can the harness get here at
+all". Currently **71 reachable, 0 unreachable**. Run it after touching the
+fakes; a new FAIL means a fake regressed or the mod grew a dependency.
+
+## Standing caveat
+
+These specs validate mod logic against **our assumptions about the engine**. A
+wrong constant in `fakes.lua` becomes a permanently green spec. Values taken
+from engine source are cited in comments; anything else should be pinned against
+a real game before it is trusted.
+
+## Not covered yet
+
+The harness reaches every non-UI function, but **specs have only been written
+for a fraction of them**. Still unwritten: the scenario-selection matrix,
+save/load round-trip, `SpawnAmbush`, `IsItemLossAllowed`, `TransferItem` and
+the item-routing trio, the economy methods, and the full death→respawn flow.
+All are reachable — see `probe.lua` for a working call of each.
+
+Out of scope by decision: the two UI modules (`soulslike_sleep_dialog`,
+`souslike_gamemode_injector_mcm`). They monkey-patch Anomaly UI classes at file
+scope and need those classes to exist before they will load; they are thin
+decorators, so testing them mostly tests the stub.
+
+### Known sharp edge
+
+`create_new` reads `spawn_location.position.x` and passes it to
+`vector():set()`. Before any spawn has been recorded those are nil, and the
+engine binds `set(float,float,float)` only — luabind raises `lua_cast_failed`,
+which becomes `Debug.fatal`, i.e. a CTD. `RespawnActor` has the same shape at
+soulslike_scenarios.script:845.
+
+The harness reproduces this rather than coercing nil to 0, so it stays visible.
+Measured: `create_new` raises on a fresh state, and stops raising after a single
+`save_state` (which calls `set_spawn`). So the exposure is a death occurring
+before the first save or level change. Whether Anomaly's new-game autosave
+always closes that window has not been confirmed in-game.
+
+Set `H.builders.strict_vectors = false` in a spec that needs to step past it.

--- a/tests/README.md
+++ b/tests/README.md
@@ -84,7 +84,7 @@ copy  luajit.exe  <mod>\tests\tools\
 | `harness/world.lua` | Item/container model + the alife simulator |
 | `harness/timeevents.lua` | `CreateTimeEvent` queue and pump |
 | `harness/mods.lua` | Base-Anomaly and third-party script registry |
-| `harness/mcm_labels.lua` | MCM label derivation, analysis and its baselines |
+| `harness/mcm_labels.lua` | MCM label derivation and analysis |
 | `harness/encoding.lua` | Byte-level inspection of the localisation XML |
 | `self/*.spec.lua` | Harness self-tests — these gate everything else |
 | `unit/*.spec.lua` | Unit specs against the real mod scripts |
@@ -467,15 +467,18 @@ Outcomes, deliberately not treated alike:
 
 | | Fails? | Why |
 |---|---|---|
-| **Regression** — node with no English string | **yes, always** | The player sees the raw string id in the menu. There is no case for accepting one; add four lines to `configs/text/eng`. `MISSING_ENG` is empty and should stay empty. |
+| **Missing** — node with no English string | **yes, always** | The player sees the raw string id in the menu. Add four lines to `configs/text/eng`. |
+| **Hardcoded** — node carries an English sentence, not a string id | **yes, always** | Renders, because `translate_string` passes unknown input through, but can never be translated. Delete the literal and let the node derive its key. |
+| **Orphan** — string with no node | **yes, always** | Half a rename, or a string for an option that no longer exists. Delete it; git holds the text if the option returns. |
 | **Duplicate** — one id declared twice | **yes, always** | The engine keeps one `<text>` and drops the rest. Every other check reads a *set*, where the repeat has collapsed and the id still resolves, so this is the only thing that can see it. |
-| **Half a rename** — Russian string with no English one | **yes, always** | Not translation work: there is nothing left to translate. Not baselined. |
-| **Baselined** — hardcoded English, or an orphaned string | no | Renders correctly (or is invisible). Recorded in `harness/mcm_labels.lua` with a reason. |
+| **Half a rename** — Russian string with no English one | **yes, always** | Not translation work: there is nothing left to translate. |
 | **Debt** — English present, Russian absent | in `locals.bat`, not in `run.bat` | Work outstanding, not a defect. `run.bat` gates the build on what is *broken*; `locals.bat` is the translation tool and should not exit 0 while there is debt to look at. `--lax` opts out. |
 
-Baselines carry a guard asserting their own entries still describe reality. A
-stale entry is worse than a plain break — it masks the next one in that slot —
-so it should be deleted, never updated to match.
+There is no list of accepted breakages and nothing to add an id to. Every
+assertion expects an empty list, so the only way to reach green is to fix the
+localisation. Four "known broken" tables used to live in
+`harness/mcm_labels.lua`; they let four visibly broken labels ship while
+`run.bat` said PASS, and they are gone. Do not add them back.
 
 > The Russian tables ship as **windows-1251**, not UTF-8. Everything here
 > compares string *ids*, which are ASCII, so it never matters; anything that

--- a/tests/README.md
+++ b/tests/README.md
@@ -246,7 +246,80 @@ not a default.
 H.fakes.set_random_const(1)          -- always 1
 H.fakes.set_random_sequence{1, 5, 3} -- in order; errors past the end
 H.fakes.set_time(5000)               -- backs time_global()
+H.fakes.random_count()               -- rolls spent, for exact-budget asserts
 ```
+
+Budgets are worth asserting. `IsItemLossAllowed` spends 0 or 1 roll depending on
+the item category, and a stray roll desynchronises every later one in a death.
+
+Some functions spend rolls of **different call forms** that want opposite
+values — `TransferItem` wants a high `math.random()` (fail the keep roll) and a
+low `math.random(0, 100)` (pass the loss roll). A constant cannot express that;
+use a predicate on the call form:
+
+```lua
+H.fakes.set_random(function(a, b)
+  if a == nil then return 0.999 end   -- 0-arg: fail every keep roll
+  return a                            -- ranged: pass every loss roll
+end)
+```
+
+### Scenario fixtures
+
+```lua
+H.set_spawn{ level = "zaton" }              -- required before create_new/RespawnActor
+B.stub_finders{ friendly_stalker = npc }    -- the four find_closest_* helpers
+B.make_scenario{ class = "NoLossSoulslikeScenarioLogic", state = {...} }
+B.make_logic_state{ allow_weapon_loss = false }
+B.finder_count("enemy_mutant")              -- which finder an arm consulted
+```
+
+`finder_count` is load-bearing, not a convenience: several selection arms differ
+only by *which* finder supplies the looter, so asserting the returned object
+cannot tell them apart.
+
+`make_logic_state` is a hand-written literal mirroring the mod's `__init`. A
+drift guard in `self/builders.spec.lua` asserts its key set still matches a
+freshly constructed scenario, so a field added to the mod fails there rather
+than silently rotting every fixture.
+
+### Crossing a level change
+
+```lua
+H.reboot{ load = MOD_SCRIPTS, soulslike_mode = true }
+```
+
+Re-executes every script and discards every module table while preserving the
+save. That is exactly what `ChangeLevel` does, and it is the only way to test
+the save/load round trip — a plain `H.boot` wipes the save, so the "reload"
+would have nothing to restore from.
+
+### Observing a retrying time event
+
+`H.tick()` runs to completion and raises if anything is still waiting. To watch
+an event mid-wait, bound it:
+
+```lua
+H.world.hide(stash_id)
+H.tick{ passes = 1 }                        -- one frame; leaves the retry queued
+expect(H.timeevents.pending()).toBeGreaterThan(0)
+H.world.reveal(stash_id)
+H.tick()                                    -- now it completes
+```
+
+### Save files
+
+The hardcore save-pruning walk reads each sibling save with a real `io.open`
+before decoding it, so it needs a shim:
+
+```lua
+H.fakes.install_save_fs()
+H.fakes.set_save("older", { soulslike = { uuid = "run-1" } })
+H.fakes.set_save("corrupt", nil)            -- models an unreadable file
+```
+
+Non-save paths fall through to the real `io.open`, which the module loader still
+needs. Uninstalled automatically on the next `H.boot`.
 
 ### Testing a file-local function
 
@@ -304,7 +377,7 @@ tools\luajit.exe probe.lua
 
 Calls every non-UI mod function once and reports reachable / unreachable. It
 asserts nothing about correctness — it answers "can the harness get here at
-all". Currently **71 reachable, 0 unreachable**. Run it after touching the
+all". Currently **72 reachable, 0 unreachable**. Run it after touching the
 fakes; a new FAIL means a fake regressed or the mod grew a dependency.
 
 ## Standing caveat
@@ -314,31 +387,58 @@ wrong constant in `fakes.lua` becomes a permanently green spec. Values taken
 from engine source are cited in comments; anything else should be pinned against
 a real game before it is trusted.
 
-## Not covered yet
+Engine behaviour cited here was read from `xray-monolith`. The load-bearing
+facts, and where they bite:
 
-The harness reaches every non-UI function, but **specs have only been written
-for a fraction of them**. Still unwritten: the scenario-selection matrix,
-save/load round-trip, `SpawnAmbush`, `IsItemLossAllowed`, `TransferItem` and
-the item-routing trio, the economy methods, and the full death→respawn flow.
-All are reachable — see `probe.lua` for a working call of each.
+| Fact | Citation |
+|---|---|
+| Inventory slots run **1..18** — `LAST_SLOT = CUSTOM_SLOT_5`, since `MORE_INVENTORY_SLOTS` is defined. Slot 0 is `NO_ACTIVE_SLOT` and is rejected | `inventory_space.h:6-45`, `build_config_defines.h:15` |
+| `iterate_inventory` is a live walk and stops on **any truthy** return, not just `true` | `script_game_object_inventory_owner.cpp:256-271` |
+| `CreateTimeEvent` re-queues on anything **not literally `true`** — the opposite convention | `_g.script:366-390` |
+| `transfer_item` is **deferred** through `GE_TRADE_SELL` / `GE_TRADE_BUY` | `script_game_object_inventory_owner.cpp:584-610` |
+| Server objects expose `id`/`position` as **fields**; client objects use methods | `xrServer_Objects_script.cpp:110-124` |
+| `alife():register` **frees its argument** and returns a new pointer | `alife_simulator_script.cpp:396-413` |
+| `set_character_rank`/`_reputation` are int, **unclamped**, and truncate **toward zero** | `character_info_defs.h:8-24`, `policy.hpp:377` |
+| `give_money(-N)` does **not** clamp — it underflows u32 | `InventoryOwner.cpp:630-645` |
+| Grenades are **not** weapons at either layer, so `IsWeapon(x) and not is_grenade` is redundant | `Grenade.h:6`, `_g.script:3081-3149` |
+| `clsid()` values are **runtime ordinals** — never hardcode one | `object_factory_script.cpp:85-97` |
+| `vector():set(nil,…)` is **UB in a release build**, not a catchable error: `NDEBUG` compiles out luabind's no-overload guard | `class_rep.cpp:605-688`, `config.hpp:81-91` |
+
+That last one is why `H.builders.strict_vectors` raises rather than coercing nil
+to 0. Both call sites that could reach it are now guarded
+(`soulslike_scenario_logic_factory.script:164`,
+`soulslike_scenarios.script:902`), and specs assert they no longer raise. Set
+`strict_vectors = false` only in a spec that deliberately needs to step past it.
+
+## Pinned behaviour
+
+Specs assert **correct** behaviour, so the suite runs green; a defect found
+along the way was fixed rather than pinned. Three markers flag the exceptions:
+
+| Marker | Meaning |
+|---|---|
+| `FIXES: Dn` | The spec exists because it caught a defect. It failed first, then the fix landed. |
+| `CHARACTERIZATION:` | Behaviour deliberately left alone, pinned so a change is deliberate rather than accidental. |
+| `DEAD CODE:` | An unreachable branch, with the gate that disables it cited. |
+
+Currently pinned as characterization: `save_state`/`load_state` shadow their
+`data` parameter, so the dispatched payload is ignored · `logic_state` is stored
+by reference with no serialization step · weapon condition loss never destroys
+the weapon or sets `items_were_lost`, because parts clamp at 1 · toolkits have
+an allow flag but no keep roll, unlike the other four categories · squad
+ambushers are tracked without vertex ids · the indoor selection arm leaves the
+loot scalar at 1.0 where every other no-loss arm sets 0 · the ignore list
+matches bare `medkit`/`bandage` while Anomaly ships variants (a balance
+decision, not a code bug).
+
+Currently marked dead: the RF-detector and hidden-stash selection arms, whose
+MCM getters hard-return `false`/`0.0` · `debug/debug_hidden_stashes`, whose tree
+entry is commented out · `scenarios/nearby_dead_stalker_scenario_weight`, a
+getter nothing calls.
+
+## Not covered
 
 Out of scope by decision: the two UI modules (`soulslike_sleep_dialog`,
 `souslike_gamemode_injector_mcm`). They monkey-patch Anomaly UI classes at file
 scope and need those classes to exist before they will load; they are thin
 decorators, so testing them mostly tests the stub.
-
-### Known sharp edge
-
-`create_new` reads `spawn_location.position.x` and passes it to
-`vector():set()`. Before any spawn has been recorded those are nil, and the
-engine binds `set(float,float,float)` only — luabind raises `lua_cast_failed`,
-which becomes `Debug.fatal`, i.e. a CTD. `RespawnActor` has the same shape at
-soulslike_scenarios.script:845.
-
-The harness reproduces this rather than coercing nil to 0, so it stays visible.
-Measured: `create_new` raises on a fresh state, and stops raising after a single
-`save_state` (which calls `set_spawn`). So the exposure is a death occurring
-before the first save or level change. Whether Anomaly's new-game autosave
-always closes that window has not been confirmed in-game.
-
-Set `H.builders.strict_vectors = false` in a spec that needs to step past it.

--- a/tests/README.md
+++ b/tests/README.md
@@ -84,6 +84,8 @@ copy  luajit.exe  <mod>\tests\tools\
 | `harness/world.lua` | Item/container model + the alife simulator |
 | `harness/timeevents.lua` | `CreateTimeEvent` queue and pump |
 | `harness/mods.lua` | Base-Anomaly and third-party script registry |
+| `harness/mcm_labels.lua` | MCM label derivation, analysis and its baselines |
+| `harness/encoding.lua` | Byte-level inspection of the localisation XML |
 | `self/*.spec.lua` | Harness self-tests — these gate everything else |
 | `unit/*.spec.lua` | Unit specs against the real mod scripts |
 | `e2e/*.spec.lua` | End-to-end journeys through the callback chain |
@@ -439,10 +441,14 @@ getter nothing calls.
 ## Localisation
 
 ```
-locals.bat              report, plus the spec that asserts it
-locals.bat --report     report only
-locals.bat --strict     also fail on untranslated strings
+locals.bat              the spec that asserts it, then the report
+locals.bat --report     report only, skip the spec
+locals.bat --lax        do not fail on untranslated strings
 ```
+
+The report runs **last**. It is the part you came here to read, and when it ran
+first its summary scrolled off behind the spec output — the closing line said
+`PASS` while 20 strings were untranslated.
 
 A node with no `text` derives its label as `"ui_mcm_" .. <path with "/" → "_">`,
 so `allow_weapon_loss` in group `items` under root `soulslike` needs
@@ -453,13 +459,19 @@ Checked **in both directions**, which is what makes a rename obvious: the new
 id has no translation *and* the old translation is orphaned, so one mistake
 fails two assertions pointing at each other.
 
-Three outcomes, deliberately not treated alike:
+Parity is compared **whole-table**, not just across MCM labels: the label scan
+only sees the 112 ids the option tree asks for, so a gap in
+`soulslike_messages.xml` was outside its reach entirely.
+
+Outcomes, deliberately not treated alike:
 
 | | Fails? | Why |
 |---|---|---|
 | **Regression** — node with no English string | **yes, always** | The player sees the raw string id in the menu. There is no case for accepting one; add four lines to `configs/text/eng`. `MISSING_ENG` is empty and should stay empty. |
+| **Duplicate** — one id declared twice | **yes, always** | The engine keeps one `<text>` and drops the rest. Every other check reads a *set*, where the repeat has collapsed and the id still resolves, so this is the only thing that can see it. |
+| **Half a rename** — Russian string with no English one | **yes, always** | Not translation work: there is nothing left to translate. Not baselined. |
 | **Baselined** — hardcoded English, or an orphaned string | no | Renders correctly (or is invisible). Recorded in `harness/mcm_labels.lua` with a reason. |
-| **Debt** — English present, Russian absent | only with `--strict` | Work outstanding, not a defect. Reported on every run so the count cannot quietly grow. |
+| **Debt** — English present, Russian absent | in `locals.bat`, not in `run.bat` | Work outstanding, not a defect. `run.bat` gates the build on what is *broken*; `locals.bat` is the translation tool and should not exit 0 while there is debt to look at. `--lax` opts out. |
 
 Baselines carry a guard asserting their own entries still describe reality. A
 stale entry is worse than a plain break — it masks the next one in that slot —

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,14 +7,25 @@ Specs are BDD — nested `describe` / `it` with a Jest-style `expect`, the same
 shape as a TS suite.
 
 ```
-run.bat          all specs (self-tests gate the unit specs)
-run.bat self     harness self-tests only
-run.bat unit     unit specs only
+run.bat                  all specs (self-tests gate unit and e2e)
+run.bat self             harness self-tests only
+run.bat unit             unit specs only
+run.bat e2e              end-to-end journeys only
+
+run.bat --file ambush    only spec files whose path contains "ambush"
+run.bat -t "keep roll"   only tests whose full name contains "keep roll"
 
 tools\luajit.exe probe.lua    reachability check -- see "Reachability probe"
 ```
 
-Exit code is 0 on success, 1 on failure, 2 if no Lua runtime was found.
+Exit code is 0 on success, 1 on failure, 2 if no Lua runtime was found or no
+spec file matched.
+
+Both filters take a plain substring, not a pattern, and both **skip the
+self-test gate** — they are the "run just this one thing" switches, so dragging
+the whole self-suite along would defeat the point. A filter matching nothing
+reports `EMPTY` and exits non-zero rather than reading as a green run of zero
+tests.
 
 Nothing here ships to players: `deploy.bat` packages only `gamedata/`.
 
@@ -75,6 +86,7 @@ copy  luajit.exe  <mod>\tests\tools\
 | `harness/mods.lua` | Base-Anomaly and third-party script registry |
 | `self/*.spec.lua` | Harness self-tests — these gate everything else |
 | `unit/*.spec.lua` | Unit specs against the real mod scripts |
+| `e2e/*.spec.lua` | End-to-end journeys through the callback chain |
 | `probe.lua` | Reachability check, not a test suite |
 
 ## Writing a spec
@@ -101,7 +113,12 @@ end)
 return true
 ```
 
-Then add the file to `SELF` or `UNIT` in `run.lua`.
+Drop the file in `self/`, `unit/` or `e2e/` and it is picked up automatically —
+spec files are discovered from those directories, so `run.lua` needs no edit.
+
+The `MANIFEST` table in `run.lua` is only a fallback for hosts where the
+directory listing is unavailable (`io.popen` disabled, or a shell that is not
+`cmd`). Discovery sorts alphabetically, so specs must not depend on load order.
 
 ### Naming
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -436,31 +436,38 @@ MCM getters hard-return `false`/`0.0` · `debug/debug_hidden_stashes`, whose tre
 entry is commented out · `scenarios/nearby_dead_stalker_scenario_weight`, a
 getter nothing calls.
 
-## Known-broken baselines
+## Localisation
 
-`unit/mcm_localization.spec.lua` checks MCM option labels against the string
-tables **in both directions**, and the things it currently finds are recorded
-as baseline tables inside that spec rather than fixed. The suite stays green, so
-a *new* break fails immediately — which is the point, since MCM resolves a
-missing label to the raw string id on screen and nothing else signals it.
+```
+locals.bat              report, plus the spec that asserts it
+locals.bat --report     report only
+locals.bat --strict     also fail on untranslated strings
+```
 
-Shrinking a baseline table is the fix. Growing one should be deliberate.
+A node with no `text` derives its label as `"ui_mcm_" .. <path with "/" → "_">`,
+so `allow_weapon_loss` in group `items` under root `soulslike` needs
+`ui_mcm_soulslike_items_allow_weapon_loss`. A miss renders the raw string id on
+screen and nothing else reports it.
 
-| Baseline | What it holds | Now |
+Checked **in both directions**, which is what makes a rename obvious: the new
+id has no translation *and* the old translation is orphaned, so one mistake
+fails two assertions pointing at each other.
+
+Three outcomes, deliberately not treated alike:
+
+| | Fails? | Why |
 |---|---|---|
-| `MISSING_ENG` | Node exists, translation does not — renders as the raw id | 4 |
-| `LITERAL_TEXT` | Node hardcodes an English sentence instead of a string id | 2 |
-| `ORPHAN_ENG` | Translation exists, node does not | 8 |
-| `MISSING_RUS` | English present, Russian absent | 14 |
+| **Regression** — node with no English string | **yes, always** | The player sees the raw string id in the menu. There is no case for accepting one; add four lines to `configs/text/eng`. `MISSING_ENG` is empty and should stay empty. |
+| **Baselined** — hardcoded English, or an orphaned string | no | Renders correctly (or is invisible). Recorded in `harness/mcm_labels.lua` with a reason. |
+| **Debt** — English present, Russian absent | only with `--strict` | Work outstanding, not a defect. Reported on every run so the count cannot quietly grow. |
 
-Each table also has a guard asserting its own entries are still accurate, so a
-stale baseline fails rather than quietly masking a real regression.
+Baselines carry a guard asserting their own entries still describe reality. A
+stale entry is worse than a plain break — it masks the next one in that slot —
+so it should be deleted, never updated to match.
 
-The derivation the spec relies on: a node with no `text` gets
-`"ui_mcm_" .. <path with "/" → "_">`, so `allow_weapon_loss` in group `items`
-under root `soulslike` needs `ui_mcm_soulslike_items_allow_weapon_loss`.
-Renaming an option id moves its label key — which shows up here as a missing
-key *and* an orphan at the same time.
+> The Russian tables ship as **windows-1251**, not UTF-8. Everything here
+> compares string *ids*, which are ASCII, so it never matters; anything that
+> starts reading the `<text>` bodies has to decode first.
 
 ## Not covered
 

--- a/tests/e2e/death_to_respawn.spec.lua
+++ b/tests/e2e/death_to_respawn.spec.lua
@@ -1,0 +1,383 @@
+-- End to end: the player takes hits, dies, and wakes up somewhere else.
+--
+--   actor_on_before_hit xN
+--     -> actor_on_before_death
+--          -> create_new              (scenario selection)
+--          -> OnDeath                 (heal, rank/rep loss)
+--          -> HandleItemsAndRespawn   (record death location, CreateStash)
+--          -> CreateTimeEvent         <-- the flow suspends here
+--   H.tick()
+--          -> TransferItems           (per-item loss decisions)
+--          -> ApplyMoneyLoss
+--          -> RespawnActor            -> CreateTimeEvent -> ChangeLevel
+--
+-- The suspension is the reason this needs a tick pump: HandleItemsAndRespawn
+-- returns long before anything has moved, so asserting immediately after the
+-- death callback would only ever see an empty stash.
+--
+-- House style here: run the journey once in beforeEach, then one `it` per
+-- observable, rather than replaying a forty-step flow for every assertion.
+
+local H = require("harness.init")
+local B = H.builders
+
+local MOD_SCRIPTS = {
+    "soulslike_classes", "soulslike", "soulslike_mcm",
+    "soulslike_message_factory", "soulslike_scenarios",
+    "soulslike_scenario_logic_factory",
+}
+
+--- Boot a world where the player is far from spawn, so selection lands on a
+--- real loss scenario rather than the close-range no-loss arm.
+local function boot(opts)
+    opts = opts or {}
+    H.boot{ load = MOD_SCRIPTS, soulslike_mode = true }
+    H.fakes.set_random_min()
+    H.set_spawn{ level = "zaton", position = { x = 0, y = 0, z = 0 } }
+    H.set_actor{
+        position = { x = 0, y = 0, z = 500 },
+        rank = 5000, reputation = 400, money = 10000,
+    }
+    B.stub_finders{ friendly_stalker = B.make_stalker{ name = "medic" } }
+
+    H.fakes.set_ltx("itm_actor_backpack", { kind = "i_backpack" })
+    -- Force the Default scenario so a stash is actually created; the weighted
+    -- pick is covered on its own in unit/create_new.spec.lua.
+    H.fakes.set_mcm("debug/is_enabled", true)
+    H.fakes.set_mcm("debug/debug_the_default_scenario", true)
+
+    soulslike.on_game_start()
+    return opts
+end
+
+local function live_scenario()
+    return H.loader.upvalue(soulslike.wakeup_callback, "scenario_logic")
+end
+
+-- TransferItem spends two different KINDS of roll per item and they want
+-- opposite values, so a single constant cannot drive either outcome:
+--
+--   math.random()        -- the keep roll in IsItemLossAllowed (:966-981);
+--                           LOW keeps the item
+--   math.random(0, 100)  -- the loss roll in TransferItem (:1196);
+--                           LOW loses the item
+--
+-- Hence a predicate on the call form rather than set_random_const.
+local function lose_everything()
+    H.fakes.set_random(function(a, b)
+        if a == nil then return 0.999 end   -- fail every keep roll
+        return a                            -- pass every loss roll
+    end)
+end
+
+local function lose_nothing()
+    H.fakes.set_random(function(a, b)
+        if a == nil then return 0.0 end     -- win every keep roll
+        return b or 1                       -- fail every loss roll
+    end)
+end
+
+--- Take a hit, as actor_on_before_hit records it.
+local function take_hit(opts)
+    opts = opts or {}
+    SendScriptCallback("actor_on_before_hit",
+        { power = opts.power or 10, type = opts.type or hit.wound }, opts.bone or 1,
+        { ret_value = true })
+end
+
+--- Die. Returns the flags table the handler wrote into.
+local function die()
+    local flags = { ret_value = true }
+    SendScriptCallback("actor_on_before_death", nil, flags)
+    return flags
+end
+
+describe("e2e: death to respawn", function()
+
+    describe("given the player dies carrying loot", function()
+        local flags, stash_id
+
+        beforeEach(function()
+            boot()
+            H.world.give("actor", "wpn_ak74", { kind = "weapon" })
+            H.world.give("actor", "medkit")
+            H.world.give("actor", "bread")
+
+            -- All loss rolls succeed, so every eligible item is destroyed and
+            -- the ignore-list survivors stand out.
+            lose_everything()
+            H.fakes.set_mcm("items/item_loss_scalar", 1.0)
+            H.fakes.set_mcm("items/ignore_rank_when_computing_item_loss_chance", true)
+
+            take_hit{ power = 50 }
+            flags = die()
+            stash_id = live_scenario().logic_state.stash_id
+            H.tick()
+        end)
+
+        it("suppresses the engine's own death handling", function()
+            expect(flags.ret_value).toBe(false)
+        end)
+
+        it("creates exactly one stash", function()
+            expect(H.world.created).toHaveLength(1)
+            expect(H.world.created[1].section).toBe("inv_backpack")
+        end)
+
+        it("registers the stash in the save", function()
+            local stash = soulslike.get_soulslike_state().created_stashes[stash_id]
+            expect(stash).toBeDefined()
+            expect(stash.lost_items).toBeDefined()
+            expect(stash.examine).toBe(false)
+        end)
+
+        it("records where the player died", function()
+            local loc = live_scenario().logic_state.death_location
+            expect(loc.position.z).toBe(500)
+            expect(loc.level_vertex_id).toBeDefined()
+        end)
+
+        it("leaves ignore-listed items on the actor", function()
+            expect(H.world.contents("actor")).toContain("medkit")
+        end)
+
+        it("destroys the items the loss rolls claimed", function()
+            expect(H.world.destroyed()).toContain("wpn_ak74")
+        end)
+
+        it("marks the story as having lost items", function()
+            expect(live_scenario().logic_state.story.items_were_lost).toBe(true)
+        end)
+
+        it("deducts rank", function()
+            expect(db.actor:character_rank()).toBeLessThan(5000)
+        end)
+
+        it("deducts reputation", function()
+            expect(db.actor:character_reputation()).toBeLessThan(400)
+        end)
+
+        it("heals the actor", function()
+            expect(db.actor.health).toBeGreaterThan(0)
+        end)
+
+        it("grants temporary invulnerability", function()
+            expect(bind_stalker_ext.invulnerable_time).toBeGreaterThan(0)
+        end)
+
+        it("counts the death", function()
+            expect(H.fakes.call_count("increment_statistic")).toBe(1)
+        end)
+
+        it("changes level exactly once", function()
+            expect(H.fakes.call_count("ChangeLevel")).toBe(1)
+        end)
+
+        it("fades the screen out before the transition", function()
+            expect(H.fakes.call_count("level.add_pp_effector")).toBeGreaterThan(0)
+        end)
+
+        it("leaves no time events pending", function()
+            expect(H.timeevents.pending()).toBe(0)
+        end)
+    end)
+
+    describe("given items survive the loss rolls", function()
+        local stash_id
+
+        beforeEach(function()
+            boot()
+            H.world.give("actor", "wpn_ak74", { kind = "weapon" })
+            H.world.give("actor", "bread")
+
+            -- Every loss roll fails, so nothing is destroyed and everything
+            -- transferable ends up in the stash.
+            lose_nothing()
+            die()
+            stash_id = live_scenario().logic_state.stash_id
+            H.tick()
+        end)
+
+        it("moves them into the stash", function()
+            local stash = H.world.object(stash_id)
+            expect(H.world.where(H.world.item_by_section("bread")))
+                .toBe(H.world.where(H.world.item_by_section("wpn_ak74")))
+            expect(stash).toBeDefined()
+        end)
+
+        it("destroys nothing", function()
+            expect(H.world.destroyed()).toEqual({})
+        end)
+
+        it("empties the actor's inventory", function()
+            expect(H.world.contents("actor")).toEqual({})
+        end)
+
+        it("marks the stash on the map", function()
+            expect(H.fakes.call_count("level.map_add_object_spot_ser")).toBe(1)
+        end)
+
+        it("records the pda marker in the story", function()
+            expect(live_scenario().logic_state.story.has_pda_marker).toBe(true)
+        end)
+    end)
+
+    describe("given the stash is not online yet when the timer fires", function()
+        -- wait_for_stash_creation returns false until level.object_by_id can
+        -- resolve the stash, and CreateTimeEvent re-queues on anything that is
+        -- not literally `true` (_g.script:375). This is the retry contract.
+        local stash_id
+
+        beforeEach(function()
+            boot()
+            H.world.give("actor", "bread")
+            lose_nothing()
+            die()
+            stash_id = live_scenario().logic_state.stash_id
+            H.world.hide(stash_id)
+        end)
+
+        -- A bounded pump runs exactly one frame and leaves the retry in place,
+        -- which is the only way to observe the mid-wait state.
+        it("does not transfer anything on the first tick", function()
+            H.tick{ passes = 1 }
+            expect(H.world.contents("actor")).toContain("bread")
+        end)
+
+        it("keeps the event queued", function()
+            H.tick{ passes = 1 }
+            expect(H.timeevents.pending()).toBeGreaterThan(0)
+        end)
+
+        it("does not change level yet", function()
+            H.tick{ passes = 1 }
+            expect(H.fakes.call_count("ChangeLevel")).toBe(0)
+        end)
+
+        it("completes once the stash comes online", function()
+            H.tick{ passes = 1 }
+            H.world.reveal(stash_id)
+            H.tick()
+            expect(H.world.contents("actor")).toEqual({})
+            expect(H.fakes.call_count("ChangeLevel")).toBe(1)
+        end)
+    end)
+
+    describe("given hardcore lose-all-items is enabled", function()
+        beforeEach(function()
+            boot()
+            H.fakes.set_mcm("hardcore/lose_all_items_on_death", true)
+            H.world.give("actor", "wpn_ak74", { kind = "weapon" })
+            H.world.give("actor", "bread")
+            lose_nothing()
+            die()
+            H.tick()
+        end)
+
+        it("creates no stash at all", function()
+            expect(H.world.created).toEqual({})
+        end)
+
+        it("destroys everything", function()
+            expect(H.world.contents("actor")).toEqual({})
+        end)
+
+        it("still respawns the player", function()
+            expect(H.fakes.call_count("ChangeLevel")).toBe(1)
+        end)
+    end)
+
+    describe("given the player was in an arena fight", function()
+        it("ignores the death entirely", function()
+            boot()
+            give_info_portion("bar_arena_fight")
+            local flags = die()
+            expect(flags.ret_value).toBe(true)
+            expect(live_scenario()).toBeNil()
+        end)
+    end)
+
+    describe("given soulslike mode is off", function()
+        it("ignores the death entirely", function()
+            H.boot{ load = MOD_SCRIPTS }
+            H.fakes.set_random_min()
+            soulslike.on_game_start()
+            local flags = die()
+            expect(flags.ret_value).toBe(true)
+        end)
+    end)
+
+    -- FIXES: D5. RespawnActor built its destination vector straight from
+    -- spawn_location with no nil-guard, unlike the identical call in
+    -- SpawnAmbush (:770). A save with no recorded spawn made the respawn an
+    -- access violation rather than a recoverable error.
+    describe("given no spawn point was ever recorded", function()
+        beforeEach(function()
+            boot()
+            soulslike.get_soulslike_state().spawn_location = {
+                level = nil,
+                position = { x = nil, y = nil, z = nil },
+                angle = { x = nil, y = nil, z = nil },
+                level_vertex_id = nil,
+                game_vertex_id = nil,
+            }
+            H.world.give("actor", "bread")
+            lose_nothing()
+        end)
+
+        it("does not raise on death", function()
+            expect(function() die() end).never.toThrow()
+        end)
+
+        it("does not raise while the transfer completes", function()
+            die()
+            expect(function() H.tick() end).never.toThrow()
+        end)
+
+        it("does not attempt the level change", function()
+            die()
+            H.tick()
+            expect(H.fakes.call_count("ChangeLevel")).toBe(0)
+        end)
+
+        -- The items still need to reach the stash: failing to respawn must not
+        -- also cost the player their gear.
+        it("still transfers the items to the stash", function()
+            die()
+            H.tick()
+            expect(H.world.contents("actor")).toEqual({})
+        end)
+    end)
+
+    describe("the hit queue", function()
+        it("feeds the recorded hits into scenario selection", function()
+            boot()
+            local killer = B.make_monster{ name = "boar" }
+            H.fakes.register_object(killer)
+
+            SendScriptCallback("actor_on_before_hit",
+                { power = 90, type = hit.wound, draftsman = killer }, 1,
+                { ret_value = true })
+            die()
+
+            expect(live_scenario().logic_state.killer_type)
+                .toBe(soulslike.entity_type.Monster)
+        end)
+
+        it("is cleared after the death is handled", function()
+            boot()
+            take_hit{ power = 50 }
+
+            -- hit_queue is a file-local of the handlers, which are themselves
+            -- upvalues of on_game_start -- hence the two-level reach.
+            local on_hit = H.loader.upvalue(soulslike.on_game_start, "actor_on_before_hit")
+            local queue = H.loader.upvalue(on_hit, "hit_queue")
+            expect(#queue:Values()).toBeGreaterThan(0)
+
+            die()
+            expect(queue:Values()).toEqual({})
+        end)
+    end)
+end)
+
+return true

--- a/tests/e2e/hardcore_save.spec.lua
+++ b/tests/e2e/hardcore_save.spec.lua
@@ -1,0 +1,252 @@
+-- End to end: hardcore saves.
+--
+-- Two halves, both irreversible from the player's side.
+--
+--   on_before_save_input  -- blocks manual saving outside the permitted spots
+--   on_console_execute    -- after a save completes, DELETES every sibling save
+--                            belonging to the same run, so there is only ever
+--                            one restore point
+--
+-- The pruning walk reads each candidate off disk with io.open before decoding
+-- it (soulslike.script:666), so without the save-fs shim the loop body never
+-- executes and a spec asserting "nothing was deleted" would pass for entirely
+-- the wrong reason.
+
+local H = require("harness.init")
+
+local MOD_SCRIPTS = {
+    "soulslike_classes", "soulslike", "soulslike_mcm",
+    "soulslike_message_factory", "soulslike_scenarios",
+    "soulslike_scenario_logic_factory",
+}
+
+local UUID = "test_run_uuid"
+
+local function boot(opts)
+    opts = opts or {}
+    H.boot{ load = MOD_SCRIPTS, soulslike_mode = opts.soulslike_mode ~= false }
+    H.fakes.set_random_min()
+    H.set_spawn{ level = "zaton" }
+    H.fakes.install_save_fs()
+    if opts.hardcore ~= false then
+        H.fakes.set_mcm("hardcore/is_enabled", true)
+    end
+    soulslike.get_soulslike_state().uuid = UUID
+    soulslike.on_game_start()
+end
+
+--- Attempt a manual save. Returns the flags table the handler wrote into.
+local function try_save()
+    local flags = {}
+    SendScriptCallback("on_before_save_input", flags, nil, "quicksave")
+    return flags
+end
+
+local function deleted_saves()
+    local out = {}
+    for _, call in ipairs(H.fakes.calls_to("delete_save_game")) do
+        out[#out + 1] = call[1]
+    end
+    table.sort(out)
+    return out
+end
+
+describe("e2e: hardcore saves", function()
+
+    describe("blocking manual saves", function()
+
+        describe("given hardcore saves are enabled on a normal level", function()
+            local flags
+
+            beforeEach(function()
+                boot()
+                flags = try_save()
+            end)
+
+            it("blocks the save", function()
+                expect(flags.ret).toBe(true)
+            end)
+
+            it("tells the player why", function()
+                expect(H.fakes.call_count("set_msg")).toBe(1)
+            end)
+
+            it("closes the menu", function()
+                expect(H.fakes.last_call("exec_console_cmd")[1]).toBe("main_menu off")
+            end)
+        end)
+
+        describe("given hardcore saves are off", function()
+            it("allows the save", function()
+                boot{ hardcore = false }
+                expect(try_save().ret).toBeNil()
+            end)
+        end)
+
+        describe("given soulslike mode is off", function()
+            it("allows the save", function()
+                boot{ soulslike_mode = false }
+                expect(try_save().ret).toBeNil()
+            end)
+        end)
+
+        describe("given campfire saves are permitted", function()
+            it("allows the save", function()
+                boot()
+                H.fakes.set_mcm("hardcore/override_campfire_hardcore_saves", true)
+                expect(try_save().ret).toBeNil()
+            end)
+        end)
+
+        describe("given the player is on an invalid level", function()
+            -- Underground and lab levels are not in valid_levels, and saving is
+            -- left alone there rather than trapping the player.
+            it("allows the save", function()
+                boot()
+                H.fakes.set_level("underground_lab")
+                expect(try_save().ret).toBeNil()
+            end)
+        end)
+    end)
+
+    describe("pruning sibling saves", function()
+
+        local function save_as(name)
+            SendScriptCallback("on_console_execute", "save", name)
+        end
+
+        describe("given siblings from the same run", function()
+            beforeEach(function()
+                boot()
+                H.fakes.set_save("current",  { soulslike = { uuid = UUID } })
+                H.fakes.set_save("older",    { soulslike = { uuid = UUID } })
+                H.fakes.set_save("other_run",{ soulslike = { uuid = "different" } })
+                H.fakes.set_save("vanilla",  {})
+                save_as("current")
+            end)
+
+            it("deletes the older sibling", function()
+                expect(deleted_saves()).toEqual({ "older" })
+            end)
+
+            it("keeps the save just written", function()
+                expect(deleted_saves()).never.toContain("current")
+            end)
+
+            it("keeps saves from a different run", function()
+                expect(deleted_saves()).never.toContain("other_run")
+            end)
+
+            it("keeps saves with no soulslike data", function()
+                expect(deleted_saves()).never.toContain("vanilla")
+            end)
+
+            -- Three files per save: the state, the position data, and the
+            -- thumbnail. All are backed up before the delete.
+            it("backs up all three files first", function()
+                expect(H.fakes.call_count("fs.file_copy")).toBe(3)
+            end)
+
+            it("backs them up into the soulslike-backup folder", function()
+                -- Called as fs:file_copy(src, dest), so the recorder sees the
+                -- fs table as arg 1 and the destination as arg 3.
+                local dest = H.fakes.last_call("fs.file_copy")[3]
+                expect(dest).toContain("soulslike-backup/")
+            end)
+
+            it("backs up the state, position and thumbnail files", function()
+                local copied = {}
+                for _, call in ipairs(H.fakes.calls_to("fs.file_copy")) do
+                    copied[#copied + 1] = tostring(call[2]):match("%.(%w+)$")
+                end
+                table.sort(copied)
+                expect(copied).toEqual({ "dds", "scoc", "scop" })
+            end)
+        end)
+
+        describe("given several older siblings", function()
+            it("deletes all of them", function()
+                boot()
+                H.fakes.set_save("current", { soulslike = { uuid = UUID } })
+                H.fakes.set_save("save_a",  { soulslike = { uuid = UUID } })
+                H.fakes.set_save("save_b",  { soulslike = { uuid = UUID } })
+                save_as("current")
+                expect(deleted_saves()).toEqual({ "save_a", "save_b" })
+            end)
+        end)
+
+        describe("given the save name differs only by case", function()
+            -- Both sides are lowercased before comparison (:647, :678), so a
+            -- save typed as "QuickSave" must not delete itself.
+            it("still recognises the current save", function()
+                boot()
+                H.fakes.set_save("quicksave", { soulslike = { uuid = UUID } })
+                save_as("QuickSave")
+                expect(deleted_saves()).toEqual({})
+            end)
+        end)
+
+        describe("given a save name with spaces", function()
+            it("reassembles it from the console arguments", function()
+                boot()
+                H.fakes.set_save("my save", { soulslike = { uuid = UUID } })
+                H.fakes.set_save("older",   { soulslike = { uuid = UUID } })
+                SendScriptCallback("on_console_execute", "save", "my", "save")
+                expect(deleted_saves()).toEqual({ "older" })
+            end)
+        end)
+
+        describe("given hardcore saves are off", function()
+            it("deletes nothing", function()
+                boot{ hardcore = false }
+                H.fakes.set_save("current", { soulslike = { uuid = UUID } })
+                H.fakes.set_save("older",   { soulslike = { uuid = UUID } })
+                save_as("current")
+                expect(deleted_saves()).toEqual({})
+            end)
+        end)
+
+        describe("given soulslike mode is off", function()
+            it("deletes nothing", function()
+                boot{ soulslike_mode = false }
+                H.fakes.set_save("older", { soulslike = { uuid = UUID } })
+                save_as("current")
+                expect(deleted_saves()).toEqual({})
+            end)
+        end)
+
+        describe("given this run has no uuid yet", function()
+            -- The uuid is stamped on the first on_game_load
+            -- (soulslike.script:857). Before that, nothing can match, and
+            -- crucially nothing must be deleted on a guess.
+            it("deletes nothing", function()
+                boot()
+                soulslike.get_soulslike_state().uuid = nil
+                H.fakes.set_save("older", { soulslike = { uuid = UUID } })
+                save_as("current")
+                expect(deleted_saves()).toEqual({})
+            end)
+        end)
+
+        describe("given a save file that cannot be read", function()
+            it("skips it rather than deleting it", function()
+                boot()
+                H.fakes.set_save("current", { soulslike = { uuid = UUID } })
+                H.fakes.set_save("corrupt", nil)
+                save_as("current")
+                expect(deleted_saves()).toEqual({})
+            end)
+        end)
+
+        describe("given a console command other than save", function()
+            it("is ignored", function()
+                boot()
+                H.fakes.set_save("older", { soulslike = { uuid = UUID } })
+                SendScriptCallback("on_console_execute", "quit")
+                expect(deleted_saves()).toEqual({})
+            end)
+        end)
+    end)
+end)
+
+return true

--- a/tests/e2e/respawn_to_completion.spec.lua
+++ b/tests/e2e/respawn_to_completion.spec.lua
@@ -1,0 +1,298 @@
+-- End to end: the player wakes up on the far side of the level change.
+--
+--   on_game_load -> OnRespawn -> HealActor
+--                             -> AdvanceTime  (fade to black, sleep effector)
+--   dream_callback   (fired by the sleep effector)
+--     -> change_game_time, actor_on_sleep
+--   wakeup_callback  (fired by the second effector)
+--     -> OnComplete -> GiveFoodAndWater, SpawnAmbush, SendWakeupMessage
+--     -> scenario torn down, logic_state cleared from the save
+--
+-- The teardown at the end is what makes the death "over": until wakeup_callback
+-- runs, a reload would restore the scenario and replay the respawn.
+
+local H = require("harness.init")
+local B = H.builders
+
+local MOD_SCRIPTS = {
+    "soulslike_classes", "soulslike", "soulslike_mcm",
+    "soulslike_message_factory", "soulslike_scenarios",
+    "soulslike_scenario_logic_factory",
+}
+
+local function live_scenario()
+    return H.loader.upvalue(soulslike.wakeup_callback, "scenario_logic")
+end
+
+--- Boot with a scenario already saved, as it would be after a death that
+--- triggered a level change.
+local function boot_mid_death(state_overrides)
+    H.boot{ load = MOD_SCRIPTS, soulslike_mode = true }
+    H.fakes.set_random_min()
+    H.set_spawn{ level = "zaton" }
+    H.set_actor{
+        health = 0, power = 0, radiation = 0.5,
+        bleeding = 0.5, psy_health = 0.2, satiety = 0.1,
+    }
+    B.stub_finders{}
+
+    local saved = B.make_logic_state(state_overrides or {})
+    saved.scenario_id = _G.soulslike.SCENARIOS.NoLoss
+    soulslike.get_soulslike_state().logic_state = saved
+
+    soulslike.on_game_start()
+    SendScriptCallback("load_state", {})
+    return saved
+end
+
+describe("e2e: respawn to completion", function()
+
+    describe("given the player loads in after dying", function()
+        beforeEach(function()
+            boot_mid_death()
+            SendScriptCallback("on_game_load")
+        end)
+
+        it("restores the scenario", function()
+            expect(live_scenario()).toBeDefined()
+        end)
+
+        it("heals to the configured fraction", function()
+            -- health_loss_percent defaults to 0.75, so a quarter health.
+            expect(db.actor.health).toBeCloseTo(0.25)
+        end)
+
+        it("restores stamina", function()
+            expect(db.actor.power).toBe(1)
+        end)
+
+        it("clears radiation and bleeding", function()
+            expect(db.actor.radiation).toBe(0)
+            expect(db.actor.bleeding).toBe(0)
+        end)
+
+        it("restores psy health", function()
+            expect(db.actor.psy_health).toBe(1)
+        end)
+
+        it("clears the in-water flag", function()
+            expect(load_var(db.actor, "grw_in_water")).toBeNil()
+        end)
+
+        it("fades to black and starts the sleep effector", function()
+            expect(H.fakes.call_count("level.add_cam_effector")).toBeGreaterThan(0)
+        end)
+
+        it("stamps a save uuid for hardcore save pruning", function()
+            expect(soulslike.get_soulslike_state().uuid).toBeDefined()
+        end)
+    end)
+
+    describe("given the dream plays out", function()
+        beforeEach(function()
+            boot_mid_death()
+            SendScriptCallback("on_game_load")
+            H.fakes.set_random_const(8)
+            soulslike.dream_callback()
+        end)
+
+        it("advances the clock", function()
+            expect(H.fakes.call_count("level.change_game_time")).toBe(1)
+        end)
+
+        it("advances by the rolled number of hours", function()
+            expect(H.fakes.last_call("level.change_game_time")[2]).toBe(8)
+        end)
+
+        it("queues the wakeup effector", function()
+            local last = H.fakes.last_call("level.add_cam_effector")
+            expect(last[4]).toBe("soulslike.wakeup_callback")
+        end)
+
+        it("announces the sleep", function()
+            expect(H.dispatch.sends_of("actor_on_sleep")).toHaveLength(1)
+        end)
+
+        -- actor_on_sleep force-saves only when no scenario is running
+        -- (soulslike.script:877). Mid-death there is one, so the save is
+        -- suppressed -- otherwise the player could bank the half-finished state.
+        it("does not force a save while the scenario is still running", function()
+            expect(H.fakes.call_count("delete_save_game")).toBe(0)
+            expect(H.fakes.calls_to("exec_console_cmd")).never.toContain("save")
+        end)
+    end)
+
+    describe("given the player wakes up", function()
+        beforeEach(function()
+            boot_mid_death()
+            SendScriptCallback("on_game_load")
+            H.fakes.set_random_const(8)
+            soulslike.dream_callback()
+            soulslike.wakeup_callback()
+        end)
+
+        it("re-enables the interface", function()
+            expect(H.fakes.call_count("xr_effects.enable_ui")).toBe(1)
+        end)
+
+        it("clears the sleeping info portions", function()
+            expect(has_alife_info("actor_is_sleeping")).toBe(false)
+            expect(has_alife_info("sleep_active")).toBe(false)
+        end)
+
+        it("re-activates the hud", function()
+            expect(H.fakes.call_count("actor_status.activate_hud")).toBe(1)
+        end)
+
+        it("sends the wakeup message", function()
+            expect(H.fakes.call_count("send_tip")
+                   + H.fakes.call_count("set_msg")).toBeGreaterThan(0)
+        end)
+
+        it("reports the death count", function()
+            expect(H.fakes.call_count("set_msg")).toBeGreaterThan(0)
+        end)
+
+        -- The scenario is finished: nothing left to restore on a later load.
+        it("tears the scenario down", function()
+            expect(live_scenario()).toBeNil()
+        end)
+
+        it("clears logic_state from the save", function()
+            expect(soulslike.get_soulslike_state().logic_state).toBeNil()
+        end)
+    end)
+
+    describe("given the player was fed on wakeup", function()
+        beforeEach(function()
+            boot_mid_death()
+            SendScriptCallback("on_game_load")
+            H.fakes.set_random_const(8)
+            soulslike.dream_callback()
+            soulslike.wakeup_callback()
+        end)
+
+        it("spawns bread and water", function()
+            expect(H.world.contents("actor")).toContain("bread")
+            expect(H.world.contents("actor")).toContain("water_drink")
+        end)
+
+        it("records it in the story before the message is built", function()
+            -- The scenario is torn down by now, so this is asserted through the
+            -- effect: the items only spawn when the flag was set.
+            expect(H.world.contents("actor")).toContain("bread")
+        end)
+    end)
+
+    describe("given hardcore saves are enabled", function()
+        it("force-saves on respawn", function()
+            boot_mid_death()
+            H.fakes.set_mcm("hardcore/is_enabled", true)
+            SendScriptCallback("on_game_load")
+            H.fakes.set_random_const(8)
+            soulslike.dream_callback()
+            soulslike.wakeup_callback()
+
+            local saved = false
+            for _, call in ipairs(H.fakes.calls_to("exec_console_cmd")) do
+                if tostring(call[1]):find("save", 1, true) then saved = true end
+            end
+            expect(saved).toBe(true)
+        end)
+    end)
+
+    describe("nighttime respawn", function()
+        -- RespawnActor pushes the clock to daylight when nighttime respawns are
+        -- disabled (soulslike_scenarios.script:887-900).
+        local function respawn_at(hour)
+            H.boot{ load = MOD_SCRIPTS, soulslike_mode = true }
+            H.fakes.set_random_min()
+            H.set_spawn{ level = "zaton" }
+            B.stub_finders{}
+            H.fakes.set_mcm("character/allow_nighttime_respawn", false)
+            H.fakes.time_hours = hour
+            H.fakes.set_random_const(0)     -- no extra scatter
+
+            B.make_scenario{}:RespawnActor()
+            return H.fakes.calls_to("level.change_game_time")
+        end
+
+        it("advances from 3am to 7am", function()
+            local calls = respawn_at(3)
+            expect(calls).toHaveLength(1)
+            expect(calls[1][2]).toBe(4)
+        end)
+
+        it("advances from 23:00 to 7am the next day", function()
+            local calls = respawn_at(23)
+            expect(calls).toHaveLength(1)
+            expect(calls[1][2]).toBe(8)
+        end)
+
+        it("advances from 21:00, the first blocked hour", function()
+            expect(respawn_at(21)).toHaveLength(1)
+        end)
+
+        it("does not advance at 7am", function()
+            expect(respawn_at(7)).toHaveLength(0)
+        end)
+
+        it("does not advance at midday", function()
+            expect(respawn_at(12)).toHaveLength(0)
+        end)
+
+        it("does not advance at 20:00, the last allowed hour", function()
+            expect(respawn_at(20)).toHaveLength(0)
+        end)
+
+        it("leaves the clock alone when nighttime respawn is allowed", function()
+            H.boot{ load = MOD_SCRIPTS, soulslike_mode = true }
+            H.fakes.set_random_min()
+            H.set_spawn{ level = "zaton" }
+            B.stub_finders{}
+            H.fakes.time_hours = 3
+
+            B.make_scenario{}:RespawnActor()
+            expect(H.fakes.calls_to("level.change_game_time")).toHaveLength(0)
+        end)
+    end)
+
+    -- FIXES: D8. SetIsInDoor and SetIsInWater wrote only the top-level
+    -- logic_state fields, but SendWakeupMessage hands `story` to the message
+    -- factory as its params (:935) and the factory keys the indoor rescue text
+    -- off params.player_died_indoor
+    -- (soulslike_message_factory.script:135). story declared both keys and
+    -- never received either, so the indoor message set was unreachable.
+    describe("the indoor rescue message", function()
+        it("puts the indoor flag where the message factory reads it", function()
+            H.boot{ load = MOD_SCRIPTS, soulslike_mode = true }
+            H.fakes.set_random_min()
+            local s = B.make_scenario{ indoor = true }
+            expect(s.logic_state.story.player_died_indoor).toBe(true)
+        end)
+
+        it("keeps the top-level flag IsItemLossAllowed reads", function()
+            H.boot{ load = MOD_SCRIPTS, soulslike_mode = true }
+            H.fakes.set_random_min()
+            local s = B.make_scenario{ in_water = true }
+            expect(s.logic_state.player_died_in_water).toBe(true)
+            expect(s.logic_state.story.player_died_in_water).toBe(true)
+        end)
+
+        it("selects the indoor message set", function()
+            H.boot{ load = MOD_SCRIPTS, soulslike_mode = true }
+            H.fakes.set_random_const(1)
+            local rescuer = B.make_stalker{ name = "medic" }
+
+            local indoor = soulslike_message_factory.create(rescuer, {
+                player_died_indoor = true, level_name = "zaton",
+            })
+            local outdoor = soulslike_message_factory.create(rescuer, {
+                player_died_indoor = false, level_name = "zaton",
+            })
+            expect(indoor).never.toBe(outdoor)
+        end)
+    end)
+end)
+
+return true

--- a/tests/e2e/save_load_level_change.spec.lua
+++ b/tests/e2e/save_load_level_change.spec.lua
@@ -1,0 +1,254 @@
+-- End to end: a death that spans a level change.
+--
+-- Dying triggers a ChangeLevel, and the engine unloads and re-executes every
+-- script across that boundary. So the death is genuinely split in two:
+--
+--   [level A]  hit -> death -> stash -> transfer -> save_state -> ChangeLevel
+--   ===================== scripts re-execute ======================
+--   [level B]  load_state -> on_game_load -> OnRespawn -> ... -> wakeup
+--
+-- Nothing but the save table survives the middle. This is the journey the mod's
+-- own comment at soulslike.script:790 calls fragile, and the one where a
+-- regression costs the player their gear with no way back.
+
+local H = require("harness.init")
+local B = H.builders
+
+local MOD_SCRIPTS = {
+    "soulslike_classes", "soulslike", "soulslike_mcm",
+    "soulslike_message_factory", "soulslike_scenarios",
+    "soulslike_scenario_logic_factory",
+}
+
+local function live_scenario()
+    return H.loader.upvalue(soulslike.wakeup_callback, "scenario_logic")
+end
+
+--- Wire up whichever copy of the scripts is currently loaded.
+local function arm()
+    H.fakes.set_random_min()
+    B.stub_finders{ friendly_stalker = B.make_stalker{ name = "medic" } }
+    soulslike.on_game_start()
+end
+
+local function boot_on_level(name)
+    H.boot{ load = MOD_SCRIPTS, soulslike_mode = true }
+    H.fakes.set_level(name or "zaton")
+    H.set_spawn{ level = "zaton", position = { x = 0, y = 0, z = 0 } }
+    H.set_actor{ position = { x = 0, y = 0, z = 500 }, rank = 5000 }
+    H.fakes.set_mcm("debug/is_enabled", true)
+    H.fakes.set_mcm("debug/debug_the_default_scenario", true)
+    arm()
+end
+
+--- The other side of the ChangeLevel: same save, brand new script state.
+local function change_level_to(name)
+    H.reboot{ load = MOD_SCRIPTS, soulslike_mode = true }
+    H.fakes.set_level(name or "jupiter")
+    H.set_actor{ position = { x = 0, y = 0, z = 0 } }
+    arm()
+end
+
+local function die()
+    SendScriptCallback("actor_on_before_death", nil, { ret_value = true })
+end
+
+describe("e2e: a death across a level change", function()
+
+    describe("given the player dies and the level changes", function()
+        local before_state, before_scenario, stash_id
+
+        beforeEach(function()
+            boot_on_level("zaton")
+            H.world.give("actor", "wpn_ak74", { kind = "weapon" })
+            H.world.give("actor", "bread")
+
+            -- Nothing lost, so the stash contents are predictable.
+            H.fakes.set_random(function(a, b)
+                if a == nil then return 0.0 end
+                return b or 1
+            end)
+
+            die()
+            H.tick()
+
+            before_scenario = live_scenario()
+            before_state = before_scenario.logic_state
+            stash_id = before_state.stash_id
+
+            SendScriptCallback("save_state", {})
+            change_level_to("jupiter")
+            SendScriptCallback("load_state", {})
+        end)
+
+        it("restores the scenario", function()
+            expect(live_scenario()).toBeDefined()
+        end)
+
+        -- The scenario OBJECT is rebuilt: the module table holding it was
+        -- discarded with the rest of the script state.
+        it("rebuilds the scenario object", function()
+            expect(live_scenario()).never.toBe(before_scenario)
+        end)
+
+        -- logic_state, however, is the SAME table -- save_state stored it by
+        -- reference (:793) and the save survives the transition. In-game a real
+        -- serialize/deserialize would yield an equal-but-distinct table, so
+        -- this identity is a harness artifact; what matters, and what the rest
+        -- of this block asserts, is that the contents round-trip intact.
+        it("carries the state table through the save", function()
+            expect(live_scenario().logic_state).toBe(before_state)
+        end)
+
+        it("keeps the scenario id", function()
+            expect(live_scenario().logic_state.scenario_id)
+                .toBe(before_state.scenario_id)
+        end)
+
+        it("keeps the stash id, so the player can find their gear", function()
+            expect(live_scenario().logic_state.stash_id).toBe(stash_id)
+        end)
+
+        it("keeps the death location", function()
+            expect(live_scenario().logic_state.death_location.position.z).toBe(500)
+        end)
+
+        it("keeps the story", function()
+            expect(live_scenario().logic_state.story.level_name)
+                .toBe(before_state.story.level_name)
+        end)
+
+        it("keeps the created stash registered in the save", function()
+            expect(soulslike.get_soulslike_state().created_stashes[stash_id])
+                .toBeDefined()
+        end)
+
+        it("keeps the spawn point", function()
+            expect(soulslike.get_soulslike_state().spawn_location.level).toBe("zaton")
+        end)
+    end)
+
+    describe("given the respawn completes on the new level", function()
+        beforeEach(function()
+            boot_on_level("zaton")
+            H.world.give("actor", "bread")
+            H.fakes.set_random(function(a, b)
+                if a == nil then return 0.0 end
+                return b or 1
+            end)
+
+            die()
+            H.tick()
+            SendScriptCallback("save_state", {})
+
+            change_level_to("jupiter")
+            SendScriptCallback("load_state", {})
+            SendScriptCallback("on_game_load")
+
+            H.fakes.set_random_const(8)
+            soulslike.dream_callback()
+            soulslike.wakeup_callback()
+        end)
+
+        it("heals the player on the far side", function()
+            expect(db.actor.health).toBeCloseTo(0.25)
+        end)
+
+        it("finishes the scenario", function()
+            expect(live_scenario()).toBeNil()
+        end)
+
+        it("clears logic_state from the save", function()
+            expect(soulslike.get_soulslike_state().logic_state).toBeNil()
+        end)
+
+        -- The stash outlives the scenario on purpose: the player still has to
+        -- walk back for it.
+        it("leaves the stash registered", function()
+            local stashes = soulslike.get_soulslike_state().created_stashes
+            local n = 0
+            for _ in pairs(stashes) do n = n + 1 end
+            expect(n).toBe(1)
+        end)
+    end)
+
+    describe("on_level_changing", function()
+        it("records a spawn point if none exists", function()
+            boot_on_level("zaton")
+            soulslike.get_soulslike_state().spawn_location.level = nil
+            SendScriptCallback("on_level_changing")
+            expect(soulslike.get_soulslike_state().spawn_location.level).toBe("zaton")
+        end)
+
+        it("leaves an existing spawn point alone", function()
+            boot_on_level("zaton")
+            H.fakes.set_level("jupiter")
+            SendScriptCallback("on_level_changing")
+            expect(soulslike.get_soulslike_state().spawn_location.level).toBe("zaton")
+        end)
+
+        it("does not record one on fake_start", function()
+            boot_on_level("fake_start")
+            soulslike.get_soulslike_state().spawn_location.level = nil
+            SendScriptCallback("on_level_changing")
+            expect(soulslike.get_soulslike_state().spawn_location.level).toBeNil()
+        end)
+
+        it("does nothing outside soulslike mode", function()
+            H.boot{ load = MOD_SCRIPTS }
+            arm()
+            soulslike.get_soulslike_state().spawn_location = { level = nil, position = {} }
+            SendScriptCallback("on_level_changing")
+            expect(soulslike.get_soulslike_state().spawn_location.level).toBeNil()
+        end)
+    end)
+
+    describe("given the level changes twice before the player wakes", function()
+        -- A transition can chain (respawn point on another level), so the
+        -- restored state has to survive being saved again from the restored
+        -- copy rather than the original.
+        it("still restores the same scenario", function()
+            boot_on_level("zaton")
+            H.world.give("actor", "bread")
+            H.fakes.set_random(function(a, b)
+                if a == nil then return 0.0 end
+                return b or 1
+            end)
+
+            die()
+            H.tick()
+            local stash_id = live_scenario().logic_state.stash_id
+            SendScriptCallback("save_state", {})
+
+            change_level_to("jupiter")
+            SendScriptCallback("load_state", {})
+            SendScriptCallback("save_state", {})
+
+            change_level_to("pripyat")
+            SendScriptCallback("load_state", {})
+
+            expect(live_scenario()).toBeDefined()
+            expect(live_scenario().logic_state.stash_id).toBe(stash_id)
+        end)
+    end)
+
+    describe("given the save has no scenario in progress", function()
+        it("loads cleanly on the far side", function()
+            boot_on_level("zaton")
+            SendScriptCallback("save_state", {})
+            change_level_to("jupiter")
+            SendScriptCallback("load_state", {})
+            expect(live_scenario()).toBeNil()
+        end)
+
+        it("does not raise on game load", function()
+            boot_on_level("zaton")
+            SendScriptCallback("save_state", {})
+            change_level_to("jupiter")
+            SendScriptCallback("load_state", {})
+            expect(function() SendScriptCallback("on_game_load") end).never.toThrow()
+        end)
+    end)
+end)
+
+return true

--- a/tests/e2e/scenario_variants.spec.lua
+++ b/tests/e2e/scenario_variants.spec.lua
@@ -1,0 +1,329 @@
+-- End to end: each of the four scenario variants, from CreateStash through
+-- the transfer to ApplyTransferItemsPostConditions.
+--
+-- The variants differ entirely in where the player's gear ends up and how they
+-- are told to find it again:
+--
+--   Default      backpack dropped where they died, marked straight on the PDA
+--   RFDetector   gear hidden in a treasure stash, located by radio frequency
+--   HiddenStash  gear hidden at the death site, marked on the PDA
+--   NoLoss       nothing taken at all
+--
+-- Both hidden variants monkey-patch treasure_manager.box_in_same_map and
+-- restore it (:1414-1421, :1500-1508). The restore runs BEFORE the nil check,
+-- so it survives the early return -- which is exactly the kind of thing that
+-- usually does not, hence the leak assertions.
+
+local H = require("harness.init")
+local B = H.builders
+
+local MOD_SCRIPTS = {
+    "soulslike_classes", "soulslike", "soulslike_mcm",
+    "soulslike_message_factory", "soulslike_scenarios",
+    "soulslike_scenario_logic_factory",
+}
+
+local TREASURE_ID = 8080
+
+--- Boot with a treasure stash available for the hidden variants to claim.
+local function boot(opts)
+    opts = opts or {}
+    H.boot{ load = MOD_SCRIPTS, soulslike_mode = true }
+    H.fakes.set_random_min()
+    H.set_spawn{ level = "zaton" }
+    H.set_actor{ position = { x = 10, y = 0, z = 20 } }
+    B.stub_finders{}
+
+    if opts.treasure ~= false then
+        H.world.container("treasure", {
+            id = TREASURE_ID,
+            position = B.make_vector{ x = 300, y = 0, z = 400 },
+        })
+    end
+
+    H.mods.enable("treasure_manager", {
+        get_random_stash = function()
+            return opts.treasure ~= false and TREASURE_ID or nil
+        end,
+    })
+end
+
+local function scenario(class)
+    return B.make_scenario{ class = class }
+end
+
+describe("e2e: scenario variants", function()
+
+    describe("the Default scenario", function()
+        local s, se_stash
+
+        beforeEach(function()
+            boot()
+            s = scenario("DefaultSoulslikeScenarioLogic")
+            se_stash = s:CreateStash()
+        end)
+
+        it("drops a backpack", function()
+            expect(H.world.created[1].section).toBe("inv_backpack")
+        end)
+
+        it("returns a server object with an id field", function()
+            expect(se_stash.id).toBeType("number")
+        end)
+
+        it("registers the stash in the save", function()
+            expect(s.game_state.created_stashes[se_stash.id]).toBeDefined()
+        end)
+
+        it("remembers the stash id", function()
+            expect(s.logic_state.stash_id).toBe(se_stash.id)
+        end)
+
+        it("marks it on the PDA afterwards", function()
+            s:ApplyTransferItemsPostConditions()
+            expect(s.logic_state.story.has_pda_marker).toBe(true)
+            expect(H.fakes.call_count("level.map_add_object_spot_ser")).toBe(1)
+        end)
+
+        it("names the marker after the player", function()
+            s:ApplyTransferItemsPostConditions()
+            expect(H.fakes.last_call("level.map_add_object_spot_ser")[3])
+                .toContain("Marked One")
+        end)
+    end)
+
+    describe("the RF Detector scenario", function()
+        local s, se_stash
+
+        beforeEach(function()
+            boot()
+            s = scenario("RFDetectorSoulslikeScenarioLogic")
+            se_stash = s:CreateStash()
+        end)
+
+        it("creates a hidden box", function()
+            expect(H.world.created[1].section).toBe("hidden_box")
+        end)
+
+        it("places it at the treasure, not at the body", function()
+            expect(H.world.created[1].container).toBeDefined()
+            expect(s.logic_state.treasure_stash_id).toBe(TREASURE_ID)
+        end)
+
+        it("forces the stash online", function()
+            expect(se_stash).toBeDefined()
+        end)
+
+        it("wires the hidden stash to its radio", function()
+            local entry = s.game_state.hidden_stashes[TREASURE_ID]
+            expect(entry.stash_id).toBe(se_stash.id)
+            expect(entry.radio_id).toBe(TREASURE_ID)
+            expect(entry.radio_level).toBe("zaton")
+        end)
+
+        it("restores the treasure_manager patch", function()
+            expect(H.mods.patched("treasure_manager")).toEqual({})
+        end)
+
+        describe("after the transfer", function()
+            beforeEach(function()
+                H.fakes.set_random_const(150)
+                s:ApplyTransferItemsPostConditions()
+            end)
+
+            it("picks a radio frequency in range", function()
+                expect(s.logic_state.story.radio_freq).toBeGreaterThan(29)
+                expect(s.logic_state.story.radio_freq).toBeLessThan(301)
+            end)
+
+            it("registers the stash with the radio", function()
+                expect(H.fakes.call_count("item_radio.add_stash")).toBe(1)
+            end)
+
+            it("gives the player a note", function()
+                expect(H.world.contents("actor")).toContain(
+                    "soulslike_rescuers_radio_frequency_note")
+            end)
+
+            -- The note is keyed by se_note.id. alife_create_item returns a
+            -- SERVER object, so `.id` is a field; if it returned a client
+            -- object this table would silently be keyed by a function and
+            -- soulslike_note could never look the frequency up.
+            it("keys the note data by a numeric id", function()
+                local keys = {}
+                for k in pairs(s.game_state.note_message_data) do
+                    keys[#keys + 1] = type(k)
+                end
+                expect(keys).toEqual({ "number" })
+            end)
+
+            it("records the frequency against the note", function()
+                for _, entry in pairs(s.game_state.note_message_data) do
+                    expect(entry.freq).toBe(s.logic_state.story.radio_freq)
+                    expect(entry.level_name).toBe("zaton")
+                end
+            end)
+        end)
+    end)
+
+    describe("the Hidden Stash scenario", function()
+        local s, se_stash
+
+        beforeEach(function()
+            boot()
+            s = scenario("HiddenStashSoulslikeScenarioLogic")
+            se_stash = s:CreateStash()
+        end)
+
+        it("creates a hidden box", function()
+            expect(H.world.created[1].section).toBe("hidden_box")
+        end)
+
+        it("registers the stash in the save", function()
+            expect(s.game_state.created_stashes[se_stash.id]).toBeDefined()
+        end)
+
+        -- Asymmetric with the RF variant on purpose: no radio, so no radio_id
+        -- or radio_level to record.
+        it("records only the stash id against the treasure", function()
+            expect(s.game_state.hidden_stashes[TREASURE_ID])
+                .toEqual({ stash_id = se_stash.id })
+        end)
+
+        it("restores the treasure_manager patch", function()
+            expect(H.mods.patched("treasure_manager")).toEqual({})
+        end)
+
+        it("marks the treasure on the PDA afterwards", function()
+            s:ApplyTransferItemsPostConditions()
+            expect(s.logic_state.story.has_stash_pda_marker).toBe(true)
+            expect(H.fakes.last_call("level.map_add_object_spot_ser")[1])
+                .toBe(TREASURE_ID)
+        end)
+    end)
+
+    describe("the NoLoss scenario", function()
+        local s
+
+        beforeEach(function()
+            boot()
+            s = scenario("NoLossSoulslikeScenarioLogic")
+            H.world.give("actor", "wpn_ak74", { kind = "weapon" })
+            H.world.give("actor", "medkit")
+        end)
+
+        it("creates no stash", function()
+            expect(s:CreateStash()).toBeNil()
+            expect(H.world.created).toEqual({})
+        end)
+
+        it("transfers nothing", function()
+            s:TransferItems(nil)
+            H.tick()
+            expect(H.world.contents("actor")).toEqual({ "wpn_ak74", "medkit" })
+        end)
+
+        it("refuses every item loss", function()
+            expect(s:IsItemLossAllowed(H.world.item_by_section("wpn_ak74"))).toBe(false)
+        end)
+
+        it("respawns without a transfer", function()
+            s:HandleItemsAndRespawn()
+            H.tick()
+            expect(H.world.contents("actor")).toEqual({ "wpn_ak74", "medkit" })
+            expect(H.fakes.call_count("ChangeLevel")).toBe(1)
+        end)
+
+        -- NoLoss overrides TransferItems and IsItemLossAllowed but NOT
+        -- TransferAndRespawn, which is what applies the money loss (:533).
+        it("still costs the player money", function()
+            H.set_actor{ money = 10000 }
+            H.fakes.set_random_sequence{ 0.1, 0.5 }
+            s:ApplyMoneyLoss()
+            expect(db.actor:money()).toBeLessThan(10000)
+        end)
+    end)
+
+    describe("given no treasure stash is available", function()
+        -- The hidden variants bail out early. The restore of the monkey-patch
+        -- happens before that return, so it must still be clean.
+        for _, class in ipairs{ "RFDetectorSoulslikeScenarioLogic",
+                                "HiddenStashSoulslikeScenarioLogic" } do
+            describe(class, function()
+                local s
+
+                beforeEach(function()
+                    boot{ treasure = false }
+                    s = scenario(class)
+                end)
+
+                it("creates no stash", function()
+                    expect(s:CreateStash()).toBeNil()
+                end)
+
+                it("does not leak the treasure_manager patch", function()
+                    s:CreateStash()
+                    expect(H.mods.patched("treasure_manager")).toEqual({})
+                end)
+
+                it("respawns the player anyway", function()
+                    H.world.give("actor", "bread")
+                    s:HandleItemsAndRespawn()
+                    H.tick()
+                    expect(H.fakes.call_count("ChangeLevel")).toBe(1)
+                end)
+
+                it("leaves the player's items alone", function()
+                    H.world.give("actor", "bread")
+                    s:HandleItemsAndRespawn()
+                    H.tick()
+                    expect(H.world.contents("actor")).toContain("bread")
+                end)
+            end)
+        end
+    end)
+
+    describe("every variant", function()
+        local CLASSES = {
+            "DefaultSoulslikeScenarioLogic",
+            "RFDetectorSoulslikeScenarioLogic",
+            "HiddenStashSoulslikeScenarioLogic",
+            "NoLossSoulslikeScenarioLogic",
+        }
+
+        it("stamps its own scenario id", function()
+            local seen = {}
+            for _, class in ipairs(CLASSES) do
+                boot()
+                seen[#seen + 1] = scenario(class).logic_state.scenario_id
+            end
+            expect(seen).toEqual{
+                soulslike.SCENARIOS.Default,
+                soulslike.SCENARIOS.RFDetectorStash,
+                soulslike.SCENARIOS.HiddenStash,
+                soulslike.SCENARIOS.NoLoss,
+            }
+        end)
+
+        it("round-trips through create_by_id", function()
+            for _, class in ipairs(CLASSES) do
+                boot()
+                local id = scenario(class).logic_state.scenario_id
+                local restored = soulslike_scenario_logic_factory.create_by_id(id)
+                expect(H.class.is_instance(restored, _G[class])).toBe(true)
+            end
+        end)
+
+        it("reaches a respawn", function()
+            for _, class in ipairs(CLASSES) do
+                boot()
+                H.world.give("actor", "bread")
+                scenario(class):HandleItemsAndRespawn()
+                H.tick()
+                expect(H.fakes.call_count("ChangeLevel")).toBe(1)
+            end
+        end)
+    end)
+end)
+
+return true

--- a/tests/e2e/stash_recovery.spec.lua
+++ b/tests/e2e/stash_recovery.spec.lua
@@ -1,0 +1,246 @@
+-- End to end: the player walks back and empties their death stash.
+--
+--   actor_on_item_take_from_box  (fires per item taken)
+--     -> once the box is empty:
+--          hide_hud_inventory, map spot removed, stash released,
+--          try_send_inventory_examined_message, entry cleared from the save
+--
+--   actor_on_stash_remove        (the "abandon stash" path)
+--     -> cancels the removal, same cleanup
+--
+-- The examined message is the only place the player learns what did NOT
+-- survive, and it is latched so it can only ever be shown once.
+
+local H = require("harness.init")
+local B = H.builders
+
+local MOD_SCRIPTS = {
+    "soulslike_classes", "soulslike", "soulslike_mcm",
+    "soulslike_message_factory", "soulslike_scenarios",
+    "soulslike_scenario_logic_factory",
+}
+
+local STASH_ID = 4242
+
+--- A world where a death stash exists, optionally holding items and a record
+--- of what was lost.
+local function boot(opts)
+    opts = opts or {}
+    H.boot{ load = MOD_SCRIPTS, soulslike_mode = true }
+    H.fakes.set_random_min()
+    H.set_spawn{ level = "zaton" }
+    soulslike.on_game_start()
+
+    local stash = H.world.container("stash", {
+        id = STASH_ID, section = opts.section or "inv_backpack",
+    })
+
+    for _, sec in ipairs(opts.contents or {}) do
+        H.world.give("stash", sec)
+    end
+
+    soulslike.get_soulslike_state().created_stashes[STASH_ID] = {
+        lost_items = opts.lost_items or {},
+        examine = opts.examine or false,
+    }
+
+    return stash
+end
+
+--- The last examined message shown to the player, or nil.
+local function examined_message()
+    local call = H.fakes.last_call("give_game_news")
+    return call and call[2]
+end
+
+local function take_from(stash)
+    SendScriptCallback("actor_on_item_take_from_box", stash, nil)
+end
+
+describe("e2e: stash recovery", function()
+
+    describe("given the player empties the stash", function()
+        local stash
+
+        beforeEach(function()
+            stash = boot{ lost_items = { "wpn_ak74", "medkit", "medkit" } }
+            take_from(stash)
+        end)
+
+        it("closes the inventory window", function()
+            expect(H.fakes.call_count("hide_hud_inventory")).toBe(1)
+        end)
+
+        it("removes the map marker", function()
+            expect(H.fakes.call_count("level.map_remove_object_spot")).toBe(1)
+        end)
+
+        it("releases the stash object", function()
+            H.tick()
+            expect(H.world.object(STASH_ID)).toBeNil()
+        end)
+
+        it("clears the stash from the save", function()
+            expect(soulslike.get_soulslike_state().created_stashes[STASH_ID]).toBeNil()
+        end)
+
+        it("tells the player what was missing", function()
+            expect(examined_message()).toContain("missing the following items")
+        end)
+
+        it("groups repeated sections with a count", function()
+            expect(examined_message()).toContain("2 x medkit")
+        end)
+
+        it("lists a single item without a count", function()
+            expect(examined_message()).toContain("wpn_ak74")
+            expect(examined_message()).never.toContain("1 x wpn_ak74")
+        end)
+    end)
+
+    describe("given the stash still holds items", function()
+        local stash
+
+        beforeEach(function()
+            stash = boot{
+                contents = { "bread", "vodka" },
+                lost_items = { "wpn_ak74" },
+            }
+            take_from(stash)
+        end)
+
+        it("leaves the stash in place", function()
+            expect(soulslike.get_soulslike_state().created_stashes[STASH_ID]).toBeDefined()
+        end)
+
+        it("keeps the map marker", function()
+            expect(H.fakes.call_count("level.map_remove_object_spot")).toBe(0)
+        end)
+
+        it("says nothing yet", function()
+            expect(examined_message()).toBeNil()
+        end)
+    end)
+
+    describe("given nothing was lost", function()
+        it("cleans up without a message", function()
+            local stash = boot{ lost_items = {} }
+            take_from(stash)
+            expect(soulslike.get_soulslike_state().created_stashes[STASH_ID]).toBeNil()
+            expect(examined_message()).toBeNil()
+        end)
+    end)
+
+    describe("given the message was already shown", function()
+        -- The `examine` latch exists so a stash emptied over several trips
+        -- does not repeat the bad news each time.
+        it("does not repeat it", function()
+            local stash = boot{ lost_items = { "wpn_ak74" }, examine = true }
+            take_from(stash)
+            expect(examined_message()).toBeNil()
+        end)
+    end)
+
+    describe("given a box that is not a death stash", function()
+        it("is ignored", function()
+            local other = boot{ section = "inv_box_generic" }
+            take_from(other)
+            expect(H.fakes.call_count("hide_hud_inventory")).toBe(0)
+            expect(soulslike.get_soulslike_state().created_stashes[STASH_ID]).toBeDefined()
+        end)
+    end)
+
+    describe("given the player abandons the stash from the map", function()
+        local data
+
+        beforeEach(function()
+            boot{ lost_items = { "wpn_ak74" } }
+            data = { stash_id = STASH_ID }
+            SendScriptCallback("actor_on_stash_remove", data)
+        end)
+
+        -- The mod owns this stash's lifetime, so the engine's own removal has
+        -- to be cancelled or the cleanup below runs against a dead object.
+        it("cancels the engine's removal", function()
+            expect(data.cancel).toBe(true)
+        end)
+
+        it("removes the map marker", function()
+            expect(H.fakes.call_count("level.map_remove_object_spot")).toBe(1)
+        end)
+
+        it("shows the examined message", function()
+            expect(examined_message()).toContain("missing the following items")
+        end)
+
+        it("clears the stash from the save", function()
+            expect(soulslike.get_soulslike_state().created_stashes[STASH_ID]).toBeNil()
+        end)
+    end)
+
+    describe("given an unrelated stash is removed", function()
+        it("is left to the engine", function()
+            boot{ lost_items = { "wpn_ak74" } }
+            local data = { stash_id = 9999 }
+            SendScriptCallback("actor_on_stash_remove", data)
+            expect(data.cancel).toBeNil()
+            expect(soulslike.get_soulslike_state().created_stashes[STASH_ID]).toBeDefined()
+        end)
+    end)
+
+    describe("given soulslike mode is off", function()
+        it("ignores the box entirely", function()
+            H.boot{ load = MOD_SCRIPTS }
+            H.fakes.set_random_min()
+            soulslike.on_game_start()
+
+            local stash = H.world.container("stash", {
+                id = STASH_ID, section = "inv_backpack",
+            })
+            soulslike.get_soulslike_state().created_stashes[STASH_ID] =
+                { lost_items = { "wpn_ak74" }, examine = false }
+
+            take_from(stash)
+            expect(soulslike.get_soulslike_state().created_stashes[STASH_ID]).toBeDefined()
+        end)
+    end)
+
+    describe("the full round trip", function()
+        -- Die, walk back, empty the stash: the state the death created must be
+        -- entirely gone afterwards.
+        it("leaves no trace of the stash in the save", function()
+            H.boot{ load = MOD_SCRIPTS, soulslike_mode = true }
+            H.fakes.set_random_min()
+            H.set_spawn{ level = "zaton", position = { x = 0, y = 0, z = 0 } }
+            H.set_actor{ position = { x = 0, y = 0, z = 500 } }
+            B.stub_finders{ friendly_stalker = B.make_stalker{} }
+            H.fakes.set_mcm("debug/is_enabled", true)
+            H.fakes.set_mcm("debug/debug_the_default_scenario", true)
+            soulslike.on_game_start()
+
+            H.world.give("actor", "bread")
+            H.fakes.set_random(function(a, b)
+                if a == nil then return 0.0 end
+                return b or 1
+            end)
+
+            SendScriptCallback("actor_on_before_death", nil, { ret_value = true })
+            H.tick()
+
+            local stash_id = H.world.created[1].id
+            expect(soulslike.get_soulslike_state().created_stashes[stash_id]).toBeDefined()
+
+            -- Empty it and hand the now-empty box back to the callback.
+            local box = H.world.object(stash_id)
+            for _, item in ipairs({ H.world.item_by_section("bread") }) do
+                H.world.queue_release(item)
+            end
+            H.tick()
+
+            take_from(box)
+            expect(soulslike.get_soulslike_state().created_stashes[stash_id]).toBeNil()
+        end)
+    end)
+end)
+
+return true

--- a/tests/harness/builders.lua
+++ b/tests/harness/builders.lua
@@ -201,7 +201,16 @@ function M.make_actor(opts)
         return self._slots[n]
     end
     function o:transfer_item(_, _) end
-    function o:give_game_news(...) end
+
+    -- Recorded, not a no-op: this is how the mod delivers the
+    -- inventory-examined message listing what did not survive
+    -- (soulslike.script:591), which is the player's only account of it.
+    function o:give_game_news(...)
+        local F = require("harness.fakes")
+        F.calls["give_game_news"] = F.calls["give_game_news"] or {}
+        local t = F.calls["give_game_news"]
+        t[#t + 1] = { n = select("#", ...), ... }
+    end
 
     return o
 end

--- a/tests/harness/builders.lua
+++ b/tests/harness/builders.lua
@@ -1,0 +1,248 @@
+-- Fixture builders for the userdata-ish objects the mod receives from the
+-- engine. Everything is a plain table with method-style accessors, because
+-- the mod calls them as obj:id(), obj:section(), etc.
+--
+-- The `_kind` tag drives the IsStalker / IsMonster / ... predicates in fakes.lua.
+
+local M = {}
+
+local next_id = 1000
+local function alloc_id()
+    next_id = next_id + 1
+    return next_id
+end
+
+-- Shared: gives an object the id()/name()/section() accessors the mod expects.
+local function base(o, kind)
+    o = o or {}
+    o._kind = kind
+    o._id = o._id or alloc_id()
+    o._name = o._name or (kind .. "_" .. tostring(o._id))
+    o._section = o._section or (kind .. "_section")
+
+    function o:id() return self._id end
+    function o:name() return self._name end
+    function o:section() return self._section end
+    return o
+end
+
+--- An NPC (stalker or monster). Opts:
+---   id, name, section, kind ("stalker" | "monster"), community,
+---   goodwill (general_goodwill vs actor), alive, position {x,y,z}
+function M.make_npc(opts)
+    opts = opts or {}
+    local o = base({
+        _id      = opts.id,
+        _name    = opts.name,
+        _section = opts.section,
+    }, opts.kind or "stalker")
+
+    o._community = opts.community or "stalker"
+    o._goodwill  = opts.goodwill == nil and 0 or opts.goodwill
+    o._alive     = opts.alive ~= false
+    o._position  = M.make_vector(opts.position)
+
+    function o:community() return self._community end
+    function o:character_community() return self._community end
+    function o:general_goodwill() return self._goodwill end
+    function o:alive() return self._alive end
+    function o:position() return self._position end
+    function o:character_rank() return opts.rank or 0 end
+    function o:character_name() return self._name end
+    function o:clsid() return opts.clsid or 1 end
+    function o:section_name() return self._section end
+    function o:level_vertex_id() return opts.level_vertex_id or 1 end
+    function o:game_vertex_id() return opts.game_vertex_id or 1 end
+
+    -- Server-object style fields, for objects reached via alife():object().
+    o.m_level_vertex_id = opts.level_vertex_id or 1
+    o.m_game_vertex_id  = opts.game_vertex_id or 1
+    o.online            = opts.online == true
+    o.parent_id         = opts.parent_id
+    o.section           = o._section
+    function o:switch_online() self.online = true end
+
+    -- State setters npc_on_net_spawn drives (soulslike.script:929-934).
+    -- Recorded rather than modelled: specs assert which constant was applied.
+    o.applied = {}
+    local function setter(field)
+        return function(self, v) self.applied[field] = v end
+    end
+    o.set_mental_state     = setter("mental_state")
+    o.set_body_state       = setter("body_state")
+    o.set_movement_type    = setter("movement_type")
+    o.set_desired_position = setter("desired_position")
+    function o:set_sight(t) self.applied.sight_type = t end
+    function o:set_desired_direction() self.applied.desired_direction = true end
+
+    -- Squad support for SpawnAmbush's is_squad branch.
+    o._squad_members = opts.squad_members or {}
+    function o:squad_members()
+        local i = 0
+        return function()
+            i = i + 1
+            return self._squad_members[i]
+        end
+    end
+    function o:create_npc() end
+
+    return o
+end
+
+function M.make_stalker(opts)
+    opts = opts or {}; opts.kind = "stalker"
+    return M.make_npc(opts)
+end
+
+function M.make_monster(opts)
+    opts = opts or {}; opts.kind = "monster"
+    return M.make_npc(opts)
+end
+
+function M.make_anomaly(opts)
+    opts = opts or {}; opts.kind = "anomaly"
+    return M.make_npc(opts)
+end
+
+--- The actor. Opts: id (defaults to AC_ID), health, power, rank, community,
+--- position, inventory (list of items for iterate_inventory).
+function M.make_actor(opts)
+    opts = opts or {}
+    local o = base({
+        _id      = opts.id or (_G.AC_ID or 0),
+        _name    = opts.name or "actor",
+        _section = "actor",
+    }, "actor")
+
+    -- Plain fields the mod writes directly (HealActor, dream_callback).
+    o.health    = opts.health == nil and 1.0 or opts.health
+    o.power     = opts.power  == nil and 1.0 or opts.power
+    o.radiation = opts.radiation or 0
+    o.bleeding  = opts.bleeding or 0
+    o.psy_health= opts.psy_health == nil and 1.0 or opts.psy_health
+    o.satiety   = opts.satiety == nil and 1.0 or opts.satiety
+
+    o._rank      = opts.rank or 0
+    o._rep       = opts.reputation or 0
+    o._money     = opts.money or 0
+    o._community = opts.community or "stalker"
+    o._position  = M.make_vector(opts.position)
+    o._inventory = opts.inventory or {}
+    o._slots     = opts.slots or {}
+
+    function o:character_rank() return self._rank end
+    function o:set_character_rank(v) self._rank = v end
+    function o:character_reputation() return self._rep end
+    function o:set_character_reputation(v) self._rep = v end
+    function o:character_community() return self._community end
+    function o:character_name() return opts.character_name or "Marked One" end
+    function o:position() return self._position end
+    function o:alive() return true end
+    function o:general_goodwill() return 0 end
+    function o:set_health_ex(v) self.health = v end
+    function o:level_vertex_id() return opts.level_vertex_id or 1 end
+    function o:game_vertex_id() return opts.game_vertex_id or 1 end
+    function o:money() return self._money end
+    function o:give_money(v) self._money = self._money + v end
+    function o:give_info_portion(id) if _G.give_info_portion then _G.give_info_portion(id) end end
+
+    -- Only the accessors GiveFoodAndWater reads (soulslike_scenarios.script:576).
+    o._conditions = {
+        GetSatiety      = function() return o.satiety end,
+        SatietyCritical = function() return opts.satiety_critical or 0.2 end,
+    }
+    function o:cast_Actor()
+        return { conditions = function() return o._conditions end }
+    end
+
+    -- Overridden by world.lua when the item model is active. The default here
+    -- keeps actor-only specs working without booting the world.
+    function o:iterate_inventory(fn)
+        for _, item in ipairs(self._inventory) do
+            if fn(self, item) then return end
+        end
+    end
+
+    function o:item_in_slot(n) return self._slots[n] end
+    function o:transfer_item(_, _) end
+    function o:give_game_news(...) end
+
+    return o
+end
+
+--- An inventory item. Opts: id, section, kind (drives Is* predicates),
+--- condition.
+function M.make_item(opts)
+    opts = opts or {}
+    local o = base({
+        _id      = opts.id,
+        _name    = opts.name,
+        _section = opts.section or "itm_generic",
+    }, opts.kind or "item")
+
+    o._condition = opts.condition == nil and 1.0 or opts.condition
+    function o:condition() return self._condition end
+    return o
+end
+
+-- The engine binds set(float,float,float) only
+-- (xray-monolith/src/xrServerEntities/script_fvector_script.cpp:24). Passing
+-- nil matches no overload, so luabind raises lua_cast_failed, which under
+-- !XRAY_EXCEPTIONS becomes Debug.fatal -- a hard CTD, not a catchable error.
+--
+-- We raise to match. Coercing nil to 0 would silently paper over two mod sites
+-- that can pass nil coordinates (soulslike_scenario_logic_factory.script:174
+-- and soulslike_scenarios.script:845, both when no spawn was ever recorded).
+-- Set this false only in a spec that deliberately needs to step past it.
+M.strict_vectors = true
+
+--- A vector with the distance methods the mod uses.
+function M.make_vector(v)
+    v = v or {}
+    local o = { x = v.x or 0, y = v.y or 0, z = v.z or 0 }
+
+    function o:set(x, y, z)
+        if M.strict_vectors and (x == nil or y == nil or z == nil) then
+            error("vector:set() got nil (" .. tostring(x) .. ", " .. tostring(y)
+                  .. ", " .. tostring(z) .. ") -- the engine binds "
+                  .. "set(float,float,float) and would hard-crash here", 2)
+        end
+        self.x, self.y, self.z = x, y, z
+        return self
+    end
+
+    function o:distance_to_sqr(other)
+        local dx, dy, dz = self.x - other.x, self.y - other.y, self.z - other.z
+        return dx * dx + dy * dy + dz * dz
+    end
+
+    function o:distance_to(other)
+        return math.sqrt(self:distance_to_sqr(other))
+    end
+
+    return o
+end
+
+--- A hit record, shaped as soulslike.actor_on_before_hit enqueues them
+--- (soulslike.script:907-913).
+function M.make_hit(opts)
+    opts = opts or {}
+    return {
+        type         = opts.type or (_G.hit and _G.hit.wound) or 5,
+        power        = opts.power or 0,
+        is_fatal     = opts.is_fatal or false,
+        time         = opts.time or 0,
+        draftsman_id = opts.draftsman_id,
+    }
+end
+
+--- Installs the `vector()` global used across the mod.
+function M.install(env)
+    env = env or _G
+    env.vector = function() return M.make_vector() end
+    return env
+end
+
+function M.reset() next_id = 1000 end
+
+return M

--- a/tests/harness/builders.lua
+++ b/tests/harness/builders.lua
@@ -406,9 +406,18 @@ function M.make_scenario(opts)
     s:SetIsInWater(opts.in_water or false)
 
     for k, v in pairs(opts.state or {}) do
-        if k == "story" or k == "death_location" then
+        if (k == "story" or k == "death_location") and type(v) == "table" then
             s.logic_state[k] = s.logic_state[k] or {}
             for sk, sv in pairs(v) do s.logic_state[k][sk] = sv end
+        elseif k == "death_location" and v == false then
+            -- "no location was ever recorded", the shape __init actually builds
+            -- (soulslike_scenarios.script:282-290). Not the same as omitting
+            -- the key, which leaves the constructor's own nils in place.
+            s.logic_state.death_location = {
+                position = { x = nil, y = nil, z = nil },
+                level_vertex_id = nil,
+                game_vertex_id = nil,
+            }
         else
             s.logic_state[k] = v
         end

--- a/tests/harness/builders.lua
+++ b/tests/harness/builders.lua
@@ -49,7 +49,13 @@ function M.make_npc(opts)
     function o:position() return self._position end
     function o:character_rank() return opts.rank or 0 end
     function o:character_name() return self._name end
-    function o:clsid() return opts.clsid or 1 end
+    -- Defaults to the opaque clsid registered for this kind, so the Is*
+    -- predicates classify this object when it is reached via a server scan
+    -- that calls them as IsStalker(nil, cls) -- soulslike.script:307.
+    function o:clsid()
+        if opts.clsid ~= nil then return opts.clsid end
+        return require("harness.fakes").clsid_for(self._kind)
+    end
     function o:section_name() return self._section end
     function o:level_vertex_id() return opts.level_vertex_id or 1 end
     function o:game_vertex_id() return opts.game_vertex_id or 1 end
@@ -130,10 +136,21 @@ function M.make_actor(opts)
     o._inventory = opts.inventory or {}
     o._slots     = opts.slots or {}
 
+    -- Rank and reputation are int-typed on both sides
+    -- (xrServerEntities/character_info_defs.h:8), and luabind converts a Lua
+    -- number to int with static_cast, which truncates TOWARD ZERO -- not floor,
+    -- so -5.9 stores as -5. Neither setter clamps: nothing in the engine keeps
+    -- these in a documented range (InventoryOwner.cpp:450-491). Modelled
+    -- faithfully because the mod hands both a raw float.
+    local function to_int(v)
+        if type(v) ~= "number" then return v end
+        return v >= 0 and math.floor(v) or math.ceil(v)
+    end
+
     function o:character_rank() return self._rank end
-    function o:set_character_rank(v) self._rank = v end
+    function o:set_character_rank(v) self._rank = to_int(v) end
     function o:character_reputation() return self._rep end
-    function o:set_character_reputation(v) self._rep = v end
+    function o:set_character_reputation(v) self._rep = to_int(v) end
     function o:character_community() return self._community end
     function o:character_name() return opts.character_name or "Marked One" end
     function o:position() return self._position end
@@ -142,8 +159,18 @@ function M.make_actor(opts)
     function o:set_health_ex(v) self.health = v end
     function o:level_vertex_id() return opts.level_vertex_id or 1 end
     function o:game_vertex_id() return opts.game_vertex_id or 1 end
+    -- money() returns u32 and give_money() does NOT clamp at zero
+    -- (xrGame/InventoryOwner.cpp:630-645): deducting more than the actor holds
+    -- underflows to ~4.29e9 in-game. Modelled, because a spec asserting "money
+    -- never goes negative" would pass against a clamping fake while the real
+    -- game wrapped.
+    local U32 = 4294967296
     function o:money() return self._money end
-    function o:give_money(v) self._money = self._money + v end
+    function o:give_money(v)
+        local n = self._money + v
+        if n < 0 then n = n + U32 end
+        self._money = n % U32
+    end
     function o:give_info_portion(id) if _G.give_info_portion then _G.give_info_portion(id) end end
 
     -- Only the accessors GiveFoodAndWater reads (soulslike_scenarios.script:576).
@@ -163,7 +190,16 @@ function M.make_actor(opts)
         end
     end
 
-    function o:item_in_slot(n) return self._slots[n] end
+    -- Slot 0 is NO_ACTIVE_SLOT and the engine rejects it outright
+    -- (xrGame/Inventory.cpp:658-664). Valid slots are 1..LAST_SLOT, and
+    -- LAST_SLOT is CUSTOM_SLOT_5 = 18 in this build, because
+    -- MORE_INVENTORY_SLOTS is defined (build_config_defines.h:15) --
+    -- so BACKPACK(13) and CUSTOM_1..5(14-18) exist beyond HELMET(12).
+    o.LAST_SLOT = 18
+    function o:item_in_slot(n)
+        if n == nil or n <= 0 then return nil end
+        return self._slots[n]
+    end
     function o:transfer_item(_, _) end
     function o:give_game_news(...) end
 
@@ -236,6 +272,235 @@ function M.make_hit(opts)
     }
 end
 
+-- ------------------------------------------------------- scenario fixtures
+
+-- Mirrors the literal SoulslikeScenarioLogic:__init builds when constructed
+-- WITHOUT a saved state (soulslike_scenarios.script:249-302). Defaults are the
+-- MCM defaults each field is initialised from, so make_logic_state() and a
+-- freshly constructed scenario agree; self/builders.spec.lua asserts that.
+--
+-- Kept as a literal rather than derived from the mod, so that a field
+-- appearing or vanishing in the mod shows up as a failing drift guard instead
+-- of silently changing every spec's fixture.
+local function default_logic_state()
+    return {
+        rank = 0,
+        ranked_chance = 0,
+        item_condition_loss_percent = 0,
+        keep_equipped_items_on_death = false,
+        item_loss_scalar = 0.2,
+        ignore_rank_item_loss = false,
+        ignore_rank_item_condition_loss = false,
+        health_loss_percent = 0.75,
+        rank_loss_percent = 0.02,
+        rep_loss_percent = 0.05,
+        allow_weapon_loss = true,
+        allow_artifact_loss = true,
+        allow_outfit_loss = true,
+        allow_headgear_loss = true,
+        allow_toolkit_loss = true,
+        mutant_ambush_chance = 0.25,
+        stalker_ambush_chance = 0.25,
+        allow_boar_ambush = true,
+        allow_flesh_ambush = true,
+        allow_dogs_ambush = true,
+        allow_cats_ambush = true,
+        allow_snorks_ambush = true,
+        allow_bloodsucker_ambush = true,
+        allow_burer_ambush = true,
+        allow_chimera_ambush = true,
+        allow_controller_ambush = true,
+        allow_stalker_novice_ambush = true,
+        allow_stalker_advanced_ambush = true,
+        allow_stalker_veteran_ambush = true,
+        allow_stalker_sniper_ambush = true,
+        allow_npc_looting = true,
+        are_looter_npcs_marked = false,
+        death_location = {
+            position = { x = 0, y = 0, z = 0 },
+            level_vertex_id = 1,
+            game_vertex_id = 1,
+        },
+        story = {
+            gave_food_or_water = nil,
+            has_pda_marker = nil,
+            has_stash_pda_marker = nil,
+            radio_freq = nil,
+            items_were_lost = nil,
+            enemy = nil,
+            player_died_indoor = nil,
+            player_died_in_water = nil,
+            level_name = nil,
+        },
+    }
+end
+
+--- A logic_state table. Top-level keys in `opts` are merged over the defaults;
+--- `story` and `death_location` merge one level deep so a spec can override a
+--- single field without restating the whole sub-table.
+---
+--- death_location defaults to a real position rather than the mod's nils, so
+--- specs do not trip strict_vectors by accident. Pass `death_location = false`
+--- for the "no location recorded" case that SpawnAmbush guards against.
+function M.make_logic_state(opts)
+    opts = opts or {}
+    local s = default_logic_state()
+
+    for k, v in pairs(opts) do
+        if k ~= "story" and k ~= "death_location" then s[k] = v end
+    end
+
+    for k, v in pairs(opts.story or {}) do s.story[k] = v end
+
+    if opts.death_location == false then
+        s.death_location = {
+            position = { x = nil, y = nil, z = nil },
+            level_vertex_id = nil,
+            game_vertex_id = nil,
+        }
+    elseif type(opts.death_location) == "table" then
+        for k, v in pairs(opts.death_location) do
+            if k == "position" then
+                for pk, pv in pairs(v) do s.death_location.position[pk] = pv end
+            else
+                s.death_location[k] = v
+            end
+        end
+    end
+
+    return s
+end
+
+--- A spawn_location, as set_spawn records it into the save
+--- (soulslike.script:207-265). Every spec that reaches create_new or
+--- RespawnActor needs one, or those build a vector out of nils.
+function M.make_spawn_location(opts)
+    opts = opts or {}
+    local p = opts.position or {}
+    local a = opts.angle or {}
+    return {
+        level = opts.level or "zaton",
+        position = { x = p.x or 0, y = p.y or 0, z = p.z or 0 },
+        angle    = { x = a.x or 0, y = a.y or 0, z = a.z or 0 },
+        level_vertex_id = opts.level_vertex_id or 1,
+        game_vertex_id  = opts.game_vertex_id or 1,
+    }
+end
+
+--- Construct a scenario and apply the setters create_new would.
+--- Opts: class (default "DefaultSoulslikeScenarioLogic"), level_name,
+--- loot_scalar, indoor, in_water, state (merged into logic_state).
+---
+--- Must run after H.boot: it reads the class globals class.lua installs.
+function M.make_scenario(opts)
+    opts = opts or {}
+    local name = opts.class or "DefaultSoulslikeScenarioLogic"
+    local cls = _G[name]
+    assert(cls, "make_scenario: no class '" .. name .. "' -- is " ..
+                "soulslike_scenarios loaded?")
+
+    local s = cls()
+    s:SetLevelName(opts.level_name or "zaton")
+    s:SetLootScalar(opts.loot_scalar == nil and 1.0 or opts.loot_scalar)
+    s:SetIsInDoor(opts.indoor or false)
+    s:SetIsInWater(opts.in_water or false)
+
+    for k, v in pairs(opts.state or {}) do
+        if k == "story" or k == "death_location" then
+            s.logic_state[k] = s.logic_state[k] or {}
+            for sk, sv in pairs(v) do s.logic_state[k][sk] = sv end
+        else
+            s.logic_state[k] = v
+        end
+    end
+
+    return s
+end
+
+-- ------------------------------------------------------------ server objects
+
+--- A server-side object, as alife():object(id) returns. Distinct from a client
+--- object in two ways the mod depends on: `id` and `position` are FIELDS, not
+--- methods (xrServerEntities/xrServer_Objects_script.cpp:110-124).
+--- soulslike.find_closest_enemy:317 reads se_obj.position directly.
+function M.make_se_npc(opts)
+    opts = opts or {}
+    local kind = opts.kind or "stalker"
+    local id = opts.id or alloc_id()
+
+    local o = {
+        id       = id,
+        position = M.make_vector(opts.position),
+        m_game_vertex_id  = opts.game_vertex_id or 1,
+        m_level_vertex_id = opts.level_vertex_id or 1,
+        online   = opts.online == true,
+        parent_id = opts.parent_id,
+        _kind    = kind,
+        _name    = opts.name or (kind .. "_" .. tostring(id)),
+        _section = opts.section or ("sim_default_" .. kind),
+        _community = opts.community or "stalker",
+        _alive   = opts.alive ~= false,
+    }
+
+    function o:name() return self._name end
+    function o:section_name() return self._section end
+    function o:community() return self._community end
+    function o:alive() return self._alive end
+    function o:clsid()
+        if opts.clsid ~= nil then return opts.clsid end
+        return require("harness.fakes").clsid_for(self._kind)
+    end
+    function o:switch_online() self.online = true end
+
+    return o
+end
+
+-- --------------------------------------------------------- finder stubbing
+
+-- Which finder create_new called, and how many times. Load-bearing: branches
+-- 10 and 11 of the selection tree (soulslike_scenario_logic_factory.script:256
+-- and :272) differ only by which finder supplies the looter, so asserting the
+-- returned object is not enough to tell them apart.
+M.finder_calls = {}
+
+local FINDERS = {
+    "find_closest_friendly_stalker",
+    "find_closest_enemy",
+    "find_closest_enemy_stalker",
+    "find_closest_enemy_mutant",
+}
+
+--- Replace soulslike's four find_closest_* helpers with constant returns.
+--- `t` maps a finder name (with or without the "find_closest_" prefix) to the
+--- object it should return; omitted finders return nil.
+---
+--- Stubs the real scans, which walk 65534 alife slots. Safe across specs
+--- because H.boot re-executes soulslike.script, rebuilding its module table.
+function M.stub_finders(t)
+    t = t or {}
+    assert(_G.soulslike, "stub_finders: soulslike.script is not loaded")
+
+    M.finder_calls = {}
+    for _, name in ipairs(FINDERS) do
+        local short = name:gsub("^find_closest_", "")
+        local ret = t[name]
+        if ret == nil then ret = t[short] end
+
+        M.finder_calls[name] = 0
+        _G.soulslike[name] = function()
+            M.finder_calls[name] = M.finder_calls[name] + 1
+            return ret
+        end
+    end
+end
+
+--- Times `name` was called since the last stub_finders(). Accepts the short
+--- form ("enemy_mutant") as well as the full function name.
+function M.finder_count(name)
+    if M.finder_calls[name] then return M.finder_calls[name] end
+    return M.finder_calls["find_closest_" .. name] or 0
+end
+
 --- Installs the `vector()` global used across the mod.
 function M.install(env)
     env = env or _G
@@ -243,6 +508,9 @@ function M.install(env)
     return env
 end
 
-function M.reset() next_id = 1000 end
+function M.reset()
+    next_id = 1000
+    M.finder_calls = {}
+end
 
 return M

--- a/tests/harness/class.lua
+++ b/tests/harness/class.lua
@@ -25,6 +25,13 @@ local M = {}
 -- against the class whose __init is running, not against the instance's class.
 local init_stack = {}
 
+-- Every class name registered since the last install(). `class "X"` writes a
+-- true global, and nothing in Lua removes it, so without tracking them a spec
+-- that never loaded soulslike_scenarios would still find the class a PREVIOUS
+-- spec left on _G -- and pass for the wrong reason. A fresh game has no classes
+-- until the scripts declaring them run, so install() clears them.
+local registered = {}
+
 local function construct(cls, ...)
     local obj = setmetatable({}, { __index = cls, __class = cls })
     M.call_init(cls, obj, ...)
@@ -75,6 +82,7 @@ local function class(name)
     setmetatable(cls, { __call = construct })
 
     _G[name] = cls
+    registered[name] = true
 
     -- Enables the `class "X" (Base)` second call. Returning the class itself
     -- would break that, so return a deriver closure.
@@ -106,8 +114,23 @@ function M.is_instance(obj, cls)
     return false
 end
 
+--- Names registered by `class` since the last install(). Test aid.
+function M.registered_names()
+    local out = {}
+    for name in pairs(registered) do out[#out + 1] = name end
+    table.sort(out)
+    return out
+end
+
 function M.install(env)
     env = env or _G
+    -- Drop classes declared during a previous boot before re-arming, so each
+    -- spec starts from a world where no script has run yet.
+    for name in pairs(registered) do
+        if rawget(env, name) ~= nil then env[name] = nil end
+    end
+    registered = {}
+
     env.class = class
     return env
 end

--- a/tests/harness/class.lua
+++ b/tests/harness/class.lua
@@ -1,0 +1,117 @@
+-- Shim for luabind's `class` global.
+--
+-- `class` is NOT part of Lua. The engine installs it from C++ in luabind::open()
+-- (xray-monolith/src/3rd party/luabind/src/open.cpp:64, implemented in
+-- create_class.cpp). The mod uses both forms:
+--
+--     class "SoulslikeScenarioLogic"                                  -- base
+--     class "DefaultSoulslikeScenarioLogic" (SoulslikeScenarioLogic)  -- derived
+--     function DefaultSoulslikeScenarioLogic:__init(state) super (state) end
+--
+-- Fidelity notes vs. luabind:
+--   * `__init` and `__finalize` are NOT inherited. create_class.cpp:36-62
+--     explicitly skips both when copying the base member table down. We match
+--     that: a derived class with no own __init runs no constructor at all.
+--   * Other members ARE reachable from the derived class. luabind copies them
+--     eagerly at derivation time; we resolve them lazily through __index. The
+--     observable difference only shows up if a base method is replaced *after*
+--     the derived class is declared -- luabind would keep the old one, we pick
+--     up the new one. The mod never does this.
+
+local M = {}
+
+-- Stack of {obj=, cls=} frames, one per __init currently executing. `super`
+-- reads the top frame, so in an A <- B <- C chain each super() call resolves
+-- against the class whose __init is running, not against the instance's class.
+local init_stack = {}
+
+local function construct(cls, ...)
+    local obj = setmetatable({}, { __index = cls, __class = cls })
+    M.call_init(cls, obj, ...)
+    return obj
+end
+
+function M.call_init(cls, obj, ...)
+    -- rawget, not cls.__init: __init must not be inherited (see header note).
+    local init = rawget(cls, "__init")
+
+    init_stack[#init_stack + 1] = { obj = obj, cls = cls }
+    local saved_super = rawget(_G, "super")
+
+    _G.super = function(...)
+        local frame = init_stack[#init_stack]
+        local base = frame and rawget(frame.cls, "__base")
+        if base then
+            M.call_init(base, frame.obj, ...)
+        end
+    end
+
+    local ok, err
+    if init then
+        ok, err = pcall(init, obj, ...)
+    else
+        ok = true
+    end
+
+    init_stack[#init_stack] = nil
+    _G.super = saved_super
+
+    if not ok then error(err, 0) end
+    return obj
+end
+
+-- The `class` global itself.
+local function class(name)
+    if type(name) ~= "string" then
+        error("invalid construct, expected class name", 2)
+    end
+
+    local cls = {}
+    cls.__name = name
+    cls.__index = cls   -- instances resolve members here
+
+    -- No base yet. __index on the *class* metatable is what makes inherited
+    -- members reachable; it gets filled in by the returned deriver.
+    setmetatable(cls, { __call = construct })
+
+    _G[name] = cls
+
+    -- Enables the `class "X" (Base)` second call. Returning the class itself
+    -- would break that, so return a deriver closure.
+    return function(base)
+        if base ~= nil then
+            if type(base) ~= "table" then
+                error("expected class to derive from or a newline", 2)
+            end
+            rawset(cls, "__base", base)
+            setmetatable(cls, { __call = construct, __index = base })
+        end
+        return cls
+    end
+end
+
+-- ------------------------------------------------------------------ test aid
+
+function M.class_of(obj)
+    local mt = getmetatable(obj)
+    return mt and mt.__class or nil
+end
+
+function M.is_instance(obj, cls)
+    local c = M.class_of(obj)
+    while c do
+        if c == cls then return true end
+        c = rawget(c, "__base")
+    end
+    return false
+end
+
+function M.install(env)
+    env = env or _G
+    env.class = class
+    return env
+end
+
+M.class = class
+
+return M

--- a/tests/harness/dispatch.lua
+++ b/tests/harness/dispatch.lua
@@ -1,0 +1,175 @@
+-- Callback dispatch: RegisterScriptCallback / SendScriptCallback and the
+-- axr_main intercepts registry behind them.
+--
+-- WHY THIS IS REIMPLEMENTED RATHER THAN LOADED
+--
+-- _g.script loads fine standalone, but axr_main.script does load-time I/O at
+-- its very top (_scripts/axr_main.script:15):
+--
+--     config = ini_file_ex("axr_options.ltx",true)
+--     if not (config:section_exist("temp")) then
+--         get_console():execute("cfg_load " .. getFS():update_path(...))
+--         config:w_value("temp","rspec_default",true)
+--         config:save()
+--     end
+--
+-- Booting it requires working ini_file_ex / getFS / get_console fakes before
+-- the callback system is even reachable. The dispatch core below is a
+-- line-for-line transcription of axr_main.script:240-285 instead, preserving
+-- the semantics that actually affect the mod:
+--
+--   * callback_set on a name with no prior callback_add silently no-ops.
+--     The mod's on_game_start registrations vanish if names aren't pre-added.
+--   * make_callback dispatches to both plain functions and to objects
+--     carrying a method of the same name.
+--   * SendScriptCallback additionally invokes axr_main[name] when present.
+--
+-- To swap in the real file later: add those three fakes and load
+-- _scripts/axr_main.script through the loader instead of calling M.install().
+
+local M = {}
+
+local intercepts = {}
+
+-- Recorded dispatches, for assertions. { {name=, args={...}, n=}, ... }
+M.log = {}
+
+-- --------------------------------------------------- axr_main registry core
+
+local function callback_add(name)
+    if not intercepts[name] then
+        intercepts[name] = {}
+    end
+    -- Real impl printf/callstacks on redundant add; harmless, so we stay quiet.
+end
+
+local function callback_set(name, func_or_userdata)
+    if func_or_userdata == nil then
+        M.warn("callback_set: trying to set callback " .. tostring(name) .. " to nil function!")
+        return
+    end
+    if intercepts[name] then
+        intercepts[name][func_or_userdata] = true
+    else
+        M.warn("callback_set: callback " .. tostring(name) .. " doesn't exist!")
+    end
+end
+
+local function callback_unset(name, func_or_userdata)
+    if intercepts[name] then
+        intercepts[name][func_or_userdata] = nil
+    else
+        M.warn("callback_unset: callback " .. tostring(name) .. " doesn't exist!")
+    end
+end
+
+local function make_callback(name, ...)
+    if intercepts[name] then
+        for func_or_userdata in pairs(intercepts[name]) do
+            if type(func_or_userdata) == "function" then
+                func_or_userdata(...)
+            elseif func_or_userdata[name] then
+                func_or_userdata[name](func_or_userdata, ...)
+            end
+        end
+    else
+        M.warn("make_callback: can't make callback to non existing intercept " .. tostring(name) .. "!")
+    end
+end
+
+-- Warnings are collected rather than printed so tests can assert on the
+-- silent-no-op paths instead of scraping stdout.
+M.warnings = {}
+function M.warn(msg)
+    M.warnings[#M.warnings + 1] = msg
+end
+
+-- ------------------------------------------------------ _g.script wrappers
+
+-- Names the mod registers in soulslike.on_game_start (soulslike.script:948-965).
+-- Without these pre-added, every RegisterScriptCallback there silently no-ops.
+M.CALLBACK_NAMES = {
+    "actor_on_stash_remove",
+    "actor_on_first_update",
+    "actor_on_item_take_from_box",
+    "actor_on_before_death",
+    "on_before_save_input",
+    "save_state",
+    "load_state",
+    "on_level_changing",
+    "on_game_load",
+    "actor_on_sleep",
+    "on_console_execute",
+    "actor_on_before_hit",
+    "physic_object_on_use_callback",
+    -- Sent (not registered) by the mod:
+    "squad_on_npc_creation",
+    "npc_on_net_spawn",
+}
+
+function M.install(env)
+    env = env or _G
+
+    env.axr_main = env.axr_main or {}
+    env.axr_main.callback_add   = callback_add
+    env.axr_main.callback_set   = callback_set
+    env.axr_main.callback_unset = callback_unset
+    env.axr_main.make_callback  = make_callback
+
+    -- _g.script:104-130
+    function env.RegisterScriptCallback(name, func_or_userdata)
+        env.axr_main.callback_set(name, func_or_userdata)
+    end
+
+    function env.UnregisterScriptCallback(name, func_or_userdata)
+        env.axr_main.callback_unset(name, func_or_userdata)
+    end
+
+    function env.AddScriptCallback(name)
+        env.axr_main.callback_add(name)
+    end
+
+    function env.SendScriptCallback(name, ...)
+        M.log[#M.log + 1] = { name = name, args = { ... }, n = select("#", ...) }
+        env.axr_main.make_callback(name, ...)
+        if env.axr_main[name] then
+            env.axr_main[name](...)
+        end
+    end
+
+    for _, n in ipairs(M.CALLBACK_NAMES) do
+        callback_add(n)
+    end
+
+    return env
+end
+
+-- --------------------------------------------------------------- test aids
+
+function M.add(name) callback_add(name) end
+
+function M.handler_count(name)
+    local t = intercepts[name]
+    if not t then return nil end          -- nil means "intercept doesn't exist"
+    local n = 0
+    for _ in pairs(t) do n = n + 1 end
+    return n
+end
+
+function M.exists(name) return intercepts[name] ~= nil end
+
+function M.sends_of(name)
+    local out = {}
+    for _, entry in ipairs(M.log) do
+        if entry.name == name then out[#out + 1] = entry end
+    end
+    return out
+end
+
+function M.reset()
+    intercepts = {}
+    M.log = {}
+    M.warnings = {}
+end
+
+return M

--- a/tests/harness/encoding.lua
+++ b/tests/harness/encoding.lua
@@ -1,0 +1,179 @@
+-- Byte-level inspection of the localisation XML under gamedata/configs/text.
+--
+-- Anomaly's XML reader is not encoding-aware in any useful sense: it takes the
+-- bytes as they are and hands them to the engine's cp1251 font tables. So a
+-- Russian string table is only correct if it is *stored* as windows-1251, one
+-- byte per Cyrillic letter. A file that says `encoding="windows-1251"` in its
+-- declaration while holding UTF-8 bytes renders as mojibake in game, and
+-- nothing anywhere reports it -- the file still parses, the string ids still
+-- resolve, so `mcm_localization.spec.lua` stays green while every label is
+-- garbage.
+--
+-- The way this breaks in practice is an editor. VS Code guesses an encoding on
+-- open, and on a cp1251 file it usually guesses wrong; saving then rewrites
+-- every Cyrillic byte. Nothing in the diff looks alarming -- the declaration is
+-- untouched -- which is exactly why it needs a byte-level check rather than a
+-- reading of the header.
+--
+-- Reference for what a correct file looks like: any stock Anomaly/GAMMA
+-- translation, e.g. gamedata/configs/text/rus/st_items_glowstick.xml from
+-- "HD Glowsticks" -- declaration windows-1251, single-byte Cyrillic in
+-- 0xC0..0xFF, no BOM.
+
+local M = {}
+
+-- ------------------------------------------------------------------ cp1251
+--
+-- The high half of windows-1251. Cyrillic occupies a contiguous 0xC0..0xFF
+-- (А..я); the rest is typographic punctuation and the two Ё/ё that sit outside
+-- the block. Everything not listed here is either undefined in cp1251 or a
+-- character no string table has a reason to contain -- and, more usefully, the
+-- 0x80..0xBF range is where UTF-8 continuation bytes live, so keeping the
+-- allowance there narrow is what makes a UTF-8 re-save visible.
+--
+-- Codepage chart: https://en.wikipedia.org/wiki/Windows-1251
+
+local CP1251_HIGH = {}
+for b = 0xC0, 0xFF do CP1251_HIGH[b] = true end     -- А..я
+for _, b in ipairs{
+    0xA8,   -- Ё
+    0xB8,   -- ё
+    0xAB,   -- «
+    0xBB,   -- »
+    0x85,   -- …
+    0x93,   -- “
+    0x94,   -- ”
+    0x96,   -- –
+    0x97,   -- —
+    0xB9,   -- №  (0xB9 is № in cp1251, not the superscript one)
+} do CP1251_HIGH[b] = true end
+M.CP1251_HIGH = CP1251_HIGH
+
+-- ------------------------------------------------------------------- utf-8
+--
+-- A genuine cp1251 sentence is essentially never valid UTF-8: Cyrillic lands in
+-- 0xC0..0xFF, so every letter reads as a lead byte demanding continuations that
+-- the next letter does not supply. That makes "decodes cleanly as UTF-8" a
+-- sharp positive signal that the file was re-encoded, and it is the one check
+-- here that cannot be fooled by a lucky byte.
+
+local function is_valid_utf8(s)
+    local i, n = 1, #s
+    while i <= n do
+        local c = s:byte(i)
+        local extra
+        if c < 0x80 then extra = 0
+        elseif c >= 0xC2 and c <= 0xDF then extra = 1
+        elseif c >= 0xE0 and c <= 0xEF then extra = 2
+        elseif c >= 0xF0 and c <= 0xF4 then extra = 3
+        else return false                       -- continuation or overlong lead
+        end
+        for k = 1, extra do
+            local cc = s:byte(i + k)
+            if not cc or cc < 0x80 or cc > 0xBF then return false end
+        end
+        i = i + 1 + extra
+    end
+    return true
+end
+M.is_valid_utf8 = is_valid_utf8
+
+-- ------------------------------------------------------------------- report
+
+local BOMS = {
+    { name = "utf-8",    bytes = "\239\187\191" },
+    { name = "utf-16le", bytes = "\255\254"     },
+    { name = "utf-16be", bytes = "\254\255"     },
+}
+
+local function read_file(path)
+    local f = io.open(path, "rb")
+    if not f then return nil end
+    local src = f:read("*all")
+    f:close()
+    return src
+end
+M.read_file = read_file
+
+--- Everything worth asserting about one file, as plain data.
+---
+--- @return table|nil
+---   path       as given
+---   size       bytes
+---   bom        "utf-8" | "utf-16le" | "utf-16be" | nil
+---   declared   encoding= from the XML declaration, lowercased, or nil
+---   high       count of bytes >= 0x80
+---   illegal    { {offset=, byte=}, ... } bytes >= 0x80 not valid in cp1251,
+---              first few only
+---   utf8       true if the whole file decodes as UTF-8
+function M.inspect(path)
+    local src = read_file(path)
+    if not src then return nil end
+
+    local report = {
+        path = path, size = #src, high = 0, illegal = {}, bom = nil,
+    }
+
+    for _, bom in ipairs(BOMS) do
+        if src:sub(1, #bom.bytes) == bom.bytes then report.bom = bom.name break end
+    end
+
+    -- Only the declaration, and only if it is where XML requires it -- byte 0.
+    local decl = src:match("^<%?xml.-%?>")
+    if decl then
+        local enc = decl:match("encoding%s*=%s*[\"']([^\"']+)[\"']")
+        report.declared = enc and enc:lower() or nil
+        report.has_declaration = true
+    else
+        report.has_declaration = false
+    end
+
+    for i = 1, #src do
+        local b = src:byte(i)
+        if b >= 0x80 then
+            report.high = report.high + 1
+            if not CP1251_HIGH[b] and #report.illegal < 8 then
+                report.illegal[#report.illegal + 1] = { offset = i - 1, byte = b }
+            end
+        end
+    end
+
+    report.utf8 = report.high > 0 and is_valid_utf8(src) or false
+
+    return report
+end
+
+--- Language subdirectories of gamedata/configs/text. Discovered rather than
+--- listed so a new translation is covered without editing the harness -- the
+--- same bargain as spec discovery.
+function M.languages(text_dir)
+    local ok, pipe = pcall(io.popen,
+        'dir /b /ad "' .. text_dir:gsub("/", "\\") .. '" 2>nul')
+    if not ok or not pipe then return {} end
+
+    local found = {}
+    for line in pipe:lines() do
+        local name = line:gsub("%s+$", "")
+        if name ~= "" then found[#found + 1] = name end
+    end
+    pipe:close()
+    table.sort(found)
+    return found
+end
+
+--- A one-line description of a report, for assertion messages. Assertions read
+--- better against a string than a nested table, and the offset is what you need
+--- to find the damage.
+function M.describe(report)
+    local bits = { report.path }
+    bits[#bits + 1] = "declared=" .. tostring(report.declared)
+    bits[#bits + 1] = "bom=" .. tostring(report.bom)
+    bits[#bits + 1] = "high=" .. report.high
+    if report.utf8 then bits[#bits + 1] = "decodes as UTF-8" end
+    for _, bad in ipairs(report.illegal) do
+        bits[#bits + 1] = string.format("0x%02X@%d", bad.byte, bad.offset)
+    end
+    return table.concat(bits, " ")
+end
+
+return M

--- a/tests/harness/fakes.lua
+++ b/tests/harness/fakes.lua
@@ -1,0 +1,486 @@
+-- Fake engine globals: the minimum surface the baseline tests touch.
+--
+-- Deliberately small. The loader resolves unknown globals to nil rather than
+-- raising, so a missing fake shows up as a clear nil-index failure in the test
+-- that needs it -- add it then, not speculatively.
+--
+-- CAVEAT: these tests validate mod logic against OUR ASSUMPTIONS about the
+-- engine. A wrong constant here becomes a permanently green test. Every value
+-- below that came from the engine source is cited; values that are guesses are
+-- marked GUESS and should be pinned against a real game before being trusted.
+
+local M = {}
+
+M.calls = {}          -- recorder name -> list of arg tables
+
+-- ------------------------------------------------------------------ helpers
+
+local function recorder(name, ret)
+    M.calls[name] = {}
+    return function(...)
+        local t = M.calls[name]
+        t[#t + 1] = { n = select("#", ...), ... }
+        return ret
+    end
+end
+M.recorder = recorder
+
+function M.calls_to(name) return M.calls[name] or {} end
+function M.call_count(name) return #(M.calls[name] or {}) end
+function M.last_call(name)
+    local t = M.calls[name] or {}
+    return t[#t]
+end
+
+-- ------------------------------------------------------------- clock / RNG
+
+local now_ms = 0
+
+function M.set_time(ms) now_ms = ms end
+function M.advance_time(ms) now_ms = now_ms + ms end
+function M.now() return now_ms end
+
+-- Deterministic RNG control. The real math.random is never used in tests.
+local random_impl = nil
+
+-- Replace math.random wholesale with fn(...) -> number.
+function M.set_random(fn) random_impl = fn end
+
+-- Return values from `seq` in order. Errors past the end so an unexpected
+-- extra roll is a loud failure rather than a silent reuse.
+function M.set_random_sequence(seq)
+    local i = 0
+    random_impl = function()
+        i = i + 1
+        if seq[i] == nil then
+            error("math.random called " .. i .. " times but only " ..
+                  #seq .. " values were queued", 2)
+        end
+        return seq[i]
+    end
+end
+
+-- Always returns v, ignoring range args. Handy for "always pick bucket 1".
+function M.set_random_const(v)
+    random_impl = function() return v end
+end
+
+-- Real-ish deterministic fallback: lowest legal value for the given call form.
+function M.set_random_min()
+    random_impl = function(a, b)
+        if a == nil then return 0.0 end
+        if b == nil then return 1 end
+        return a
+    end
+end
+
+local function fake_random(a, b)
+    if not random_impl then
+        error("math.random called before fakes.set_random*() -- tests must be deterministic", 2)
+    end
+    return random_impl(a, b)
+end
+
+-- --------------------------------------------------------------- installer
+
+function M.install(env)
+    env = env or _G
+
+    ---- constants ------------------------------------------------------------
+
+    -- ALife::EHitType, xrServerEntities/alife_space.h:92. Exact values.
+    env.hit = {
+        burn          = 0,
+        shock         = 1,
+        chemical_burn = 2,
+        radiation     = 3,
+        telepatic     = 4,
+        wound         = 5,
+        fire_wound    = 6,
+        strike        = 7,
+        explosion     = 8,
+        wound_2       = 9,
+        light_burn    = 10,
+    }
+
+    env.AC_ID        = 0        -- actor id; 0 in Anomaly
+    env.GAME_VERSION = "test"
+    env.VEC_ZERO     = { x = 0, y = 0, z = 0 }
+
+    -- State-machine enums passed to npc:set_mental_state / set_body_state /
+    -- set_movement_type / set_sight by TrackAmbusher. Only identity matters --
+    -- specs assert which constant was handed over, never its numeric value.
+    env.anim = { look_around = 1, danger = 2, free = 3 }
+    env.move = { standing = 1, stand = 2, walk = 3, run = 4, crouch = 5 }
+    env.look = { search = 1, danger = 2, path_dir = 3 }
+
+    ---- clock / rng ----------------------------------------------------------
+
+    env.time_global = function() return now_ms end
+    math.random = fake_random           -- shared global table, as in-engine
+
+    ---- string ---------------------------------------------------------------
+
+    env.strformat = string.format
+
+    ---- level ----------------------------------------------------------------
+
+    -- Object registry backing level.object_by_id. Populate via M.register_object.
+    M.objects = {}
+
+    env.level = {
+        name              = function() return M.level_name end,
+        object_by_id      = function(id) return M.objects[id] end,
+        get_time_hours    = function() return M.time_hours end,
+        get_time_minutes  = function() return M.time_minutes end,
+        add_cam_effector       = recorder("level.add_cam_effector"),
+        add_pp_effector        = recorder("level.add_pp_effector"),
+        change_game_time       = recorder("level.change_game_time"),
+        map_add_object_spot_ser= recorder("level.map_add_object_spot_ser"),
+        map_remove_object_spot = recorder("level.map_remove_object_spot"),
+    }
+    M.level_name   = "zaton"
+    M.time_hours   = 12
+    M.time_minutes = 30
+
+    ---- game -----------------------------------------------------------------
+
+    -- Identity translation keeps message assertions readable: an assertion
+    -- reads as the string id, not a localized sentence.
+    env.game = {
+        translate_string = function(s) return s end,
+        get_game_time    = function()
+            return { get = function(_, Y, M_, D, h) return 2012, 5, 12, 14 end }
+        end,
+    }
+
+    ---- db -------------------------------------------------------------------
+
+    env.db = {
+        actor          = nil,      -- set per-test via M.set_actor
+        storage        = {},
+        OnlineStalkers = {},
+    }
+
+    ---- predicates -----------------------------------------------------------
+    --
+    -- Objects built by builders.lua carry a `_kind` tag; these read it. Real
+    -- engine predicates dispatch on clsid, which we do not model.
+
+    local function kind_is(k)
+        return function(obj, cls)
+            if obj == nil then return false end
+            return obj._kind == k
+        end
+    end
+
+    env.IsStalker  = kind_is("stalker")
+    env.IsMonster  = kind_is("monster")
+    env.IsAnomaly  = kind_is("anomaly")
+    env.IsWeapon   = kind_is("weapon")
+    env.IsOutfit   = kind_is("outfit")
+    env.IsHeadgear = kind_is("headgear")
+    env.IsArtefact = kind_is("artefact")
+    env.IsGrenade  = kind_is("grenade")
+    env.IsInvbox   = kind_is("invbox")
+    env.IsToolkit  = function(o, s) return (o and o._kind == "toolkit") or false end
+
+    -- SYS_GetParam(type, section, param) -> ltx lookup. Backed by M.ltx.
+    M.ltx = {}
+    env.SYS_GetParam = function(_, section, param)
+        local sec = M.ltx[section]
+        return sec and sec[param] or nil
+    end
+
+    ---- module stubs ---------------------------------------------------------
+
+    env.utils_data = { debug_write = recorder("debug_write") }
+
+    env.news_manager = {
+        send_tip   = recorder("send_tip"),
+        tips_icons = setmetatable({}, { __index = function() return "icon" end }),
+    }
+
+    env.actor_menu    = { set_msg = recorder("set_msg") }
+    env.exec_console_cmd = recorder("exec_console_cmd")
+
+    env.utils_xml = {
+        get_color       = function(c) return "%c[" .. tostring(c) .. "]" end,
+        get_special_txt = function(s) return tostring(s) end,
+        is_widescreen   = function() return false end,
+    }
+
+    -- Single most valuable fake: every one of soulslike_mcm's 60+ getters
+    -- funnels through ui_mcm.get (soulslike_mcm.script:939), so faking this one
+    -- function makes the real 1215-line MCM module work. Returning nil for a
+    -- key exercises that getter's declared default.
+    M.mcm = {}
+    env.ui_mcm = {
+        get = function(path) return M.mcm[path] end,
+    }
+
+    -- Backs soulslike.get_soulslike_state().
+    M.game_state = {}
+    env.alife_storage_manager = {
+        get_state = function() return M.game_state end,
+        decode    = function(_) return nil end,
+    }
+
+    env.alife = function() return M.sim end
+    M.sim = nil
+
+    ---- persistence ----------------------------------------------------------
+
+    -- Real storage, not no-ops: HealActor writes grw_in_water
+    -- (soulslike_scenarios.script:376) and create_new reads it
+    -- (soulslike_scenario_logic_factory.script:343), so the round-trip has to
+    -- work or that branch is untestable.
+    M.vars = {}
+    env.save_var = function(obj, key, value)
+        local id = obj and (type(obj.id) == "function" and obj:id() or obj.id) or "_"
+        M.vars[id] = M.vars[id] or {}
+        M.vars[id][key] = value
+    end
+    env.load_var = function(obj, key, default)
+        local id = obj and (type(obj.id) == "function" and obj:id() or obj.id) or "_"
+        local t = M.vars[id]
+        local v = t and t[key]
+        if v == nil then return default end
+        return v
+    end
+
+    ---- info portions / story ------------------------------------------------
+
+    M.infos = {}          -- info_id -> true
+    M.story_ids = {}      -- object id -> story id
+
+    env.has_alife_info    = function(id) return M.infos[id] == true end
+    env.disable_info      = function(id) M.infos[id] = nil end
+    env.give_info_portion = function(id) M.infos[id] = true end
+    env.get_object_story_id = function(id) return M.story_ids[id] end
+
+    ---- misc engine globals --------------------------------------------------
+
+    env.printf     = function() end
+    env.normalize  = function(v, lo, hi)
+        if hi == lo then return 0 end
+        return (v - lo) / (hi - lo)
+    end
+    env.bit_or     = function(a, b) return a + b end   -- flag combining only
+    env.hide_hud_inventory = recorder("hide_hud_inventory")
+    env.get_console_cmd    = function(_, name) return M.console[name] end
+    M.console = { snd_volume_music = 1, snd_volume_eff = 1 }
+
+    env.ChangeLevel = recorder("ChangeLevel")
+
+    env.device = function()
+        return {
+            is_paused = function() return M.paused end,
+            pause     = function(_, v) M.paused = v end,
+        }
+    end
+    M.paused = false
+
+    -- game_graph():vertex(id):level_id()
+    env.game_graph = function()
+        return {
+            vertex = function(_, gvid)
+                return { level_id = function() return M.gvid_level[gvid] or 1 end }
+            end,
+        }
+    end
+    M.gvid_level = {}
+
+    -- system.ltx reader. Backed by the same M.ltx table SYS_GetParam uses.
+    env.ini_sys = {
+        r_string_ex = function(_, section, key, default)
+            local sec = M.ltx[section]
+            local v = sec and sec[key]
+            if v == nil then return default end
+            return v
+        end,
+        r_bool_ex = function(_, section, key, default)
+            local sec = M.ltx[section]
+            local v = sec and sec[key]
+            if v == nil then return default end
+            return v == true or v == "true" or v == 1
+        end,
+    }
+
+    env.SIMBOARD = { setup_squad_and_group = recorder("setup_squad_and_group") }
+
+    ---- file system ----------------------------------------------------------
+    --
+    -- Only what on_console_execute's save-pruning walk touches
+    -- (soulslike.script:652-695). M.saves maps a bare file name to its decoded
+    -- save table, so a spec can stage siblings with matching/mismatching uuids.
+
+    M.saves = {}
+    env.FS = { FS_ListFiles = 1, FS_RootOnly = 2 }
+    env.getFS = function()
+        return {
+            update_path = function(_, _, tail) return "saves/" .. tostring(tail) end,
+            file_copy   = recorder("fs.file_copy"),
+            file_list_open_ex = function()
+                local names = {}
+                for name in pairs(M.saves) do names[#names + 1] = name end
+                table.sort(names)
+                return {
+                    Size  = function() return #names end,
+                    GetAt = function(_, i)
+                        local n = names[i + 1]
+                        return { NameFull = function() return n .. ".scoc" end }
+                    end,
+                }
+            end,
+        }
+    end
+
+    ---- module stubs (engine-side scripts the mod calls into) ----------------
+
+    env.xr_effects = {
+        enable_ui  = recorder("xr_effects.enable_ui"),
+        disable_ui = recorder("xr_effects.disable_ui"),
+    }
+
+    env.bind_stalker_ext = { invulnerable_time = 0 }
+
+    env.level_weathers = { valid_levels = { zaton = true, jupiter = true,
+                                            pripyat = true, escape = true } }
+
+    env.actor_status = {
+        activate_hud   = recorder("actor_status.activate_hud"),
+        deactivate_hud = recorder("actor_status.deactivate_hud"),
+    }
+
+    env.game_statistics = {
+        increment_statistic        = recorder("increment_statistic"),
+        get_statistic_count        = function() return M.stats_count end,
+        check_for_rank_change      = recorder("check_for_rank_change"),
+        check_for_reputation_change= recorder("check_for_reputation_change"),
+    }
+    M.stats_count = 1
+
+    -- utils_item.degrade RELEASES the item when its condition reaches 0.
+    -- ApplyItemConditionLoss depends on that: it is how story.items_were_lost
+    -- gets set for gear degraded into nothing (soulslike_scenarios.script:460).
+    -- Returning a number without destroying anything would make that branch
+    -- untestable.
+    env.utils_item = {
+        is_degradable = function(item, sec)
+            local t = M.ltx[sec or (item and item:section())]
+            if t and t.degradable ~= nil then return t.degradable end
+            return true
+        end,
+        degrade = function(item, percent)
+            local cond = item:condition() * (1 - (percent or 0))
+            if cond < 0.005 then cond = 0 end
+            item._condition = cond
+            if cond == 0 and _G.alife_release then _G.alife_release(item) end
+            return cond
+        end,
+    }
+
+    env.ui_item        = { get_sec_name = function(s) return s end }
+    env.ui_load_dialog = { delete_save_game = recorder("delete_save_game") }
+    env.utils_obj      = { graph_distance = function() return M.graph_distance end }
+    M.graph_distance   = 500
+    env.utils_stpk     = {
+        get_item_data = function() return {} end,
+        set_item_data = recorder("set_item_data"),
+    }
+    env.simulation_objects = { is_on_the_same_level = function() return true end }
+    env.surge_manager      = { stop_surge = recorder("stop_surge") }
+    env.psi_storm_manager  = {
+        get_psi_storm_manager = function()
+            return { started = M.psi_storm_started, finish = recorder("psi_storm.finish") }
+        end,
+    }
+    M.psi_storm_started = false
+
+    env.IsHardcoreMode = function() return M.hardcore_mode end
+    M.hardcore_mode = false
+    -- IsItem(kind, section) -- used by soulslike_note to test for "letter"
+    env.IsItem = function(kind, section, obj)
+        local sec = section or (obj and obj:section())
+        local t = M.ltx[sec]
+        return (t and t.kind) == kind
+    end
+
+    -- axr_main.config: IsSoulslikeMode reads new_game_soulslike_mode from it
+    -- (soulslike.script:193). axr_main itself is created by dispatch.install,
+    -- so extend rather than replace.
+    env.axr_main = env.axr_main or {}
+    M.config = {}
+    env.axr_main.config = {
+        r_value = function(_, sec, key, _, default)
+            local t = M.config[sec]
+            local v = t and t[key]
+            if v == nil then return default end
+            return v
+        end,
+        w_value = function(_, sec, key, value)
+            M.config[sec] = M.config[sec] or {}
+            M.config[sec][key] = value
+        end,
+        save = recorder("axr_main.config.save"),
+        section_exist = function(_, sec) return M.config[sec] ~= nil end,
+    }
+
+    return env
+end
+
+-- ------------------------------------------------------------ per-test setup
+
+function M.set_actor(actor) _G.db.actor = actor end
+
+function M.register_object(obj)
+    assert(obj and obj.id, "register_object needs an object with an id() or id field")
+    local id = type(obj.id) == "function" and obj:id() or obj.id
+    M.objects[id] = obj
+    return obj
+end
+
+-- Set an MCM value as ui_mcm.get would return it. Key omits the "soulslike/"
+-- prefix that get_config prepends.
+function M.set_mcm(key, value) M.mcm["soulslike/" .. key] = value end
+
+function M.set_ltx(section, params) M.ltx[section] = params end
+
+function M.set_info(id, on) M.infos[id] = on and true or nil end
+function M.set_config(section, key, value)
+    M.config[section] = M.config[section] or {}
+    M.config[section][key] = value
+end
+
+-- Enable soulslike mode the way the mod actually detects it
+-- (soulslike.script:192): either the character-creation config flag or the
+-- persisted save flag. Nearly every handler early-returns without this.
+function M.enable_soulslike_mode()
+    M.set_config("character_creation", "new_game_soulslike_mode", true)
+end
+
+function M.reset()
+    M.calls = {}
+    M.objects = {}
+    M.ltx = {}
+    M.mcm = {}
+    M.game_state = {}
+    M.sim = nil
+    M.vars = {}
+    M.infos = {}
+    M.story_ids = {}
+    M.saves = {}
+    M.config = {}
+    M.gvid_level = {}
+    M.paused = false
+    M.hardcore_mode = false
+    M.psi_storm_started = false
+    M.stats_count = 1
+    M.graph_distance = 500
+    now_ms = 0
+    random_impl = nil
+    M.install(_G)
+end
+
+return M

--- a/tests/harness/fakes.lua
+++ b/tests/harness/fakes.lua
@@ -74,12 +74,42 @@ function M.set_random_min()
     end
 end
 
+-- Count of math.random calls since the last reset. Lets a spec assert an exact
+-- RNG budget without consuming a queued value, which matters because several
+-- mod functions short-circuit before rolling (IsItemLossAllowed spends 0 or 1
+-- roll depending on the item category).
+local random_calls = 0
+function M.random_count() return random_calls end
+
 local function fake_random(a, b)
     if not random_impl then
         error("math.random called before fakes.set_random*() -- tests must be deterministic", 2)
     end
+    random_calls = random_calls + 1
     return random_impl(a, b)
 end
+
+-- ------------------------------------------------------------------ clsids
+--
+-- The real Is* predicates take (obj, cls) and resolve `cls or obj:clsid()`
+-- against a class table (_g.script:3081 for IsWeapon). Callers do pass obj=nil
+-- with an explicit clsid -- soulslike.find_closest_enemy:307 scans server
+-- objects that way -- so we keep a clsid -> kind registry.
+--
+-- Values are opaque strings, never numbers. Engine clsids are the runtime
+-- ordinal of the class in the sorted registry
+-- (xray-monolith/src/xrServerEntities/object_factory_script.cpp:85), so a spec
+-- that hardcoded a number would be asserting a fiction.
+
+M.clsid_kind = {}
+for _, k in ipairs{ "stalker", "monster", "anomaly", "weapon", "outfit",
+                    "headgear", "artefact", "grenade", "invbox", "toolkit" } do
+    M.clsid_kind["cls_" .. k] = k
+end
+
+--- The opaque clsid standing in for `kind`. Fixtures return this from
+--- :clsid() so the Is* predicates classify them correctly.
+function M.clsid_for(kind) return "cls_" .. tostring(kind) end
 
 -- --------------------------------------------------------------- installer
 
@@ -164,11 +194,20 @@ function M.install(env)
 
     ---- predicates -----------------------------------------------------------
     --
-    -- Objects built by builders.lua carry a `_kind` tag; these read it. Real
-    -- engine predicates dispatch on clsid, which we do not model.
-
+    -- Objects built by builders.lua carry a `_kind` tag; these read it.
+    --
+    -- The real predicates take (obj, cls) and resolve `cls or obj:clsid()`
+    -- against a class table (_g.script:3081 for IsWeapon). The clsid argument
+    -- wins when both are given, and callers do pass obj=nil with an explicit
+    -- clsid -- soulslike.find_closest_enemy:307 scans server objects that way.
+    -- So we keep a clsid -> kind registry and dispatch on it first; a nil obj
+    -- with no clsid is false.
+    --
+    -- The registry itself lives at module scope (see M.clsid_for) so fixtures
+    -- can reach it before install() has run.
     local function kind_is(k)
         return function(obj, cls)
+            if cls ~= nil then return M.clsid_kind[cls] == k end
             if obj == nil then return false end
             return obj._kind == k
         end
@@ -177,6 +216,12 @@ function M.install(env)
     env.IsStalker  = kind_is("stalker")
     env.IsMonster  = kind_is("monster")
     env.IsAnomaly  = kind_is("anomaly")
+    -- Grenades are NOT weapons at either layer: CGrenade derives from CMissile,
+    -- not CWeapon (xray-monolith/src/xrGame/Grenade.h:6), and Anomaly's Lua
+    -- weapon_classes table contains no grenade clsids (_g.script:3081-3149).
+    -- The mod's `IsWeapon(item) and not is_grenade` idiom is therefore
+    -- redundant, not load-bearing -- do not "fix" this by making the two
+    -- predicates overlap.
     env.IsWeapon   = kind_is("weapon")
     env.IsOutfit   = kind_is("outfit")
     env.IsHeadgear = kind_is("headgear")
@@ -315,6 +360,9 @@ function M.install(env)
     -- (soulslike.script:652-695). M.saves maps a bare file name to its decoded
     -- save table, so a spec can stage siblings with matching/mismatching uuids.
 
+    -- The walk does a real io.open on each .scoc before decoding it, so without
+    -- a shim the loop body never executes and the whole path is untestable.
+    -- install_save_fs() below supplies one.
     M.saves = {}
     env.FS = { FS_ListFiles = 1, FS_RootOnly = 2 }
     env.getFS = function()
@@ -453,6 +501,81 @@ function M.set_config(section, key, value)
     M.config[section][key] = value
 end
 
+--- The level name level.name() reports. Drives create_new's indoor branch,
+--- which keys off level_weathers.valid_levels.
+function M.set_level(name) M.level_name = name end
+
+-- ------------------------------------------------------------- save files
+--
+-- on_console_execute's pruning walk (soulslike.script:658-695) reads each
+-- sibling save off disk with io.open before handing the bytes to
+-- alife_storage_manager.decode. Both have to work or the loop body is dead.
+--
+-- The "bytes" are an opaque token rather than a real serialization: the mod
+-- only ever round-trips them straight back through decode, so modelling the
+-- save format would be effort spent asserting our own encoder.
+
+local real_io_open = io.open
+local save_fs_installed = false
+
+local function save_name_from_path(path)
+    return tostring(path):match("^saves/([^/]+)%.scoc$")
+end
+
+--- Stage a sibling save. `decoded` is the table decode() will return, e.g.
+--- { soulslike = { uuid = "..." } }. Pass nil to model an unreadable file.
+function M.set_save(name, decoded)
+    M.saves[name] = decoded or false
+end
+
+--- Route saves/<name>.scoc through M.saves; everything else falls through to
+--- the real io.open, which the module loader still needs (loader.lua:83).
+function M.install_save_fs()
+    if save_fs_installed then return end
+    save_fs_installed = true
+
+    io.open = function(path, mode, ...)
+        local name = save_name_from_path(path)
+        if name == nil then return real_io_open(path, mode, ...) end
+
+        local decoded = M.saves[name]
+        if decoded == nil or decoded == false then return nil end
+
+        local closed = false
+        return {
+            read  = function() return "SAVEBLOB:" .. name end,
+            close = function() closed = true end,
+            _closed = function() return closed end,
+        }
+    end
+
+    _G.alife_storage_manager.decode = function(blob)
+        local name = tostring(blob):match("^SAVEBLOB:(.+)$")
+        local decoded = name and M.saves[name]
+        if decoded == false then return nil end
+        return decoded
+    end
+end
+
+local function uninstall_save_fs()
+    if not save_fs_installed then return end
+    io.open = real_io_open
+    save_fs_installed = false
+end
+
+--- Populate db.OnlineStalkers (and db.storage, which is consulted first).
+--- These are the only inputs to find_closest_enemy_stalker /
+--- find_closest_friendly_stalker (soulslike.script:370, :395).
+function M.set_online_stalkers(list)
+    _G.db.OnlineStalkers = {}
+    for _, npc in ipairs(list or {}) do
+        local id = type(npc.id) == "function" and npc:id() or npc.id
+        _G.db.OnlineStalkers[#_G.db.OnlineStalkers + 1] = id
+        _G.db.storage[id] = { object = npc }
+        M.register_object(npc)
+    end
+end
+
 -- Enable soulslike mode the way the mod actually detects it
 -- (soulslike.script:192): either the character-creation config flag or the
 -- persisted save flag. Nearly every handler early-returns without this.
@@ -461,6 +584,7 @@ function M.enable_soulslike_mode()
 end
 
 function M.reset()
+    uninstall_save_fs()
     M.calls = {}
     M.objects = {}
     M.ltx = {}
@@ -480,6 +604,7 @@ function M.reset()
     M.graph_distance = 500
     now_ms = 0
     random_impl = nil
+    random_calls = 0
     M.install(_G)
 end
 

--- a/tests/harness/init.lua
+++ b/tests/harness/init.lua
@@ -149,8 +149,12 @@ end
 --- Advance one frame: drain deferred time events, then apply the queued
 --- inventory mutations they produced. Assertions about item placement belong
 --- AFTER this call -- see the deferred-mutation note in world.lua.
-function M.tick()
-    local events = M.timeevents.pump()
+---
+--- By default this runs to completion and raises if anything is still waiting.
+--- Pass `{ passes = 1 }` to run a bounded number of frames and leave the rest
+--- queued, which is how a spec observes a retrying event mid-wait.
+function M.tick(opts)
+    local events = M.timeevents.pump(opts)
     local ops = M.world.pump()
     return events, ops
 end

--- a/tests/harness/init.lua
+++ b/tests/harness/init.lua
@@ -1,0 +1,119 @@
+-- Harness bootstrap. Require this first from any spec file.
+--
+--   local H = require("harness.init")
+--   -- describe / it / beforeEach / expect are now ambient globals
+--
+--   describe("thing", function()
+--     beforeEach(function() H.boot{ load = {"soulslike"} } end)
+--     it("does the thing", function() expect(x).toBe(y) end)
+--   end)
+
+local M = {}
+
+M.spec       = require("harness.spec")
+M.class      = require("harness.class")
+M.loader     = require("harness.loader")
+M.dispatch   = require("harness.dispatch")
+M.fakes      = require("harness.fakes")
+M.builders   = require("harness.builders")
+M.timeevents = require("harness.timeevents")
+M.world      = require("harness.world")
+M.mods       = require("harness.mods")
+
+-- describe/it/expect as ambient globals, the way a TS suite gets them.
+M.spec.install(_G)
+
+-- tests/ ... /gamedata/scripts
+local function default_script_dir()
+    local base = os.getenv("SOULSLIKE_TESTS_DIR")
+    if base and base ~= "" then
+        return base .. "/../gamedata/scripts"
+    end
+    return "../gamedata/scripts"
+end
+
+M.booted = false
+
+--- boot{ load = {...}, actor = {...}, soulslike_mode = true, mods = {...} }
+---
+--- `load` names are loaded in order (dependency order, not alphabetical).
+--- `mods` are enabled BEFORE those scripts load, which matters for
+--- demonized_time_events -- soulslike_scenarios captures it at file scope.
+function M.boot(opts)
+    opts = opts or {}
+
+    M.fakes.reset()
+    M.class.install(_G)
+    M.builders.install(_G)
+    M.dispatch.reset()
+    M.dispatch.install(_G)
+
+    M.timeevents.reset()
+    M.timeevents.install(_G)
+
+    M.world.reset()
+    M.world.install(_G)
+
+    -- Base-Anomaly scripts first (every install has them; two are called
+    -- unguarded), then any third-party ones this spec asked for. Both happen
+    -- before the mod scripts load, which matters for demonized_time_events --
+    -- soulslike_scenarios captures it at file scope.
+    M.mods.reset()
+    M.mods.install_base()
+    for _, name in ipairs(opts.mods or {}) do M.mods.enable(name) end
+    for _, name in ipairs(opts.without or {}) do M.mods.disable(name) end
+
+    M.builders.strict_vectors = opts.strict_vectors ~= false
+
+    M.loader.reset()
+    M.loader.init{
+        script_dir = opts.script_dir or default_script_dir(),
+        autoload   = opts.autoload,
+    }
+    -- Strict is applied after the mod scripts load, never during: loading them
+    -- legitimately touches globals that are meant to resolve to nil.
+    M.loader.strict = false
+
+    -- Load order is dependency-driven, not alphabetical: soulslike.script
+    -- constructs a TimedQueue at file scope (soulslike.script:58), so
+    -- soulslike_classes must exist first. Autoload would cover it, but being
+    -- explicit makes a load failure point at the right file.
+    for _, name in ipairs(opts.load or {}) do
+        local mod = M.loader.load(name)
+        if not mod then
+            error("harness: could not load mod script '" .. name .. "' from " ..
+                  M.loader.script_dir, 0)
+        end
+    end
+
+    if opts.actor ~= false then
+        M.set_actor(opts.actor or {})
+    end
+
+    if opts.soulslike_mode then M.fakes.enable_soulslike_mode() end
+
+    M.loader.strict = opts.strict == true
+
+    M.booted = true
+    return M
+end
+
+--- Create the actor, register it, and wire its inventory into the world model.
+function M.set_actor(opts)
+    local actor = M.builders.make_actor(opts or {})
+    M.fakes.set_actor(actor)
+    M.fakes.register_object(actor)
+    M.world.attach_actor(actor, "actor")
+    return actor
+end
+
+--- Advance one frame: drain deferred time events, then apply the queued
+--- inventory mutations they produced. Assertions about item placement belong
+--- AFTER this call -- see the deferred-mutation note in world.lua.
+function M.tick()
+    local events = M.timeevents.pump()
+    local ops = M.world.pump()
+    return events, ops
+end
+
+return M

--- a/tests/harness/init.lua
+++ b/tests/harness/init.lua
@@ -43,7 +43,12 @@ function M.boot(opts)
     opts = opts or {}
 
     M.fakes.reset()
+    -- fakes.game_state is the WHOLE save table; the mod keeps its own state
+    -- under the "soulslike" key (soulslike.script:210). opts.state seeds that
+    -- sub-table, which is what a spec means by "the saved state".
+    if opts.state then M.fakes.game_state.soulslike = opts.state end
     M.class.install(_G)
+    M.builders.reset()
     M.builders.install(_G)
     M.dispatch.reset()
     M.dispatch.install(_G)
@@ -105,6 +110,40 @@ function M.set_actor(opts)
     M.fakes.register_object(actor)
     M.world.attach_actor(actor, "actor")
     return actor
+end
+
+--- Record a spawn point into the save, as set_spawn does
+--- (soulslike.script:207-265). Any spec reaching create_new or RespawnActor
+--- needs one: without it both build a vector out of nil coordinates, which
+--- strict_vectors raises on and the engine would hard-crash on.
+function M.set_spawn(opts)
+    local save = M.fakes.game_state
+    save.soulslike = save.soulslike or {}
+    save.soulslike.spawn_location = M.builders.make_spawn_location(opts)
+    return save.soulslike.spawn_location
+end
+
+--- Re-boot with the same options while preserving the save table, modelling a
+--- level change: every script re-executes and every module table is discarded,
+--- but alife_storage_manager's state survives.
+---
+--- This is what makes the save/load round-trip testable -- a plain M.boot()
+--- wipes game_state, so the "reload" would have nothing to restore from.
+--- Persisted-var and info-portion stores are carried across for the same
+--- reason; they live in the save too.
+function M.reboot(opts)
+    local saved = {
+        state = M.fakes.game_state,
+        vars  = M.fakes.vars,
+        infos = M.fakes.infos,
+    }
+
+    M.boot(opts)
+
+    M.fakes.game_state = saved.state
+    M.fakes.vars       = saved.vars
+    M.fakes.infos      = saved.infos
+    return M
 end
 
 --- Advance one frame: drain deferred time events, then apply the queued

--- a/tests/harness/loader.lua
+++ b/tests/harness/loader.lua
@@ -1,0 +1,237 @@
+-- Reproduces the X-Ray engine's script module loader.
+--
+-- Two engine behaviors are replicated here, and getting either wrong produces
+-- tests that pass for the wrong reason:
+--
+-- 1. The namespace wrapper (xrServerEntities/script_storage.cpp:608 load_buffer,
+--    using `file_header_old` at :22). Every .script file is textually prefixed
+--    with:
+--
+--      local function script_name() return "<name>" end
+--      local this = {}
+--      <name>= this
+--      setmetatable(this, {__index = _G})
+--      setfenv(1, this)
+--
+--    The `<name>= this` fragment is built by parse_namespace() (:575) and runs
+--    *before* setfenv, so it lands in _G. Consequences the mod relies on:
+--
+--      RELATIONS = {...}          -> soulslike.RELATIONS  (module-local)
+--      function debug(o)          -> soulslike.debug      (shadows stdlib debug
+--                                                          inside that module)
+--      function math.clamp(...)   -> mutates the SHARED global math table
+--                                    (read falls through __index, write lands
+--                                     on the real table)
+--      function _G.IsSoulslikeMode() -> true global
+--
+--    The engine's header is a single C string built from backslash line
+--    continuations, so it contains no newlines. We match that: the prologue
+--    adds zero lines, keeping runtime line numbers aligned with the source file.
+--
+-- 2. Lazy autoload (xrServerEntities/script_engine.cpp:257 auto_load, installed
+--    at :270). Reading an undefined global attempts to load "<key>.script" and
+--    then rawgets. A missing file resolves to nil -- it does NOT raise.
+
+local M = {}
+
+M.script_dir = nil          -- set via M.init{}
+M.loaded = {}               -- name -> true
+M.load_order = {}           -- chronological, for assertions
+M.missing = {}              -- names that autoload tried and failed to find
+
+local loading = {}          -- reentrancy guard
+local installed = false
+
+-- Mirrors CScriptStorage::parse_namespace (script_storage.cpp:575).
+-- "soulslike"  -> b="soulslike=",     c=""
+-- "a.b"        -> b="a={b=",          c="}"
+local function parse_namespace(name)
+    local b, c = "", ""
+    local rest = name
+    local i = 0
+    while true do
+        if rest == "" then
+            return nil, "the namespace name " .. name .. " is incorrect!"
+        end
+        local head, tail = rest:match("^([^.]*)%.(.*)$")
+        if not head then head, tail = rest, nil end
+
+        if i > 0 then b = b .. "{" end
+        b = b .. head .. "="
+        if i > 0 then c = "}" .. c end
+
+        if tail then rest, i = tail, i + 1 else break end
+    end
+    return b, c
+end
+M.parse_namespace = parse_namespace
+
+-- Single-line, exactly like the engine's file_header_old.
+local function build_prologue(name)
+    local b, c = parse_namespace(name)
+    if not b then error(c, 0) end
+    return table.concat({
+        ' local function script_name() return "', name, '" end ',
+        ' local this = {} ',
+        b, ' this ', c, ' ',
+        ' setmetatable(this, {__index = _G}) ',
+        ' setfenv(1, this) ',
+    })
+end
+M.build_prologue = build_prologue
+
+local function read_file(path)
+    local f = io.open(path, "rb")
+    if not f then return nil end
+    local src = f:read("*all")
+    f:close()
+    return src
+end
+
+function M.script_path(name)
+    assert(M.script_dir, "loader.init{script_dir=...} was never called")
+    return M.script_dir .. "/" .. name .. ".script"
+end
+
+function M.exists(name)
+    local f = io.open(M.script_path(name), "rb")
+    if f then f:close() return true end
+    return false
+end
+
+-- Loads <name>.script into the global namespace <name>. Returns the module
+-- table, or nil if the file does not exist (matching engine behavior: absence
+-- is not an error).
+function M.load(name)
+    if M.loaded[name] then return rawget(_G, name) end
+    if loading[name] then return rawget(_G, name) end   -- circular reference
+
+    local path = M.script_path(name)
+    local src = read_file(path)
+    if not src then
+        M.missing[name] = true
+        return nil
+    end
+
+    loading[name] = true
+    local chunk, err = loadstring(build_prologue(name) .. src, "@" .. path)
+    if not chunk then
+        loading[name] = nil
+        error("syntax error loading " .. path .. ": " .. tostring(err), 0)
+    end
+
+    local ok, rerr = pcall(chunk)
+    loading[name] = nil
+    if not ok then
+        error("error executing " .. path .. ": " .. tostring(rerr), 0)
+    end
+
+    M.loaded[name] = true
+    M.load_order[#M.load_order + 1] = name
+    return rawget(_G, name)
+end
+
+-- Strict mode: raise on a global that resolved to nil, instead of silently
+-- handing back nil the way the engine does. A forgotten fake otherwise
+-- surfaces as a confusing nil-index several frames downstream.
+--
+-- Off by default, because nil-tolerance IS the engine's real behavior and the
+-- mod relies on it -- soulslike_scenarios.script:113 reads
+-- `local dte = demonized_time_events` for a mod that may not be installed.
+-- Registered soft dependencies are therefore always exempt.
+M.strict = false
+
+local STRICT_EXEMPT = {
+    -- Lua/LuaJIT internals and harness plumbing that legitimately probe _G.
+    _PROMPT = true, _PROMPT2 = true, jit = true, arg = true,
+}
+
+local function strict_exempt(k)
+    if STRICT_EXEMPT[k] then return true end
+    local ok, mods = pcall(require, "harness.mods")
+    if ok then
+        for _, name in ipairs(mods.NAMES) do
+            if k == name or k == "dte" then return true end
+        end
+    end
+    return false
+end
+
+-- Installs the _G.__index autoload metamethod (script_engine.cpp:257).
+function M.install_autoload()
+    if installed then return end
+    installed = true
+
+    local mt = getmetatable(_G) or {}
+    local prev_index = mt.__index
+
+    mt.__index = function(t, k)
+        if type(k) == "string"
+           and not M.loaded[k]
+           and not M.missing[k]
+           and not loading[k]
+           and M.script_dir
+        then
+            M.load(k)
+        end
+        local v = rawget(t, k)
+        if v ~= nil then return v end
+        if prev_index then
+            if type(prev_index) == "function" then
+                v = prev_index(t, k)
+                if v ~= nil then return v end
+            else
+                v = prev_index[k]
+                if v ~= nil then return v end
+            end
+        end
+
+        if M.strict and type(k) == "string" and not strict_exempt(k) then
+            error("strict: undefined global '" .. k .. "' -- no fake provides it " ..
+                  "and no " .. k .. ".script exists. Add it to harness/fakes.lua, " ..
+                  "or boot without strict = true if nil is the correct answer.", 2)
+        end
+        return nil
+    end
+
+    setmetatable(_G, mt)
+end
+
+function M.init(opts)
+    M.script_dir = assert(opts.script_dir, "script_dir is required")
+    if opts.autoload ~= false then M.install_autoload() end
+    return M
+end
+
+-- Test aid: reach a file-local function through the upvalues of an exported
+-- one. `local function f` at file scope becomes an upvalue of any exported
+-- function that references it, so no mod source change is needed to test it.
+--
+-- Must be called from the *test* environment: soulslike.script defines
+-- `function debug(output)`, which shadows the stdlib debug table inside that
+-- module's environment.
+function M.upvalue(fn, name)
+    assert(type(fn) == "function", "upvalue() expects a function")
+    for i = 1, math.huge do
+        local n, v = debug.getupvalue(fn, i)
+        if not n then break end
+        if n == name then return v end
+    end
+    return nil
+end
+
+function M.upvalue_names(fn)
+    local names = {}
+    for i = 1, math.huge do
+        local n = debug.getupvalue(fn, i)
+        if not n then break end
+        names[#names + 1] = n
+    end
+    return names
+end
+
+function M.reset()
+    M.loaded, M.load_order, M.missing, loading = {}, {}, {}, {}
+end
+
+return M

--- a/tests/harness/loader.lua
+++ b/tests/harness/loader.lua
@@ -112,23 +112,44 @@ end
 
 --- Every <string id> in one language's tables, as a set. Missing files are
 --- skipped: a mod need not ship every language.
+---
+--- Returns `ids, duplicates`. A set discards repeats, and a repeated id is not
+--- harmless: the engine keeps one <text> and drops the rest, so a block that
+--- was copy-pasted and never renamed silently takes the place of the string it
+--- was supposed to become. Nothing else in the suite can see that -- the id
+--- resolves, so every label check stays green -- which is why the count comes
+--- back alongside the set rather than being thrown away here.
+---
+--- Each duplicate entry: { id, file, count }.
 function M.load_string_table(lang, files)
-    local ids = {}
+    local ids, seen, dups = {}, {}, {}
     local dir = M.text_dir() .. "/" .. (lang or "eng")
 
     for _, name in ipairs(files or M.string_table_files(lang)) do
         local src = read_file(dir .. "/" .. name)
         if src then
-            for id in src:gmatch('<string%s+id%s*=%s*"([^"]+)"') do
-                ids[id] = true
+            local function collect(pattern)
+                for id in src:gmatch(pattern) do
+                    ids[id] = true
+                    local at = seen[id]
+                    if at then
+                        at.count = at.count + 1
+                    else
+                        seen[id] = { id = id, file = name, count = 1 }
+                    end
+                end
             end
-            for id in src:gmatch("<string%s+id%s*=%s*'([^']+)'") do
-                ids[id] = true
-            end
+            collect('<string%s+id%s*=%s*"([^"]+)"')
+            collect("<string%s+id%s*=%s*'([^']+)'")
         end
     end
 
-    return ids
+    for _, at in pairs(seen) do
+        if at.count > 1 then dups[#dups + 1] = at end
+    end
+    table.sort(dups, function(a, b) return a.id < b.id end)
+
+    return ids, dups
 end
 
 --- The .xml files present for a language. Discovered the same way spec files

--- a/tests/harness/loader.lua
+++ b/tests/harness/loader.lua
@@ -93,6 +93,62 @@ function M.script_path(name)
     return M.script_dir .. "/" .. name .. ".script"
 end
 
+-- ------------------------------------------------------------ string tables
+--
+-- Anomaly's localisation lives in gamedata/configs/text/<lang>/*.xml as
+-- <string id="..."><text>...</text></string>. MCM resolves an option's label
+-- through game.translate_string, and a miss shows the raw string id on screen
+-- with no other signal -- which is the failure this exists to catch.
+--
+-- Deliberately a dumb pattern match rather than an XML parse: these files are
+-- machine-uniform, and a real parser would be more code to get wrong than the
+-- thing it checks.
+
+--- gamedata/configs/text, derived from script_dir so the two stay in step.
+function M.text_dir()
+    assert(M.script_dir, "loader.init{script_dir=...} was never called")
+    return (M.script_dir:gsub("/scripts$", "")) .. "/configs/text"
+end
+
+--- Every <string id> in one language's tables, as a set. Missing files are
+--- skipped: a mod need not ship every language.
+function M.load_string_table(lang, files)
+    local ids = {}
+    local dir = M.text_dir() .. "/" .. (lang or "eng")
+
+    for _, name in ipairs(files or M.string_table_files(lang)) do
+        local src = read_file(dir .. "/" .. name)
+        if src then
+            for id in src:gmatch('<string%s+id%s*=%s*"([^"]+)"') do
+                ids[id] = true
+            end
+            for id in src:gmatch("<string%s+id%s*=%s*'([^']+)'") do
+                ids[id] = true
+            end
+        end
+    end
+
+    return ids
+end
+
+--- The .xml files present for a language. Discovered the same way spec files
+--- are, so a new translation file is picked up without editing the harness.
+function M.string_table_files(lang)
+    local dir = M.text_dir() .. "/" .. (lang or "eng")
+    local ok, pipe = pcall(io.popen,
+        'dir /b /a-d "' .. dir:gsub("/", "\\") .. '\\*.xml" 2>nul')
+    if not ok or not pipe then return {} end
+
+    local found = {}
+    for line in pipe:lines() do
+        local name = line:gsub("%s+$", "")
+        if name ~= "" then found[#found + 1] = name end
+    end
+    pipe:close()
+    table.sort(found)
+    return found
+end
+
 function M.exists(name)
     local f = io.open(M.script_path(name), "rb")
     if f then f:close() return true end

--- a/tests/harness/mcm_labels.lua
+++ b/tests/harness/mcm_labels.lua
@@ -1,0 +1,297 @@
+-- MCM label analysis: which string id each option resolves to, and how that
+-- lines up with the shipped localisation tables.
+--
+-- Shared by unit/mcm_localization.spec.lua (which asserts) and locals.lua
+-- (which reports), so the baselines below exist in exactly one place. Two
+-- copies of these lists would drift the first time one is updated.
+--
+-- THE DERIVATION (ui_mcm.script)
+--
+--   explicit   node.text
+--   derived    "ui_mcm_" .. <full path, "/" replaced by "_">
+--   tooltip    <label key> .. "_desc"          (optional; absent = no tooltip)
+--   root       "ui_mcm_menu_" .. <root id>
+--
+-- so { id = "allow_weapon_loss" } in group `items` under root `soulslike`
+-- needs ui_mcm_soulslike_items_allow_weapon_loss. game.translate_string
+-- returns the raw id on a miss, so a broken entry renders as the string id
+-- itself and nothing else reports it.
+
+local M = {}
+
+M.ROOT = "soulslike"
+
+-- Renders nothing, so carries no label.
+local NO_LABEL = { line = true, image = true }
+
+-- ---------------------------------------------------------------- baselines
+--
+-- What is broken TODAY. Recorded rather than fixed so the suite stays green and
+-- a NEW break fails loudly. Shrinking a table is the fix; growing one should be
+-- a deliberate decision.
+
+--- Node exists, English translation does not.
+---
+--- DELIBERATELY EMPTY, and it should stay that way. This is the one category
+--- a player sees directly: the option renders as the literal string id in the
+--- settings menu. Baselining these was a mistake -- it made `run.bat` report
+--- PASS while the shipped menu showed
+--- `ui_mcm_soulslike_debug_debug_squad_spawns` to anyone who opened it, which
+--- is exactly the permanently-green-while-broken failure this suite exists to
+--- prevent.
+---
+--- Add the string to gamedata/configs/text/eng instead. It is four lines and
+--- carries no risk; there is no case for accepting one of these.
+M.MISSING_ENG = {}
+
+--- Node hardcodes an English sentence instead of a string id. It renders,
+--- because translate_string passes unknown input through, but can never be
+--- localised. Both of these already HAVE translations sitting unused -- which
+--- is why they also appear in M.ORPHAN_ENG -- so deleting the literal would
+--- wire them up without writing anything new.
+M.LITERAL_TEXT = {
+    ["soulslike/hardcore/lose_all_items_on_death"] = true,
+    ["soulslike/hardcore/lose_all_items_on_death_desc"] = true,
+}
+
+--- Translation exists, node does not. Usually a rename that left the old
+--- string behind; here, mostly options that are commented out.
+M.ORPHAN_ENG = {
+    ["ui_mcm_soulslike_debug_debug_hidden_stashes"] = true,
+    ["ui_mcm_soulslike_debug_debug_the_hidden_stash_scenario"] = true,
+    ["ui_mcm_soulslike_debug_debug_the_rf_scenario"] = true,
+    ["ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight"] = true,
+    ["ui_mcm_soulslike_scenarios_rf_detector_scenario_weight"] = true,
+    ["ui_mcm_soulslike_scenarios_rf_detector_scenario_weight_desc"] = true,
+    ["ui_mcm_soulslike_hardcore_lose_all_items_on_death"] = true,
+    ["ui_mcm_soulslike_hardcore_lose_all_items_on_death_desc"] = true,
+}
+
+--- English present, Russian absent. A Russian player sees the raw id.
+---
+--- Tracked work rather than a defect, so `locals.bat` reports it without
+--- failing (pass --strict to change that). The list is still asserted, so a
+--- newly untranslated string forces a decision: translate it, or record it
+--- here deliberately.
+M.MISSING_RUS = {
+    -- Added with the English strings that fixed the raw-id labels. Left
+    -- untranslated rather than machine-guessed: a wrong Russian label is worse
+    -- than a tracked gap.
+    ["ui_mcm_soulslike_debug_debug_squad_spawns"] = true,
+    ["ui_mcm_soulslike_debug_debug_squad_spawns_desc"] = true,
+    ["ui_mcm_soulslike_debug_debug_always_spawn_ambush"] = true,
+    ["ui_mcm_soulslike_debug_debug_always_spawn_ambush_desc"] = true,
+    ["ui_mcm_soulslike_debug_debug_remove_default_scenario"] = true,
+    ["ui_mcm_soulslike_ignored_items_other"] = true,
+
+    ["ui_mcm_soulslike_ignored_items_device_pda_0"] = true,
+    ["ui_mcm_soulslike_ignored_items_device_pda_4"] = true,
+    ["ui_mcm_soulslike_ignored_items_device_pda_getac"] = true,
+    ["ui_mcm_soulslike_ignored_items_device_pda_kulon"] = true,
+    ["ui_mcm_soulslike_ignored_items_device_pda_milspec"] = true,
+    ["ui_mcm_soulslike_ignored_items_other_desc"] = true,
+    ["ui_mcm_soulslike_items_artifact_keep_chance"] = true,
+    ["ui_mcm_soulslike_items_artifact_keep_chance_desc"] = true,
+    ["ui_mcm_soulslike_items_headgear_keep_chance"] = true,
+    ["ui_mcm_soulslike_items_headgear_keep_chance_desc"] = true,
+    ["ui_mcm_soulslike_items_outfit_keep_chance"] = true,
+    ["ui_mcm_soulslike_items_outfit_keep_chance_desc"] = true,
+    ["ui_mcm_soulslike_items_weapon_keep_chance"] = true,
+    ["ui_mcm_soulslike_items_weapon_keep_chance_desc"] = true,
+}
+
+-- ----------------------------------------------------------------- analysis
+
+--- A `text` that is not a string id at all, but a literal sentence.
+function M.is_literal(key)
+    return not key:match("^ui_") and not key:match("^st_")
+end
+
+--- Every labelled node in the tree, with the string id MCM will look up.
+--- Each entry: { path, key, explicit, group, id, type }
+---
+--- Recursive: MCM lets groups nest arbitrarily deep and the storage path
+--- traces every ancestor id, so a flat walk would mis-key anything nested.
+function M.labels(tree)
+    local out = {}
+
+    local function walk(node, prefix)
+        for _, child in ipairs(node.gr or {}) do
+            local path = prefix .. "/" .. tostring(child.id)
+            if type(child.gr) == "table" then
+                walk(child, path)
+            elseif not NO_LABEL[child.type] then
+                out[#out + 1] = {
+                    path     = path,
+                    key      = child.text or ("ui_mcm_" .. path:gsub("/", "_")),
+                    explicit = child.text ~= nil,
+                    group    = prefix:match("([^/]+)$"),
+                    id       = child.id,
+                    type     = child.type,
+                }
+            end
+        end
+    end
+
+    walk(tree, M.ROOT)
+    return out
+end
+
+--- Every string id the tree can ask for, tooltips included. A `<key>_desc` is
+--- MCM's optional tooltip for `<key>`, not a node of its own, so it counts as
+--- used whenever its owner exists.
+function M.used_keys(tree)
+    local used = { ["ui_mcm_menu_" .. M.ROOT] = true }
+
+    for _, group in ipairs(tree.gr or {}) do
+        used[group.text or ("ui_mcm_menu_" .. tostring(group.id))] = true
+    end
+
+    for _, label in ipairs(M.labels(tree)) do
+        used[label.key] = true
+        used[label.key .. "_desc"] = true
+    end
+
+    return used
+end
+
+local function sorted(t)
+    table.sort(t)
+    return t
+end
+
+--- Full comparison of the tree against the string tables.
+---
+--- Each result list is split into `new` (not in the baseline -- a regression)
+--- and `known` (in the baseline -- already accounted for). Only `new` should
+--- ever be non-empty on a clean tree.
+function M.analyse(tree, eng, rus)
+    local r = {
+        missing_eng = { new = {}, known = {} },
+        literal     = { new = {}, known = {} },
+        orphan      = { new = {}, known = {} },
+        missing_rus = { new = {}, known = {} },
+        stale       = {},   -- baseline entries that no longer describe reality
+        groups      = {},   -- group headings with no translation
+    }
+
+    for _, group in ipairs(tree.gr or {}) do
+        local key = group.text or ("ui_mcm_menu_" .. tostring(group.id))
+        if not eng[key] then
+            r.groups[#r.groups + 1] = tostring(group.id) .. "  ->  " .. key
+        end
+    end
+
+    local live_keys, live_literals = {}, {}
+
+    for _, label in ipairs(M.labels(tree)) do
+        local literal = label.explicit and M.is_literal(label.key)
+
+        if literal then
+            live_literals[label.path] = true
+            local bucket = M.LITERAL_TEXT[label.path] and "known" or "new"
+            table.insert(r.literal[bucket], label.path)
+        else
+            live_keys[label.key] = true
+
+            if not eng[label.key] then
+                local bucket = M.MISSING_ENG[label.key] and "known" or "new"
+                table.insert(r.missing_eng[bucket], label.path .. "  ->  " .. label.key)
+            end
+
+            -- Checked independently of English, not as an elseif: a label
+            -- missing from BOTH tables is missing from Russian too, and
+            -- chaining these would report only the English gap and quietly
+            -- understate the translation debt.
+            if not rus[label.key] then
+                local bucket = M.MISSING_RUS[label.key] and "known" or "new"
+                table.insert(r.missing_rus[bucket], label.path .. "  ->  " .. label.key)
+            end
+        end
+    end
+
+    local used = M.used_keys(tree)
+    for id in pairs(eng) do
+        if id:match("^ui_mcm_" .. M.ROOT .. "_") and not used[id] then
+            local bucket = M.ORPHAN_ENG[id] and "known" or "new"
+            table.insert(r.orphan[bucket], id)
+        end
+    end
+
+    -- A baseline entry that no longer describes reality is worse than useless:
+    -- it masks the next regression in that slot.
+    for key in pairs(M.MISSING_ENG) do
+        if eng[key] then
+            table.insert(r.stale, "MISSING_ENG  " .. key .. "  (now translated)")
+        elseif not live_keys[key] then
+            table.insert(r.stale, "MISSING_ENG  " .. key .. "  (no such node)")
+        end
+    end
+    for path in pairs(M.LITERAL_TEXT) do
+        if not live_literals[path] then
+            table.insert(r.stale, "LITERAL_TEXT " .. path .. "  (no longer a literal)")
+        end
+    end
+    for id in pairs(M.ORPHAN_ENG) do
+        if used[id] then
+            table.insert(r.stale, "ORPHAN_ENG   " .. id .. "  (now attached to a node)")
+        elseif not eng[id] then
+            table.insert(r.stale, "ORPHAN_ENG   " .. id .. "  (no longer in the tables)")
+        end
+    end
+    for key in pairs(M.MISSING_RUS) do
+        if rus[key] then
+            table.insert(r.stale, "MISSING_RUS  " .. key .. "  (now translated)")
+        end
+    end
+
+    for _, group in pairs{ r.missing_eng, r.literal, r.orphan, r.missing_rus } do
+        sorted(group.new)
+        sorted(group.known)
+    end
+    sorted(r.stale)
+    sorted(r.groups)
+
+    return r
+end
+
+--- Whole-table parity between two languages, independent of the MCM tree.
+---
+--- The label scan only sees ids the option tree asks for, which misses every
+--- message, item name and menu string. This compares the tables outright, so a
+--- translation gap anywhere is visible.
+---
+--- Returns { only_a, only_b }, both sorted.
+function M.parity(a, b)
+    local only_a, only_b = {}, {}
+    for id in pairs(a) do if not b[id] then only_a[#only_a + 1] = id end end
+    for id in pairs(b) do if not a[id] then only_b[#only_b + 1] = id end end
+    return { only_a = sorted(only_a), only_b = sorted(only_b) }
+end
+
+--- Load both string tables and analyse in one call. `tree` defaults to the
+--- live on_mcm_load() output.
+---
+--- NOTE ON ENCODING: the Russian tables ship as windows-1251, not UTF-8
+--- (Cyrillic occupies 0xC0-0xFF as single bytes). Everything here compares
+--- string *ids*, which are ASCII, so the encoding never matters. Anything that
+--- starts reading the <text> bodies has to decode first.
+function M.inspect(tree)
+    local loader = require("harness.loader")
+    tree = tree or _G.soulslike_mcm.on_mcm_load()
+
+    local eng = loader.load_string_table("eng")
+    local rus = loader.load_string_table("rus")
+
+    local result = M.analyse(tree, eng, rus)
+
+    local parity = M.parity(eng, rus)
+    result.parity = { only_eng = parity.only_a, only_rus = parity.only_b }
+    result.counts = { eng = 0, rus = 0 }
+    for _ in pairs(eng) do result.counts.eng = result.counts.eng + 1 end
+    for _ in pairs(rus) do result.counts.rus = result.counts.rus + 1 end
+
+    return result, tree
+end
+
+return M

--- a/tests/harness/mcm_labels.lua
+++ b/tests/harness/mcm_labels.lua
@@ -61,6 +61,9 @@ M.ORPHAN_ENG = {
     ["ui_mcm_soulslike_debug_debug_the_hidden_stash_scenario"] = true,
     ["ui_mcm_soulslike_debug_debug_the_rf_scenario"] = true,
     ["ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight"] = true,
+    -- Joins its label above only once the duplicate-id fix gave it its own id:
+    -- it had been sharing rf_detector's, so the engine dropped it entirely.
+    ["ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight_desc"] = true,
     ["ui_mcm_soulslike_scenarios_rf_detector_scenario_weight"] = true,
     ["ui_mcm_soulslike_scenarios_rf_detector_scenario_weight_desc"] = true,
     ["ui_mcm_soulslike_hardcore_lose_all_items_on_death"] = true,
@@ -73,6 +76,10 @@ M.ORPHAN_ENG = {
 --- failing (pass --strict to change that). The list is still asserted, so a
 --- newly untranslated string forces a decision: translate it, or record it
 --- here deliberately.
+---
+--- Whole-table, NOT just MCM option labels: this baseline covers every
+--- <string id> in gamedata/configs/text, so a message or item name added to
+--- eng and not rus lands here too.
 M.MISSING_RUS = {
     -- Added with the English strings that fixed the raw-id labels. Left
     -- untranslated rather than machine-guessed: a wrong Russian label is worse
@@ -165,7 +172,9 @@ end
 --- Each result list is split into `new` (not in the baseline -- a regression)
 --- and `known` (in the baseline -- already accounted for). Only `new` should
 --- ever be non-empty on a clean tree.
-function M.analyse(tree, eng, rus)
+--- `dups` is optional and comes from loader.load_string_table's second return:
+--- { eng = <list>, rus = <list> }.
+function M.analyse(tree, eng, rus, dups)
     local r = {
         missing_eng = { new = {}, known = {} },
         literal     = { new = {}, known = {} },
@@ -173,6 +182,9 @@ function M.analyse(tree, eng, rus)
         missing_rus = { new = {}, known = {} },
         stale       = {},   -- baseline entries that no longer describe reality
         groups      = {},   -- group headings with no translation
+        duplicates  = {},   -- one id declared twice; the engine keeps one
+        -- Whole-table parity, independent of the MCM tree.
+        parity      = { only_eng = { new = {}, known = {} }, only_rus = {} },
     }
 
     for _, group in ipairs(tree.gr or {}) do
@@ -210,6 +222,30 @@ function M.analyse(tree, eng, rus)
         end
     end
 
+    -- Whole-table parity. The label scan above only sees ids the option tree
+    -- asks for, which is 112 of 218 strings -- every message, item name and
+    -- main-menu string is invisible to it, and a gap there is just as visible
+    -- in game. Compare the tables outright so nothing is out of scope.
+    local par = M.parity(eng, rus)   -- only_a = eng-only, only_b = rus-only
+
+    for _, id in ipairs(par.only_a) do
+        local bucket = M.MISSING_RUS[id] and "known" or "new"
+        table.insert(r.parity.only_eng[bucket], id)
+    end
+
+    -- No baseline: an id in rus with no eng cannot be tracked translation
+    -- work, because there is nothing left to translate. It is a rename that
+    -- updated one table and not the other, so the rus entry is dead weight and
+    -- whatever replaced it is untranslated under its new id.
+    r.parity.only_rus = par.only_b
+
+    for lang, list in pairs(dups or {}) do
+        for _, dup in ipairs(list) do
+            table.insert(r.duplicates, string.format("%s/%s  %s  (x%d)",
+                lang, dup.file, dup.id, dup.count))
+        end
+    end
+
     local used = M.used_keys(tree)
     for id in pairs(eng) do
         if id:match("^ui_mcm_" .. M.ROOT .. "_") and not used[id] then
@@ -239,18 +275,26 @@ function M.analyse(tree, eng, rus)
             table.insert(r.stale, "ORPHAN_ENG   " .. id .. "  (no longer in the tables)")
         end
     end
+    -- Checked against BOTH tables now that this baseline is whole-table. An
+    -- entry whose English string was deleted describes nothing: the gap it
+    -- named is gone, and leaving it behind would silently absorb the next
+    -- string that happens to reuse the id.
     for key in pairs(M.MISSING_RUS) do
         if rus[key] then
             table.insert(r.stale, "MISSING_RUS  " .. key .. "  (now translated)")
+        elseif not eng[key] then
+            table.insert(r.stale, "MISSING_RUS  " .. key .. "  (no longer in eng)")
         end
     end
 
-    for _, group in pairs{ r.missing_eng, r.literal, r.orphan, r.missing_rus } do
+    for _, group in pairs{ r.missing_eng, r.literal, r.orphan, r.missing_rus,
+                           r.parity.only_eng } do
         sorted(group.new)
         sorted(group.known)
     end
     sorted(r.stale)
     sorted(r.groups)
+    sorted(r.duplicates)
 
     return r
 end
@@ -280,13 +324,11 @@ function M.inspect(tree)
     local loader = require("harness.loader")
     tree = tree or _G.soulslike_mcm.on_mcm_load()
 
-    local eng = loader.load_string_table("eng")
-    local rus = loader.load_string_table("rus")
+    local eng, eng_dups = loader.load_string_table("eng")
+    local rus, rus_dups = loader.load_string_table("rus")
 
-    local result = M.analyse(tree, eng, rus)
+    local result = M.analyse(tree, eng, rus, { eng = eng_dups, rus = rus_dups })
 
-    local parity = M.parity(eng, rus)
-    result.parity = { only_eng = parity.only_a, only_rus = parity.only_b }
     result.counts = { eng = 0, rus = 0 }
     for _ in pairs(eng) do result.counts.eng = result.counts.eng + 1 end
     for _ in pairs(rus) do result.counts.rus = result.counts.rus + 1 end

--- a/tests/harness/mcm_labels.lua
+++ b/tests/harness/mcm_labels.lua
@@ -2,8 +2,18 @@
 -- lines up with the shipped localisation tables.
 --
 -- Shared by unit/mcm_localization.spec.lua (which asserts) and locals.lua
--- (which reports), so the baselines below exist in exactly one place. Two
--- copies of these lists would drift the first time one is updated.
+-- (which reports), so the analysis exists in exactly one place. Two copies
+-- would drift the first time one is updated.
+--
+-- THERE IS NO EXEMPTION LIST HERE, AND THERE SHOULD NEVER BE ONE. This module
+-- used to carry four tables of string ids that were "known broken"; adding an
+-- id to one of them turned a failure into a pass. That inverts what a test is
+-- for. The only way to make these checks pass is to fix the localisation.
+--
+-- If something genuinely must be tolerated, say so in the spec, in prose, next
+-- to the assertion that tolerates it -- so a reader sees the reason at the
+-- same moment they see the exception. Do not reintroduce a data table that
+-- silences findings from a distance.
 --
 -- THE DERIVATION (ui_mcm.script)
 --
@@ -23,89 +33,6 @@ M.ROOT = "soulslike"
 
 -- Renders nothing, so carries no label.
 local NO_LABEL = { line = true, image = true }
-
--- ---------------------------------------------------------------- baselines
---
--- What is broken TODAY. Recorded rather than fixed so the suite stays green and
--- a NEW break fails loudly. Shrinking a table is the fix; growing one should be
--- a deliberate decision.
-
---- Node exists, English translation does not.
----
---- DELIBERATELY EMPTY, and it should stay that way. This is the one category
---- a player sees directly: the option renders as the literal string id in the
---- settings menu. Baselining these was a mistake -- it made `run.bat` report
---- PASS while the shipped menu showed
---- `ui_mcm_soulslike_debug_debug_squad_spawns` to anyone who opened it, which
---- is exactly the permanently-green-while-broken failure this suite exists to
---- prevent.
----
---- Add the string to gamedata/configs/text/eng instead. It is four lines and
---- carries no risk; there is no case for accepting one of these.
-M.MISSING_ENG = {}
-
---- Node hardcodes an English sentence instead of a string id. It renders,
---- because translate_string passes unknown input through, but can never be
---- localised. Both of these already HAVE translations sitting unused -- which
---- is why they also appear in M.ORPHAN_ENG -- so deleting the literal would
---- wire them up without writing anything new.
-M.LITERAL_TEXT = {
-    ["soulslike/hardcore/lose_all_items_on_death"] = true,
-    ["soulslike/hardcore/lose_all_items_on_death_desc"] = true,
-}
-
---- Translation exists, node does not. Usually a rename that left the old
---- string behind; here, mostly options that are commented out.
-M.ORPHAN_ENG = {
-    ["ui_mcm_soulslike_debug_debug_hidden_stashes"] = true,
-    ["ui_mcm_soulslike_debug_debug_the_hidden_stash_scenario"] = true,
-    ["ui_mcm_soulslike_debug_debug_the_rf_scenario"] = true,
-    ["ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight"] = true,
-    -- Joins its label above only once the duplicate-id fix gave it its own id:
-    -- it had been sharing rf_detector's, so the engine dropped it entirely.
-    ["ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight_desc"] = true,
-    ["ui_mcm_soulslike_scenarios_rf_detector_scenario_weight"] = true,
-    ["ui_mcm_soulslike_scenarios_rf_detector_scenario_weight_desc"] = true,
-    ["ui_mcm_soulslike_hardcore_lose_all_items_on_death"] = true,
-    ["ui_mcm_soulslike_hardcore_lose_all_items_on_death_desc"] = true,
-}
-
---- English present, Russian absent. A Russian player sees the raw id.
----
---- Tracked work rather than a defect, so `locals.bat` reports it without
---- failing (pass --strict to change that). The list is still asserted, so a
---- newly untranslated string forces a decision: translate it, or record it
---- here deliberately.
----
---- Whole-table, NOT just MCM option labels: this baseline covers every
---- <string id> in gamedata/configs/text, so a message or item name added to
---- eng and not rus lands here too.
-M.MISSING_RUS = {
-    -- Added with the English strings that fixed the raw-id labels. Left
-    -- untranslated rather than machine-guessed: a wrong Russian label is worse
-    -- than a tracked gap.
-    ["ui_mcm_soulslike_debug_debug_squad_spawns"] = true,
-    ["ui_mcm_soulslike_debug_debug_squad_spawns_desc"] = true,
-    ["ui_mcm_soulslike_debug_debug_always_spawn_ambush"] = true,
-    ["ui_mcm_soulslike_debug_debug_always_spawn_ambush_desc"] = true,
-    ["ui_mcm_soulslike_debug_debug_remove_default_scenario"] = true,
-    ["ui_mcm_soulslike_ignored_items_other"] = true,
-
-    ["ui_mcm_soulslike_ignored_items_device_pda_0"] = true,
-    ["ui_mcm_soulslike_ignored_items_device_pda_4"] = true,
-    ["ui_mcm_soulslike_ignored_items_device_pda_getac"] = true,
-    ["ui_mcm_soulslike_ignored_items_device_pda_kulon"] = true,
-    ["ui_mcm_soulslike_ignored_items_device_pda_milspec"] = true,
-    ["ui_mcm_soulslike_ignored_items_other_desc"] = true,
-    ["ui_mcm_soulslike_items_artifact_keep_chance"] = true,
-    ["ui_mcm_soulslike_items_artifact_keep_chance_desc"] = true,
-    ["ui_mcm_soulslike_items_headgear_keep_chance"] = true,
-    ["ui_mcm_soulslike_items_headgear_keep_chance_desc"] = true,
-    ["ui_mcm_soulslike_items_outfit_keep_chance"] = true,
-    ["ui_mcm_soulslike_items_outfit_keep_chance_desc"] = true,
-    ["ui_mcm_soulslike_items_weapon_keep_chance"] = true,
-    ["ui_mcm_soulslike_items_weapon_keep_chance_desc"] = true,
-}
 
 -- ----------------------------------------------------------------- analysis
 
@@ -169,22 +96,21 @@ end
 
 --- Full comparison of the tree against the string tables.
 ---
---- Each result list is split into `new` (not in the baseline -- a regression)
---- and `known` (in the baseline -- already accounted for). Only `new` should
---- ever be non-empty on a clean tree.
+--- Every list is a plain list of findings. A finding is a finding: there is no
+--- second bucket it can be moved into to stop it counting.
+---
 --- `dups` is optional and comes from loader.load_string_table's second return:
 --- { eng = <list>, rus = <list> }.
 function M.analyse(tree, eng, rus, dups)
     local r = {
-        missing_eng = { new = {}, known = {} },
-        literal     = { new = {}, known = {} },
-        orphan      = { new = {}, known = {} },
-        missing_rus = { new = {}, known = {} },
-        stale       = {},   -- baseline entries that no longer describe reality
+        missing_eng = {},   -- node exists, English string does not
+        literal     = {},   -- node hardcodes English instead of a string id
+        orphan      = {},   -- string exists, node does not
+        missing_rus = {},   -- label present in eng, absent in rus
         groups      = {},   -- group headings with no translation
         duplicates  = {},   -- one id declared twice; the engine keeps one
         -- Whole-table parity, independent of the MCM tree.
-        parity      = { only_eng = { new = {}, known = {} }, only_rus = {} },
+        parity      = { only_eng = {}, only_rus = {} },
     }
 
     for _, group in ipairs(tree.gr or {}) do
@@ -194,21 +120,12 @@ function M.analyse(tree, eng, rus, dups)
         end
     end
 
-    local live_keys, live_literals = {}, {}
-
     for _, label in ipairs(M.labels(tree)) do
-        local literal = label.explicit and M.is_literal(label.key)
-
-        if literal then
-            live_literals[label.path] = true
-            local bucket = M.LITERAL_TEXT[label.path] and "known" or "new"
-            table.insert(r.literal[bucket], label.path)
+        if label.explicit and M.is_literal(label.key) then
+            table.insert(r.literal, label.path)
         else
-            live_keys[label.key] = true
-
             if not eng[label.key] then
-                local bucket = M.MISSING_ENG[label.key] and "known" or "new"
-                table.insert(r.missing_eng[bucket], label.path .. "  ->  " .. label.key)
+                table.insert(r.missing_eng, label.path .. "  ->  " .. label.key)
             end
 
             -- Checked independently of English, not as an elseif: a label
@@ -216,8 +133,7 @@ function M.analyse(tree, eng, rus, dups)
             -- chaining these would report only the English gap and quietly
             -- understate the translation debt.
             if not rus[label.key] then
-                local bucket = M.MISSING_RUS[label.key] and "known" or "new"
-                table.insert(r.missing_rus[bucket], label.path .. "  ->  " .. label.key)
+                table.insert(r.missing_rus, label.path .. "  ->  " .. label.key)
             end
         end
     end
@@ -228,15 +144,7 @@ function M.analyse(tree, eng, rus, dups)
     -- in game. Compare the tables outright so nothing is out of scope.
     local par = M.parity(eng, rus)   -- only_a = eng-only, only_b = rus-only
 
-    for _, id in ipairs(par.only_a) do
-        local bucket = M.MISSING_RUS[id] and "known" or "new"
-        table.insert(r.parity.only_eng[bucket], id)
-    end
-
-    -- No baseline: an id in rus with no eng cannot be tracked translation
-    -- work, because there is nothing left to translate. It is a rename that
-    -- updated one table and not the other, so the rus entry is dead weight and
-    -- whatever replaced it is untranslated under its new id.
+    r.parity.only_eng = par.only_a
     r.parity.only_rus = par.only_b
 
     for lang, list in pairs(dups or {}) do
@@ -249,50 +157,14 @@ function M.analyse(tree, eng, rus, dups)
     local used = M.used_keys(tree)
     for id in pairs(eng) do
         if id:match("^ui_mcm_" .. M.ROOT .. "_") and not used[id] then
-            local bucket = M.ORPHAN_ENG[id] and "known" or "new"
-            table.insert(r.orphan[bucket], id)
+            table.insert(r.orphan, id)
         end
     end
 
-    -- A baseline entry that no longer describes reality is worse than useless:
-    -- it masks the next regression in that slot.
-    for key in pairs(M.MISSING_ENG) do
-        if eng[key] then
-            table.insert(r.stale, "MISSING_ENG  " .. key .. "  (now translated)")
-        elseif not live_keys[key] then
-            table.insert(r.stale, "MISSING_ENG  " .. key .. "  (no such node)")
-        end
-    end
-    for path in pairs(M.LITERAL_TEXT) do
-        if not live_literals[path] then
-            table.insert(r.stale, "LITERAL_TEXT " .. path .. "  (no longer a literal)")
-        end
-    end
-    for id in pairs(M.ORPHAN_ENG) do
-        if used[id] then
-            table.insert(r.stale, "ORPHAN_ENG   " .. id .. "  (now attached to a node)")
-        elseif not eng[id] then
-            table.insert(r.stale, "ORPHAN_ENG   " .. id .. "  (no longer in the tables)")
-        end
-    end
-    -- Checked against BOTH tables now that this baseline is whole-table. An
-    -- entry whose English string was deleted describes nothing: the gap it
-    -- named is gone, and leaving it behind would silently absorb the next
-    -- string that happens to reuse the id.
-    for key in pairs(M.MISSING_RUS) do
-        if rus[key] then
-            table.insert(r.stale, "MISSING_RUS  " .. key .. "  (now translated)")
-        elseif not eng[key] then
-            table.insert(r.stale, "MISSING_RUS  " .. key .. "  (no longer in eng)")
-        end
-    end
-
-    for _, group in pairs{ r.missing_eng, r.literal, r.orphan, r.missing_rus,
-                           r.parity.only_eng } do
-        sorted(group.new)
-        sorted(group.known)
-    end
-    sorted(r.stale)
+    sorted(r.missing_eng)
+    sorted(r.literal)
+    sorted(r.orphan)
+    sorted(r.missing_rus)
     sorted(r.groups)
     sorted(r.duplicates)
 

--- a/tests/harness/mods.lua
+++ b/tests/harness/mods.lua
@@ -73,9 +73,14 @@ local DEFAULTS = {
     end,
 
     item_radio = function()
+        -- Recorded, not no-ops: registering the stash with the radio is the
+        -- entire point of the RF Detector scenario
+        -- (soulslike_scenarios.script:1471), and clear_stash is how the entry
+        -- is retired once the player recovers it.
+        local recorder = require("harness.fakes").recorder
         return {
-            add_stash   = function() end,
-            clear_stash = function() end,
+            add_stash   = recorder("item_radio.add_stash"),
+            clear_stash = recorder("item_radio.clear_stash"),
         }
     end,
 

--- a/tests/harness/mods.lua
+++ b/tests/harness/mods.lua
@@ -1,0 +1,185 @@
+-- Registry for the scripts the mod integrates with, whether or not they are
+-- guaranteed present.
+--
+-- The plan called for "all eight absent by default", but checking Anomaly's
+-- own _scripts/ corpus showed that is wrong for five of them. Splitting by
+-- what a real install actually has:
+--
+--   BASE      arszi_psy, item_parts, item_radio, treasure_manager,
+--             actor_status_thirst -- these ship with Anomaly, so every player
+--             has them. Two are even called UNGUARDED
+--             (actor_status_thirst at soulslike_scenarios.script:590,
+--             treasure_manager at :1335), so "absent" is not a state the mod
+--             survives. Installed by default.
+--
+--   OPTIONAL  magazine_binder, grok_actor_damage_balancer,
+--             demonized_time_events -- genuinely third-party. Absent by
+--             default, which is what most installs look like.
+--
+-- Either group can be flipped per spec, so the guard branches stay reachable:
+--
+--     H.mods.disable("item_parts")     -- exercise the `if not item_parts` path
+--     H.mods.enable("magazine_binder", { is_magazine = function() return true end })
+--
+-- treasure_manager gets special attention. RFDetectorSoulslikeScenarioLogic
+-- :CreateStash monkey-patches treasure_manager.box_in_same_map and restores it
+-- afterwards (soulslike_scenarios.script:1335-1341). That restore is exactly
+-- the kind of thing that leaks on an early return, so the registry snapshots
+-- the original and exposes M.patched() for a spec to assert against.
+
+local M = {}
+
+local installed = {}
+local snapshots = {}
+
+-- Default stubs. Each is deliberately minimal -- enough for the mod's calls,
+-- no more. Override per spec with the second argument to enable().
+local DEFAULTS = {
+    magazine_binder = function()
+        return {
+            is_magazine       = function() return false end,
+            is_carried_mag    = function() return false end,
+            toggle_carried_mag= function() return true end,
+            validate_loadout  = function() end,
+        }
+    end,
+
+    grok_actor_damage_balancer = function()
+        return { damage = nil }     -- set .damage in a spec to override hit power
+    end,
+
+    -- soulslike falls back to the global CreateTimeEvent when this is absent,
+    -- so enabling it routes deferred work through the same pump either way.
+    demonized_time_events = function()
+        return { CreateTimeEvent = _G.CreateTimeEvent,
+                 RemoveTimeEvent = _G.RemoveTimeEvent }
+    end,
+
+    arszi_psy = function()
+        return { set_psy_health = function() end }
+    end,
+
+    item_parts = function()
+        -- ApplyItemConditionLoss reads and writes a section->condition map for
+        -- weapons (soulslike_scenarios.script:439-456).
+        local store = {}
+        return {
+            _store = store,
+            get_parts_con = function(item)
+                return store[item:id()] or { barrel = 100, receiver = 100 }
+            end,
+            set_parts_con = function(id, parts) store[id] = parts end,
+        }
+    end,
+
+    item_radio = function()
+        return {
+            add_stash   = function() end,
+            clear_stash = function() end,
+        }
+    end,
+
+    treasure_manager = function()
+        return {
+            get_random_stash = function() return nil end,
+            box_in_same_map  = function() return true end,
+        }
+    end,
+
+    actor_status_thirst = function()
+        return {
+            get_water_deprivation = function() return 0.1 end,
+            load_state            = function() end,
+            actor_on_update       = function() end,
+        }
+    end,
+}
+
+M.NAMES = {}
+for name in pairs(DEFAULTS) do M.NAMES[#M.NAMES + 1] = name end
+table.sort(M.NAMES)
+
+-- Ships with Anomaly: install unless a spec explicitly disables it.
+M.BASE = {
+    "actor_status_thirst", "arszi_psy", "item_parts", "item_radio",
+    "treasure_manager",
+}
+
+-- Third-party: absent unless a spec asks for it.
+M.OPTIONAL = {
+    "demonized_time_events", "grok_actor_damage_balancer", "magazine_binder",
+}
+
+--- Install the base-Anomaly set. Called by H.boot before mod scripts load.
+function M.install_base()
+    for _, name in ipairs(M.BASE) do M.enable(name) end
+end
+
+--- Install a soft dependency. `overrides` are merged over the default stub.
+function M.enable(name, overrides)
+    local factory = DEFAULTS[name]
+    if not factory then
+        error("mods.enable: unknown soft dependency '" .. tostring(name) ..
+              "'. Known: " .. table.concat(M.NAMES, ", "), 2)
+    end
+
+    local stub = factory()
+    if overrides then
+        for k, v in pairs(overrides) do stub[k] = v end
+    end
+
+    _G[name] = stub
+    installed[name] = stub
+
+    -- soulslike_scenarios.script:113 captures `local dte = demonized_time_events`
+    -- at FILE SCOPE, so enabling it after the module loaded has no effect on
+    -- that upvalue. Say so rather than letting a spec silently do nothing.
+    if name == "demonized_time_events" then
+        local loader = require("harness.loader")
+        if loader.loaded["soulslike_scenarios"] then
+            error("mods.enable(\"demonized_time_events\") must run BEFORE " ..
+                  "soulslike_scenarios loads -- it captures `local dte` at file " ..
+                  "scope (soulslike_scenarios.script:113)", 2)
+        end
+        _G.dte = stub
+    end
+
+    -- Snapshot every function so patched() can detect an unrestored monkey-patch.
+    local snap = {}
+    for k, v in pairs(stub) do snap[k] = v end
+    snapshots[name] = snap
+
+    return stub
+end
+
+function M.disable(name)
+    _G[name] = nil
+    if name == "demonized_time_events" then _G.dte = nil end
+    installed[name] = nil
+    snapshots[name] = nil
+end
+
+function M.is_enabled(name) return installed[name] ~= nil end
+
+--- Fields whose value differs from what enable() installed -- i.e. a
+--- monkey-patch that was never restored.
+function M.patched(name)
+    local snap, live = snapshots[name], _G[name]
+    if not snap or not live then return {} end
+    local out = {}
+    for k, v in pairs(snap) do
+        if live[k] ~= v then out[#out + 1] = k end
+    end
+    table.sort(out)
+    return out
+end
+
+function M.reset()
+    for name in pairs(installed) do
+        _G[name] = nil
+        if name == "demonized_time_events" then _G.dte = nil end
+    end
+    installed, snapshots = {}, {}
+end
+
+return M

--- a/tests/harness/spec.lua
+++ b/tests/harness/spec.lua
@@ -1,0 +1,408 @@
+-- BDD test runner: nested describe/it with beforeEach, plus a Jest-style
+-- expect(). Modelled on Jest/Vitest so the specs read the same way as a TS
+-- suite.
+--
+--   describe("loader", function()
+--     describe("parse_namespace()", function()
+--       beforeEach(function() ... end)
+--
+--       describe("given a flat namespace name", function()
+--         it("returns the assignment fragment", function()
+--           expect(b).toBe("soulslike=")
+--         end)
+--       end)
+--     end)
+--   end)
+--
+-- describe bodies run at load time; it bodies are deferred to run(). Hooks are
+-- resolved at run time from the live frame chain, so a beforeEach declared
+-- after an it in the same block still applies to it -- matching Jest.
+
+local M = {}
+
+local stack    = {}     -- describe frames, during registration
+local tests    = {}     -- flat, in declaration order
+local passed, failed, failures = 0, 0, {}
+
+-- ------------------------------------------------------------------ structure
+
+function M.describe(name, fn)
+    local frame = { name = name, before = {}, after = {} }
+    stack[#stack + 1] = frame
+    local ok, err = pcall(fn)
+    table.remove(stack)
+    if not ok then
+        error("error while defining describe(\"" .. tostring(name) .. "\"): " ..
+              tostring(type(err) == "table" and err.msg or err), 0)
+    end
+end
+
+function M.beforeEach(fn)
+    local frame = stack[#stack]
+    assert(frame, "beforeEach() must be called inside a describe()")
+    frame.before[#frame.before + 1] = fn
+end
+
+function M.afterEach(fn)
+    local frame = stack[#stack]
+    assert(frame, "afterEach() must be called inside a describe()")
+    frame.after[#frame.after + 1] = fn
+end
+
+function M.it(name, fn)
+    assert(#stack > 0, "it(\"" .. tostring(name) .. "\") must be inside a describe()")
+    -- Store frame *references*, not a snapshot of their hooks: hooks are
+    -- collected at run time so declaration order within a block is irrelevant.
+    local frames = {}
+    for i, f in ipairs(stack) do frames[i] = f end
+    tests[#tests + 1] = { name = name, fn = fn, frames = frames }
+end
+
+-- Declared but not implemented; reported, never run.
+function M.xit(name)
+    assert(#stack > 0, "xit() must be inside a describe()")
+    local frames = {}
+    for i, f in ipairs(stack) do frames[i] = f end
+    tests[#tests + 1] = { name = name, frames = frames, pending = true }
+end
+
+-- ----------------------------------------------------------------- failure
+
+local function fail(msg)
+    error({ __spec_failure = true, msg = msg }, 3)
+end
+M.fail = function(msg) error({ __spec_failure = true, msg = msg }, 2) end
+
+local function repr(v)
+    local tv = type(v)
+    if tv == "string" then return string.format("%q", v) end
+    if tv == "table" then
+        local parts, n = {}, 0
+        for k, val in pairs(v) do
+            n = n + 1
+            if n > 8 then parts[#parts + 1] = "..." break end
+            parts[#parts + 1] = tostring(k) .. "=" ..
+                (type(val) == "string" and string.format("%q", val) or tostring(val))
+        end
+        return "{" .. table.concat(parts, ", ") .. "}"
+    end
+    return tostring(v)
+end
+M.repr = repr
+
+local function deep_eq(a, b, path, seen)
+    if a == b then return true end
+    if type(a) ~= "table" or type(b) ~= "table" then
+        return false, path .. ": " .. repr(a) .. " ~= " .. repr(b)
+    end
+    seen = seen or {}
+    if seen[a] and seen[a][b] then return true end
+    seen[a] = seen[a] or {}; seen[a][b] = true
+
+    for k, va in pairs(a) do
+        local ok, err = deep_eq(va, b[k], path .. "." .. tostring(k), seen)
+        if not ok then return false, err end
+    end
+    for k in pairs(b) do
+        if a[k] == nil then
+            return false, path .. "." .. tostring(k) ..
+                          ": missing on left, " .. repr(b[k]) .. " on right"
+        end
+    end
+    return true
+end
+
+-- ------------------------------------------------------------------- expect
+
+-- Matchers live in their own table and are bound to the expectation by
+-- __index. That is what lets specs use TS call syntax -- expect(x).toBe(y)
+-- with a dot -- instead of Lua's expect(x):toBe(y).
+local Expect = {}
+local Matchers = {}
+
+Expect.__index = function(self, key)
+    if key == "never" then
+        return setmetatable({ actual = self.actual, negated = not self.negated }, Expect)
+    end
+    local matcher = rawget(Matchers, key)
+    if matcher then
+        return function(...) return matcher(self, ...) end
+    end
+    return nil
+end
+
+-- Runs a matcher and reports according to the negation flag.
+--
+-- A plain local, not a method: __index hands back matchers already bound to
+-- the expectation, so `self:_check(...)` would pass self twice.
+local function check(self, ok, description, extra)
+    if self.negated then ok = not ok end
+    if ok then return self end
+    local prefix = self.negated and "expected NOT " or "expected "
+    fail(prefix .. description .. (extra and ("\n           " .. extra) or ""))
+end
+
+function Matchers:toBe(expected)
+    return check(self, self.actual == expected,
+        repr(self.actual) .. " to be " .. repr(expected))
+end
+
+function Matchers:toEqual(expected)
+    local ok, err = deep_eq(self.actual, expected, "<root>")
+    return check(self, ok, "deep equality", (not self.negated) and err or nil)
+end
+
+function Matchers:toBeNil()
+    return check(self, self.actual == nil, repr(self.actual) .. " to be nil")
+end
+
+function Matchers:toBeDefined()
+    return check(self, self.actual ~= nil, "value to be defined (non-nil)")
+end
+
+function Matchers:toBeTruthy()
+    return check(self, not not self.actual, repr(self.actual) .. " to be truthy")
+end
+
+function Matchers:toBeFalsy()
+    return check(self, not self.actual, repr(self.actual) .. " to be falsy")
+end
+
+function Matchers:toBeType(t)
+    return check(self, type(self.actual) == t,
+        "type to be " .. t .. ", got " .. type(self.actual))
+end
+
+function Matchers:toContain(needle)
+    local a = self.actual
+    local found = false
+    if type(a) == "string" then
+        found = a:find(needle, 1, true) ~= nil
+    elseif type(a) == "table" then
+        for _, v in pairs(a) do if v == needle then found = true break end end
+    else
+        fail("toContain() needs a string or table, got " .. type(a))
+    end
+    local shown = type(a) == "string" and
+        (#a > 200 and (a:sub(1, 200) .. "...") or a) or repr(a)
+    return check(self, found, repr(needle) .. " to be contained in " .. repr(shown))
+end
+
+function Matchers:toHaveLength(n)
+    local a = self.actual
+    if type(a) ~= "string" and type(a) ~= "table" then
+        fail("toHaveLength() needs a string or table, got " .. type(a))
+    end
+    return check(self, #a == n, "length " .. n .. ", got " .. #a)
+end
+
+function Matchers:toBeCloseTo(expected, tol)
+    tol = tol or 1e-9
+    if type(self.actual) ~= "number" then
+        fail("toBeCloseTo() needs a number, got " .. repr(self.actual))
+    end
+    return check(self, math.abs(self.actual - expected) <= tol,
+        tostring(self.actual) .. " to be within " .. tostring(tol) ..
+        " of " .. tostring(expected))
+end
+
+function Matchers:toBeGreaterThan(n)
+    return check(self, self.actual > n, repr(self.actual) .. " > " .. repr(n))
+end
+
+function Matchers:toBeLessThan(n)
+    return check(self, self.actual < n, repr(self.actual) .. " < " .. repr(n))
+end
+
+-- expect(fn).toThrow()  /  expect(fn).toThrow("substring")
+function Matchers:toThrow(substring)
+    if type(self.actual) ~= "function" then
+        fail("toThrow() needs a function, got " .. type(self.actual))
+    end
+    local ok, err = pcall(self.actual)
+    local raised = not ok
+    local text = type(err) == "table" and (err.msg or "<table>") or tostring(err)
+
+    if raised and substring and not self.negated then
+        if not text:find(substring, 1, true) then
+            fail("expected the error to contain " .. repr(substring) ..
+                 "\n           got: " .. text)
+        end
+    end
+    return check(self, raised, "the call to raise",
+        raised and ("it raised: " .. text) or "it returned normally")
+end
+
+function M.expect(actual)
+    return setmetatable({ actual = actual, negated = false }, Expect)
+end
+
+-- ---------------------------------------------------------- output styling
+
+-- Colour is on by default and can be turned off three ways: the NO_COLOR
+-- convention (https://no-color.org), SPEC_NO_COLOR, or --no-color on the
+-- command line. FORCE_COLOR wins over NO_COLOR.
+--
+-- The tick and cross are written as explicit UTF-8 byte escapes rather than
+-- literal characters, so the encoding of this source file cannot corrupt them.
+-- They still need a UTF-8 console: run.bat switches the code page to 65001.
+-- If you invoke luajit directly from a legacy code page, set SPEC_ASCII=1.
+local style = {
+    color   = not os.getenv("NO_COLOR") and not os.getenv("SPEC_NO_COLOR")
+              or not not os.getenv("FORCE_COLOR"),
+    unicode = not os.getenv("SPEC_ASCII"),
+}
+
+local C, SYM
+
+local function refresh_style()
+    if style.color then
+        C = {
+            reset = "\27[0m",  bold = "\27[1m",   dim   = "\27[2m",
+            red   = "\27[31m", green = "\27[32m", yellow= "\27[33m",
+            cyan  = "\27[36m", gray  = "\27[90m",
+        }
+    else
+        C = setmetatable({}, { __index = function() return "" end })
+    end
+
+    if style.unicode then
+        SYM = {
+            pass    = "\226\156\147",   -- U+2713 CHECK MARK
+            fail    = "\226\156\151",   -- U+2717 BALLOT X
+            pending = "\226\151\139",   -- U+25CB WHITE CIRCLE
+        }
+    else
+        SYM = { pass = "ok", fail = "XX", pending = "--" }
+    end
+end
+refresh_style()
+
+function M.configure(opts)
+    if opts.color   ~= nil then style.color   = opts.color   end
+    if opts.unicode ~= nil then style.unicode = opts.unicode end
+    refresh_style()
+end
+
+-- ------------------------------------------------------------------ running
+
+local function path_of(test)
+    local names = {}
+    for i, f in ipairs(test.frames) do names[i] = f.name end
+    return names
+end
+
+local INDENT = "  "
+
+function M.run()
+    local shown = {}          -- last printed path, for tree headers
+
+    for _, test in ipairs(tests) do
+        local path = path_of(test)
+
+        -- Print any describe headers that changed since the previous test.
+        -- The top-level block is bold; nested context lines are dimmer, so the
+        -- eye lands on the unit under test first.
+        for depth = 1, #path do
+            if shown[depth] ~= path[depth] then
+                local tint = (depth == 1) and (C.bold .. C.cyan) or C.gray
+                print(string.rep(INDENT, depth - 1) .. tint .. path[depth] .. C.reset)
+                for d = depth, #shown do shown[d] = nil end
+                shown[depth] = path[depth]
+            end
+        end
+
+        local pad = string.rep(INDENT, #path)
+
+        if test.pending then
+            print(pad .. C.yellow .. SYM.pending .. C.reset ..
+                  " " .. C.gray .. test.name .. " (pending)" .. C.reset)
+        else
+            -- Hooks resolved now, outermost first; afterEach innermost first.
+            local before, after = {}, {}
+            for _, f in ipairs(test.frames) do
+                for _, h in ipairs(f.before) do before[#before + 1] = h end
+            end
+            for i = #test.frames, 1, -1 do
+                for _, h in ipairs(test.frames[i].after) do after[#after + 1] = h end
+            end
+
+            local ok, err = true, nil
+            for _, h in ipairs(before) do
+                ok, err = pcall(h)
+                if not ok then
+                    err = { __spec_failure = true, msg = "beforeEach failed: " ..
+                            tostring(type(err) == "table" and err.msg or err) }
+                    break
+                end
+            end
+
+            if ok then ok, err = pcall(test.fn) end
+
+            for _, h in ipairs(after) do pcall(h) end
+
+            if ok then
+                passed = passed + 1
+                print(pad .. C.green .. SYM.pass .. C.reset ..
+                      " " .. C.gray .. test.name .. C.reset)
+            else
+                failed = failed + 1
+                local detail = (type(err) == "table" and err.__spec_failure)
+                    and err.msg
+                    or ("unexpected error: " .. tostring(err))
+                print(pad .. C.red .. SYM.fail .. " " .. test.name .. C.reset)
+                for line in (detail .. "\n"):gmatch("(.-)\n") do
+                    if line ~= "" then
+                        print(pad .. INDENT .. C.red .. line .. C.reset)
+                    end
+                end
+                failures[#failures + 1] = {
+                    path = table.concat(path, " > ") .. " > " .. test.name,
+                    detail = detail,
+                }
+            end
+        end
+    end
+
+    print("")
+    print(C.gray .. string.rep("-", 66) .. C.reset)
+    if failed == 0 then
+        print(C.green .. C.bold .. " PASS " .. C.reset ..
+              C.green .. string.format("  %d passing", passed) .. C.reset)
+    else
+        print(C.red .. C.bold .. " FAIL " .. C.reset ..
+              C.green .. string.format("  %d passing", passed) .. C.reset ..
+              C.gray .. ", " .. C.reset ..
+              C.red .. string.format("%d failing", failed) .. C.reset)
+        print("")
+        for i, f in ipairs(failures) do
+            print(C.red .. string.format("  %d) ", i) .. C.reset ..
+                  C.bold .. f.path .. C.reset)
+            for line in (f.detail .. "\n"):gmatch("(.-)\n") do
+                if line ~= "" then print(C.red .. "     " .. line .. C.reset) end
+            end
+        end
+    end
+    return failed
+end
+
+function M.reset()
+    stack, tests = {}, {}
+    passed, failed, failures = 0, 0, {}
+end
+
+-- Ambient globals, as describe/it/expect are in a TS suite.
+function M.install(env)
+    env = env or _G
+    env.describe   = M.describe
+    env.it         = M.it
+    env.xit        = M.xit
+    env.beforeEach = M.beforeEach
+    env.afterEach  = M.afterEach
+    env.expect     = M.expect
+    return env
+end
+
+return M
+
+

--- a/tests/harness/spec.lua
+++ b/tests/harness/spec.lua
@@ -23,6 +23,8 @@ local M = {}
 local stack    = {}     -- describe frames, during registration
 local tests    = {}     -- flat, in declaration order
 local passed, failed, failures = 0, 0, {}
+local filtered = 0      -- skipped by M.filter, reported but not run
+local name_filter = nil
 
 -- ------------------------------------------------------------------ structure
 
@@ -294,10 +296,37 @@ end
 
 local INDENT = "  "
 
+--- Run only tests whose full path ("outer > inner > it name") contains substr.
+--- Plain substring, not a pattern, so "create_new()" needs no escaping.
+--- Call with nil to clear.
+function M.filter(substr)
+    name_filter = (substr ~= "" and substr) or nil
+end
+
+--- The tests M.run() would actually execute, after the name filter. Selection
+--- happens up front so filtered-out tests never print an empty describe header.
+local function selected()
+    local out = {}
+    for _, test in ipairs(tests) do
+        if not name_filter then
+            out[#out + 1] = test
+        else
+            local path = path_of(test)
+            local full = table.concat(path, " > ") .. " > " .. test.name
+            if full:find(name_filter, 1, true) then
+                out[#out + 1] = test
+            else
+                filtered = filtered + 1
+            end
+        end
+    end
+    return out
+end
+
 function M.run()
     local shown = {}          -- last printed path, for tree headers
 
-    for _, test in ipairs(tests) do
+    for _, test in ipairs(selected()) do
         local path = path_of(test)
 
         -- Print any describe headers that changed since the previous test.
@@ -364,16 +393,27 @@ function M.run()
         end
     end
 
+    local skipped = (filtered > 0)
+        and (C.gray .. string.format(", %d filtered", filtered) .. C.reset)
+        or ""
+
     print("")
     print(C.gray .. string.rep("-", 66) .. C.reset)
-    if failed == 0 then
+    -- A filter that matched nothing is almost always a typo. Report it as a
+    -- failure rather than "0 passing", which reads as green.
+    if failed == 0 and passed == 0 and filtered > 0 then
+        print(C.red .. C.bold .. " EMPTY " .. C.reset ..
+              C.red .. string.format("  filter %q matched none of %d tests",
+                                     name_filter, filtered) .. C.reset)
+        return 1
+    elseif failed == 0 then
         print(C.green .. C.bold .. " PASS " .. C.reset ..
-              C.green .. string.format("  %d passing", passed) .. C.reset)
+              C.green .. string.format("  %d passing", passed) .. C.reset .. skipped)
     else
         print(C.red .. C.bold .. " FAIL " .. C.reset ..
               C.green .. string.format("  %d passing", passed) .. C.reset ..
               C.gray .. ", " .. C.reset ..
-              C.red .. string.format("%d failing", failed) .. C.reset)
+              C.red .. string.format("%d failing", failed) .. C.reset .. skipped)
         print("")
         for i, f in ipairs(failures) do
             print(C.red .. string.format("  %d) ", i) .. C.reset ..
@@ -386,9 +426,12 @@ function M.run()
     return failed
 end
 
+-- Clears registered tests and counters. The name filter survives, because a
+-- full run resets between suites and the filter is a property of the invocation.
 function M.reset()
     stack, tests = {}, {}
     passed, failed, failures = 0, 0, {}
+    filtered = 0
 end
 
 -- Ambient globals, as describe/it/expect are in a TS suite.

--- a/tests/harness/timeevents.lua
+++ b/tests/harness/timeevents.lua
@@ -51,10 +51,18 @@ end
 --- Drain the queue. Events returning false are retried on the next pass, so a
 --- chain (event A queues event B) settles in one pump() call.
 --- Returns the number of callbacks invoked.
-function M.pump()
+---
+--- opts.passes bounds the number of passes and, because a bounded pump is an
+--- explicit "run N frames" rather than "run to completion", leaves anything
+--- still queued in place instead of raising. That is how a spec observes the
+--- retry contract: pump one frame with the stash offline, assert nothing moved
+--- and the event is still pending, bring the stash online, pump again.
+function M.pump(opts)
+    opts = opts or {}
+    local limit = opts.passes or M.max_passes
     local invoked = 0
 
-    for pass = 1, M.max_passes do
+    for _ = 1, limit do
         if #queue == 0 then return invoked end
 
         local batch = queue
@@ -69,6 +77,8 @@ function M.pump()
         end
 
     end
+
+    if opts.passes then return invoked end
 
     -- A retrying event is legitimate -- wait_for_stash_creation returns false
     -- until the stash exists. There is no way to tell "will succeed later" from

--- a/tests/harness/timeevents.lua
+++ b/tests/harness/timeevents.lua
@@ -1,0 +1,98 @@
+-- Deferred callbacks: CreateTimeEvent / RemoveTimeEvent.
+--
+-- The mod uses these to continue work on a later frame, so the death->respawn
+-- flow does NOT complete synchronously. Two sites depend on it:
+--
+--   HandleItemsAndRespawn (soulslike_scenarios.script:549) waits for the stash
+--     object to exist before transferring items into it.
+--   RespawnActor (:860) defers the ChangeLevel call.
+--
+-- Contract, from wait_for_stash_creation (:535): the callback returns true when
+-- it is done and the event should be dropped, false to stay queued and be
+-- retried on a later frame. We re-queue on false, which is what makes a spec
+-- able to model "the stash is not online yet, then it is".
+
+local M = {}
+
+local queue = {}
+local seq = 0
+
+-- A never-satisfied condition would spin forever. Bound it so the spec fails
+-- with a clear message instead of hanging the runner.
+M.max_passes = 32
+
+function M.install(env)
+    env = env or _G
+
+    env.CreateTimeEvent = function(a, b, delay, fn, ...)
+        seq = seq + 1
+        queue[#queue + 1] = {
+            id    = seq,
+            key   = tostring(a) .. "/" .. tostring(b),
+            delay = delay,
+            fn    = fn,
+            args  = { ... },
+            n     = select("#", ...),
+        }
+        return true
+    end
+
+    env.RemoveTimeEvent = function(a, b)
+        local key = tostring(a) .. "/" .. tostring(b)
+        for i = #queue, 1, -1 do
+            if queue[i].key == key then table.remove(queue, i) end
+        end
+        return true
+    end
+
+    return env
+end
+
+--- Drain the queue. Events returning false are retried on the next pass, so a
+--- chain (event A queues event B) settles in one pump() call.
+--- Returns the number of callbacks invoked.
+function M.pump()
+    local invoked = 0
+
+    for pass = 1, M.max_passes do
+        if #queue == 0 then return invoked end
+
+        local batch = queue
+        queue = {}
+
+        for _, ev in ipairs(batch) do
+            invoked = invoked + 1
+            local done = ev.fn(unpack(ev.args, 1, ev.n))
+            if done ~= true then
+                queue[#queue + 1] = ev      -- still waiting; retry next pass
+            end
+        end
+
+    end
+
+    -- A retrying event is legitimate -- wait_for_stash_creation returns false
+    -- until the stash exists. There is no way to tell "will succeed later" from
+    -- "never will" without running it, so max_passes is the only honest bound.
+    local keys = {}
+    for i, ev in ipairs(queue) do keys[i] = ev.key end
+    error("timeevents: " .. #queue .. " event(s) still queued after " ..
+          M.max_passes .. " passes (" .. table.concat(keys, ", ") ..
+          ") -- they never returned true, so the condition they wait on is " ..
+          "never met. If the wait is legitimate, raise timeevents.max_passes.", 2)
+end
+
+function M.pending() return #queue end
+
+function M.peek()
+    local out = {}
+    for i, ev in ipairs(queue) do out[i] = ev.key end
+    return out
+end
+
+function M.reset()
+    queue = {}
+    seq = 0
+    M.max_passes = 32
+end
+
+return M

--- a/tests/harness/world.lua
+++ b/tests/harness/world.lua
@@ -1,0 +1,372 @@
+-- Item / container model, plus the alife simulator object.
+--
+-- Items live in named containers ("actor", "stash", "looter", ...). Specs
+-- assert final placement rather than call sequences:
+--
+--     world.give("actor", "wpn_ak74", { kind = "weapon", condition = 0.8 })
+--     scenario:TransferItems(stash_id)
+--     H.tick()
+--     expect(world.where("wpn_ak74")).toBe("stash")
+--
+-- WHY MUTATIONS ARE DEFERRED
+--
+-- CScriptGameObject::IterateInventory walks the LIVE m_all container with raw
+-- iterators -- no snapshot (script_game_object_inventory_owner.cpp:266). The
+-- mod calls alife_release and transfer_item from inside that loop
+-- (TransferItem, soulslike_scenarios.script:1097/1204/1212), which would
+-- invalidate those iterators if the mutations were immediate.
+--
+-- They are not. transfer_item sends GE_TRADE_SELL / GE_TRADE_BUY network
+-- events (:601-609) processed on a later frame, and alife_release queues an
+-- alife-level release. So we queue too. Two consequences specs must respect:
+--
+--   * Inside iterate_inventory, an item already "released" is STILL PRESENT.
+--   * TransferItems returning does not mean anything moved. Assert after tick.
+--
+-- Snapshotting instead would produce the same loop coverage for the wrong
+-- reason, and would wrongly model items vanishing mid-loop.
+
+local M = {}
+
+-- SERVER vs CLIENT OBJECTS
+--
+-- These are different things in X-Ray and the mod uses both, so the model
+-- keeps two registries:
+--
+--   server object (CSE_Abstract)  -- `.id` is a FIELD, plus .section,
+--     .position, .online, .parent_id, .m_game_vertex_id. Returned by
+--     alife_create, alife_object and alife():object().
+--     e.g. soulslike_scenarios.script:1308  self.logic_state.stash_id = se_stash.id
+--
+--   client object (CScriptGameObject) -- `:id()` is a METHOD, plus :section(),
+--     :is_inv_box_empty(), :iterate_inventory_box(). Returned by
+--     level.object_by_id.
+--     e.g. soulslike.script:599  local id = box:id()
+--
+-- Conflating them makes `se.id` yield a function, which then silently indexes
+-- the registry with a function key and finds nothing.
+
+local next_id
+local items          -- id -> item
+local containers     -- name -> { ordered item ids }
+local holder         -- item id -> container name (nil once destroyed)
+local clients        -- id -> client object (`:id()`)
+local servers        -- id -> server object (`.id`)
+local pending        -- deferred mutations
+
+-- ---------------------------------------------------------------- internals
+
+local function container_of(name)
+    containers[name] = containers[name] or {}
+    return containers[name]
+end
+
+local function remove_from(name, id)
+    local c = containers[name]
+    if not c then return end
+    for i, v in ipairs(c) do
+        if v == id then table.remove(c, i) return end
+    end
+end
+
+local function place(id, name)
+    local from = holder[id]
+    if from then remove_from(from, id) end
+    if name then
+        table.insert(container_of(name), id)
+    end
+    holder[id] = name
+end
+
+-- Resolve whatever the mod passed (game object, server object, id) to a
+-- container name.
+local function name_of(target)
+    if target == nil then return nil end
+    if type(target) == "string" then return target end
+    if type(target) == "number" then
+        local o = clients[target]
+        return o and o._container or nil
+    end
+    if target._container then return target._container end
+    -- client object: :id() is a method; server object: .id is a field
+    local id = (type(target.id) == "function") and target:id() or target.id
+    local o = id and clients[id]
+    return o and o._container or nil
+end
+
+-- ------------------------------------------------------------------- items
+
+--- world.give(container, section, opts) -> item
+function M.give(container, section, opts)
+    opts = opts or {}
+    next_id = next_id + 1
+    local id = next_id
+
+    local item = {
+        _id        = id,
+        _section   = section,
+        _kind      = opts.kind or "item",
+        _condition = opts.condition == nil and 1.0 or opts.condition,
+        _parent    = nil,
+    }
+    function item:id() return self._id end
+    function item:section() return self._section end
+    function item:name() return self._section .. "_" .. self._id end
+    function item:condition() return self._condition end
+    function item:parent() return clients[self._parent] end
+
+    items[id] = item
+    clients[id] = item
+    place(id, container)
+    return item
+end
+
+--- A container that can hold items. Registers a client object (`:id()`) and a
+--- matching server object (`.id`), since the mod reaches containers both ways.
+--- Returns the client object; use M.server(id) for the twin.
+function M.container(name, opts)
+    opts = opts or {}
+    local id = opts.id
+    if not id then
+        next_id = next_id + 1
+        id = next_id
+    end
+
+    local box = {
+        _id = id, _container = name, _kind = opts.kind or "invbox",
+        _section = opts.section or "inv_backpack",
+    }
+    function box:id() return self._id end
+    function box:section() return self._section end
+    function box:name() return name end
+    function box:is_inv_box_empty() return #container_of(name) == 0 end
+    function box:iterate_inventory_box(fn)
+        for _, iid in ipairs(container_of(name)) do
+            if fn(self, items[iid]) == true then return end
+        end
+    end
+    function box:transfer_item(item, to) M.queue_transfer(item, to) end
+
+    container_of(name)
+    clients[id] = box
+
+    servers[id] = {
+        id = id,                                  -- FIELD, not a method
+        section = box._section,
+        position = opts.position,
+        online = opts.online == true,
+        parent_id = opts.parent_id,
+        m_level_vertex_id = opts.level_vertex_id or 1,
+        m_game_vertex_id  = opts.game_vertex_id or 1,
+        _container = name,
+        switch_online = function(self) self.online = true end,
+        create_npc = function() end,
+        squad_members = function() return function() return nil end end,
+    }
+
+    return box
+end
+
+--- The server-object twin of a container or npc.
+function M.server(id) return servers[id] end
+
+--- An NPC that can receive looted items.
+function M.spawn_npc(name, opts)
+    local B = require("harness.builders")
+    opts = opts or {}
+    local npc = B.make_npc(opts)
+    npc._container = name
+    container_of(name)
+    clients[npc:id()] = npc
+    servers[npc:id()] = npc      -- make_npc already carries both shapes
+    return npc
+end
+
+-- ----------------------------------------------------- deferred mutations
+
+function M.queue_transfer(item, to)
+    pending[#pending + 1] = { kind = "transfer", id = item:id(), to = name_of(to) }
+end
+
+function M.queue_release(item)
+    if item == nil then return end
+    local id = type(item) == "number" and item or
+               (type(item.id) == "function" and item:id() or item.id)
+    pending[#pending + 1] = { kind = "release", id = id }
+end
+
+--- Apply everything queued since the last pump. Returns how many were applied.
+function M.pump()
+    local n = 0
+    while #pending > 0 do
+        local batch = pending
+        pending = {}
+        for _, op in ipairs(batch) do
+            n = n + 1
+            if op.kind == "transfer" then
+                if holder[op.id] ~= nil then place(op.id, op.to) end
+            elseif op.kind == "release" then
+                local from = holder[op.id]
+                if from then remove_from(from, op.id) end
+                holder[op.id] = nil
+                -- items[] is kept so where()/destroyed() can still report it;
+                -- the object registries drop it, matching a released object
+                -- disappearing from level.object_by_id.
+                clients[op.id] = nil
+                servers[op.id] = nil
+            end
+        end
+    end
+    return n
+end
+
+-- -------------------------------------------------------------- assertions
+
+--- Container name holding the item, or nil if destroyed / never placed.
+function M.where(item)
+    local id = type(item) == "number" and item or
+               (type(item) == "string" and nil or item:id())
+    if id == nil then                       -- looked up by section name
+        for iid, it in pairs(items) do
+            if it._section == item then return holder[iid] end
+        end
+        return nil
+    end
+    return holder[id]
+end
+
+--- Sections currently in a container, in insertion order.
+function M.contents(name)
+    local out = {}
+    for _, id in ipairs(container_of(name)) do
+        out[#out + 1] = items[id] and items[id]._section or ("obj:" .. id)
+    end
+    return out
+end
+
+--- Sections of every item that has been released.
+function M.destroyed()
+    local out = {}
+    for id, it in pairs(items) do
+        if holder[id] == nil then out[#out + 1] = it._section end
+    end
+    table.sort(out)
+    return out
+end
+
+function M.count(name) return #container_of(name) end
+function M.item_by_section(section)
+    for _, it in pairs(items) do
+        if it._section == section then return it end
+    end
+end
+function M.object(id) return clients[id] end
+
+-- ------------------------------------------------------------------ install
+
+--- Rewires the actor's inventory methods and the alife globals onto the model.
+--- Call after fakes.install and after the actor exists.
+function M.attach_actor(actor, container)
+    container = container or "actor"
+    actor._container = container
+    container_of(container)
+    clients[actor:id()] = actor
+
+    -- Live walk, matching IterateInventory. Iterating a copy of the index list
+    -- is not a snapshot of *contents*: deferred ops have not been applied, so
+    -- released items are still present -- which is the engine's behavior.
+    function actor:iterate_inventory(fn)
+        local ids = container_of(container)
+        for i = 1, #ids do
+            local it = items[ids[i]]
+            if it and fn(self, it) == true then return end
+        end
+    end
+
+    function actor:transfer_item(item, to) M.queue_transfer(item, to) end
+    function actor:is_inv_box_empty() return #container_of(container) == 0 end
+
+    return actor
+end
+
+function M.install(env)
+    env = env or _G
+
+    env.alife_release = function(item) M.queue_release(item) end
+
+    -- Returns the SERVER object (`.id` field) -- that is what the engine hands
+    -- back and what the mod reads (soulslike_scenarios.script:1308).
+    env.alife_create = function(section, pos, lvid, gvid)
+        next_id = next_id + 1
+        local id = next_id
+        local name = "spawned_" .. id
+        M.container(name, {
+            id = id, section = section, position = pos,
+            level_vertex_id = lvid, game_vertex_id = gvid, online = false,
+        })
+        M.created[#M.created + 1] = { id = id, section = section, container = name }
+        return servers[id]
+    end
+
+    env.alife_create_item = function(section, owner, opts)
+        local name = (owner and name_of(owner)) or "actor"
+        return M.give(name, section, opts)
+    end
+
+    env.alife_object = function(id) return servers[id] end
+
+    -- level.object_by_id returns the CLIENT object. Specs exercising the
+    -- "stash is not online yet" retry (HandleItemsAndRespawn:536) call
+    -- world.hide(id) first.
+    local level = env.level
+    M.hidden = {}
+    level.object_by_id = function(id)
+        if M.hidden[id] then return nil end
+        if clients[id] then return clients[id] end
+        return require("harness.fakes").objects[id]
+    end
+
+    env.alife = function() return M.sim end
+
+    M.sim = {
+        actor = function()
+            local a = env.db and env.db.actor
+            if not a then return nil end
+            return {
+                position = a:position(),
+                angle = require("harness.builders").make_vector(),
+                m_level_vertex_id = a:level_vertex_id(),
+                m_game_vertex_id  = a:game_vertex_id(),
+                id = a:id(),
+            }
+        end,
+        object            = function(_, id) return servers[id] end,
+        level_name        = function(_, _) return M.level_name_for_gvid end,
+        teleport_object   = function() end,
+        set_switch_online = function() end,
+        set_switch_offline= function() end,
+        release           = function(_, o) M.queue_release(o) end,
+    }
+    M.level_name_for_gvid = "zaton"
+
+    return env
+end
+
+--- Make an object invisible to level.object_by_id, to exercise the
+--- "stash is not online yet" retry in HandleItemsAndRespawn.
+function M.hide(id) M.hidden[id] = true end
+function M.reveal(id) M.hidden[id] = nil end
+
+function M.reset()
+    next_id = 10000
+    items, containers, holder, pending = {}, {}, {}, {}
+    clients, servers = {}, {}
+    M.created = {}
+    M.hidden = {}
+    M.sim = nil
+    M.level_name_for_gvid = "zaton"
+end
+
+M.reset()
+
+return M

--- a/tests/harness/world.lua
+++ b/tests/harness/world.lua
@@ -140,9 +140,13 @@ function M.container(name, opts)
     function box:section() return self._section end
     function box:name() return name end
     function box:is_inv_box_empty() return #container_of(name) == 0 end
+    -- Stops on ANY truthy return, not just `true`: the engine tests the
+    -- functor result with lua_toboolean
+    -- (script_game_object_inventory_owner.cpp:269, converter at
+    -- luabind/detail/policy.hpp:374), so 0 and "" stop it too.
     function box:iterate_inventory_box(fn)
         for _, iid in ipairs(container_of(name)) do
-            if fn(self, items[iid]) == true then return end
+            if fn(self, items[iid]) then return end
         end
     end
     function box:transfer_item(item, to) M.queue_transfer(item, to) end
@@ -275,11 +279,18 @@ function M.attach_actor(actor, container)
     -- Live walk, matching IterateInventory. Iterating a copy of the index list
     -- is not a snapshot of *contents*: deferred ops have not been applied, so
     -- released items are still present -- which is the engine's behavior.
+    --
+    -- Stops on ANY truthy return. The engine takes a luabind::functor<bool>
+    -- and the bool converter is lua_toboolean(L,i)==1
+    -- (script_game_object_inventory_owner.cpp:269, luabind/detail/policy.hpp:374),
+    -- so returning 0 or "" also stops the walk -- only nil and false continue.
+    -- Note this is the OPPOSITE of CreateTimeEvent, which re-queues on anything
+    -- that is not literally `true` (_g.script:375).
     function actor:iterate_inventory(fn)
         local ids = container_of(container)
         for i = 1, #ids do
             local it = items[ids[i]]
-            if it and fn(self, it) == true then return end
+            if it and fn(self, it) then return end
         end
     end
 
@@ -296,21 +307,67 @@ function M.install(env)
 
     -- Returns the SERVER object (`.id` field) -- that is what the engine hands
     -- back and what the mod reads (soulslike_scenarios.script:1308).
-    env.alife_create = function(section, pos, lvid, gvid)
+    --
+    -- The 5th and 6th args are parent_id and a `register` flag; the mod passes
+    -- both when spawning a weapon part for the Tarkov looter
+    -- (soulslike_scenarios.script:1058). register=false yields an unregistered
+    -- object the caller is expected to hand to alife():register afterwards.
+    env.alife_create = function(section, pos, lvid, gvid, parent_id, register)
         next_id = next_id + 1
         local id = next_id
         local name = "spawned_" .. id
         M.container(name, {
             id = id, section = section, position = pos,
             level_vertex_id = lvid, game_vertex_id = gvid, online = false,
+            parent_id = parent_id,
         })
-        M.created[#M.created + 1] = { id = id, section = section, container = name }
-        return servers[id]
+        local se = servers[id]
+        se.registered = register ~= false
+        M.created[#M.created + 1] = {
+            id = id, section = section, container = name,
+            parent_id = parent_id, registered = se.registered,
+        }
+
+        -- Squad sections spawn their members with the squad object, which is
+        -- what SpawnAmbush then iterates (soulslike_scenarios.script:763).
+        local members = M.squads[section]
+        if members then
+            local B = require("harness.builders")
+            local built = {}
+            for i, m in ipairs(members) do
+                local npc = B.make_se_npc(m)
+                servers[npc.id] = npc
+                built[i] = npc
+            end
+            se.create_npc = require("harness.fakes").recorder("se.create_npc")
+            se.squad_members = function()
+                local i = 0
+                return function() i = i + 1 return built[i] end
+            end
+        end
+
+        return se
     end
 
+    -- Returns a SERVER object too. The mod keys note_message_data by se_note.id
+    -- (soulslike_scenarios.script:1400), which silently produces a
+    -- function-keyed table if this hands back a client object.
     env.alife_create_item = function(section, owner, opts)
         local name = (owner and name_of(owner)) or "actor"
-        return M.give(name, section, opts)
+        local item = M.give(name, section, opts)
+        local id = item:id()
+        servers[id] = servers[id] or {
+            id = id,
+            section = section,
+            position = (opts and opts.position) or nil,
+            online = false,
+            parent_id = owner and
+                (type(owner) == "table" and type(owner.id) == "function"
+                 and owner:id() or (type(owner) == "table" and owner.id))
+                or nil,
+            _container = name,
+        }
+        return servers[id]
     end
 
     env.alife_object = function(id) return servers[id] end
@@ -346,10 +403,36 @@ function M.install(env)
         set_switch_online = function() end,
         set_switch_offline= function() end,
         release           = function(_, o) M.queue_release(o) end,
+
+        -- register() FREES its argument and returns a NEW pointer
+        -- (alife_simulator_script.cpp:396-413) -- the object passed in is
+        -- dangling afterwards. Modelled by swapping in a fresh table under the
+        -- same id, so a spec that keeps using the old reference sees it go
+        -- stale rather than silently working.
+        register = function(_, se)
+            if se == nil then return nil end
+            local id = se.id
+            local fresh = {}
+            for k, v in pairs(se) do fresh[k] = v end
+            fresh.registered = true
+            servers[id] = fresh
+            se.released = true
+            M.registered[#M.registered + 1] = id
+            return fresh
+        end,
     }
     M.level_name_for_gvid = "zaton"
 
     return env
+end
+
+--- Register a server-shaped NPC so the 1..65534 alife scan in
+--- soulslike.find_closest_enemy / _enemy_mutant can find it. Ids start at
+--- 10000, comfortably inside the scanned range.
+function M.spawn_se_npc(opts)
+    local npc = require("harness.builders").make_se_npc(opts)
+    servers[npc.id] = npc
+    return npc
 end
 
 --- Make an object invisible to level.object_by_id, to exercise the
@@ -362,7 +445,11 @@ function M.reset()
     items, containers, holder, pending = {}, {}, {}, {}
     clients, servers = {}, {}
     M.created = {}
+    M.registered = {}
     M.hidden = {}
+    -- section -> list of make_se_npc opts. SpawnAmbush creates its squad
+    -- itself, so members cannot be passed in the way M.container's can.
+    M.squads = {}
     M.sim = nil
     M.level_name_for_gvid = "zaton"
 end

--- a/tests/locals.bat
+++ b/tests/locals.bat
@@ -1,13 +1,20 @@
 @echo off
 REM Soulslike localisation report.
-REM   locals.bat                 report, plus the spec that asserts it
+REM   locals.bat                 the spec that asserts it, then the report
 REM   locals.bat --report        report only, skip the spec
+REM   locals.bat --lax           do not fail on untranslated strings
 REM   locals.bat --no-color      plain output
 REM
 REM Compares every MCM option label against gamedata\configs\text, in both
 REM directions: a node with no translation renders as the raw string id, and a
 REM translation with no node is usually a rename that left the old string
-REM behind. Exit 1 on anything not already recorded in harness\mcm_labels.lua.
+REM behind. Exit 1 on anything not already recorded in harness\mcm_labels.lua,
+REM and on any untranslated string unless --lax is passed.
+REM
+REM The report runs LAST, on purpose. It is the part you came here to read, and
+REM when it ran first its summary scrolled off behind the spec output -- the
+REM last line on screen said PASS while 20 strings were untranslated, which is
+REM the same never-noticed failure this whole tool exists to prevent.
 
 setlocal
 cd /d "%~dp0"
@@ -48,14 +55,23 @@ for /f "tokens=2 delims=:" %%a in ('chcp') do set "_OLDCP=%%a"
 set "_OLDCP=%_OLDCP: =%"
 chcp 65001 >nul 2>&1
 
-"%LUA%" locals.lua %_ARGS%
-set "_RC=%ERRORLEVEL%"
+REM Spec first, report last -- see the note at the top.
+REM
+REM `if errorlevel 1`, never `if not "%ERRORLEVEL%"=="0"`: inside a
+REM parenthesised block cmd substitutes %ERRORLEVEL% when it PARSES the block,
+REM so the comparison reads the value from before the command ran. That is why
+REM a failing spec here used to leave the exit code alone unless the report
+REM happened to fail too.
+set "_RC=0"
 
 if not defined _REPORT_ONLY (
-    echo.
     "%LUA%" run.lua --file mcm_localization %_ARGS%
-    if not "%ERRORLEVEL%"=="0" set "_RC=1"
+    if errorlevel 1 set "_RC=1"
+    echo.
 )
+
+"%LUA%" locals.lua %_ARGS%
+if errorlevel 1 set "_RC=1"
 
 if defined _OLDCP chcp %_OLDCP% >nul 2>&1
 exit /b %_RC%

--- a/tests/locals.bat
+++ b/tests/locals.bat
@@ -1,0 +1,61 @@
+@echo off
+REM Soulslike localisation report.
+REM   locals.bat                 report, plus the spec that asserts it
+REM   locals.bat --report        report only, skip the spec
+REM   locals.bat --no-color      plain output
+REM
+REM Compares every MCM option label against gamedata\configs\text, in both
+REM directions: a node with no translation renders as the raw string id, and a
+REM translation with no node is usually a rename that left the old string
+REM behind. Exit 1 on anything not already recorded in harness\mcm_labels.lua.
+
+setlocal
+cd /d "%~dp0"
+
+set LUA=
+where luajit.exe >nul 2>&1 && set LUA=luajit.exe
+if "%LUA%"=="" if exist "tools\luajit.exe" set LUA=tools\luajit.exe
+
+if "%LUA%"=="" (
+    echo.
+    echo ERROR: no LuaJIT found.
+    echo Put luajit.exe on PATH or at tests\tools\luajit.exe.
+    echo A Lua 5.1-compatible VM is required -- the module loader uses setfenv,
+    echo which was removed in Lua 5.2.
+    exit /b 2
+)
+
+REM --report must come first if used; everything after it is forwarded on.
+set "_REPORT_ONLY="
+if /i "%~1"=="--report" (
+    set "_REPORT_ONLY=1"
+    shift /1
+)
+
+REM Rebuild the remaining args, preserving quoting.
+set "_ARGS=%1"
+:collect
+shift /1
+if not "%~1"=="" (
+    set "_ARGS=%_ARGS% %1"
+    goto collect
+)
+
+REM Coloured output needs code page 65001. Remember the current one and put it
+REM back on the way out -- chcp changes outlive the batch file otherwise.
+set "_OLDCP="
+for /f "tokens=2 delims=:" %%a in ('chcp') do set "_OLDCP=%%a"
+set "_OLDCP=%_OLDCP: =%"
+chcp 65001 >nul 2>&1
+
+"%LUA%" locals.lua %_ARGS%
+set "_RC=%ERRORLEVEL%"
+
+if not defined _REPORT_ONLY (
+    echo.
+    "%LUA%" run.lua --file mcm_localization %_ARGS%
+    if not "%ERRORLEVEL%"=="0" set "_RC=1"
+)
+
+if defined _OLDCP chcp %_OLDCP% >nul 2>&1
+exit /b %_RC%

--- a/tests/locals.lua
+++ b/tests/locals.lua
@@ -8,10 +8,9 @@
 -- This exists because when you are ADDING an option, "18 passing" tells you
 -- nothing; you want the list.
 --
--- Exit 0 when nothing new is broken. Exit 1 on a regression, i.e. anything not
--- already recorded in the baselines in harness/mcm_labels.lua -- or on a stale
--- baseline entry, which is worse than a plain break because it masks the next
--- one in that slot.
+-- Exit 0 when nothing is broken, 1 otherwise. There is no list of accepted
+-- breakages to check against and nothing to add an id to; the only way to
+-- reach exit 0 is to fix the localisation.
 --
 -- Also exit 1 while any string is untranslated. Pass --lax for the report
 -- without that; see the `strict` local below for why it is the default here
@@ -55,11 +54,9 @@ local function heading(text)
     print(C.bold .. C.cyan .. text .. C.reset)
 end
 
---- One category. `tint` colours the new (regression) entries.
-local function report(title, group, tint, note)
-    local n_new, n_known = #group.new, #group.known
-
-    if n_new == 0 and n_known == 0 then
+--- One category. `tint` colours the entries.
+local function report(title, list, tint, note)
+    if #list == 0 then
         print(string.format("  %s%s%s  %s-%s",
             C.gray, title, C.reset, C.gray, C.reset))
         return
@@ -68,11 +65,8 @@ local function report(title, group, tint, note)
     print(string.format("  %s%s%s", C.bold, title, C.reset))
     if note then print("    " .. C.gray .. note .. C.reset) end
 
-    for _, entry in ipairs(group.new) do
-        print("      " .. tint .. "NEW  " .. entry .. C.reset)
-    end
-    for _, entry in ipairs(group.known) do
-        print("      " .. C.gray .. "     " .. entry .. C.reset)
+    for _, entry in ipairs(list) do
+        print("      " .. tint .. entry .. C.reset)
     end
 end
 
@@ -111,12 +105,11 @@ do
     local only_eng = result.parity.only_eng
     local only_rus = result.parity.only_rus
 
-    if #only_eng.new == 0 and #only_eng.known == 0 and #only_rus == 0 then
+    if #only_eng == 0 and #only_rus == 0 then
         print("  " .. C.green .. "eng and rus tables are in step" .. C.reset)
     end
 
-    report(string.format("%d string(s) in eng with no rus",
-                         #only_eng.new + #only_eng.known),
+    report(string.format("%d string(s) in eng with no rus", #only_eng),
            only_eng, C.yellow, "a Russian player sees the raw id")
 
     if #only_rus > 0 then
@@ -147,37 +140,24 @@ if #result.groups > 0 then
     end
 end
 
-if #result.stale > 0 then
-    heading("Stale baseline entries")
-    print("    " .. C.gray ..
-          "these no longer describe reality, and mask the next break in that slot" ..
-          C.reset)
-    for _, entry in ipairs(result.stale) do
-        print("      " .. C.red .. entry .. C.reset)
-    end
-end
-
 -- ---------------------------------------------------------------- summary
 
 -- Two different things, deliberately not added together.
 --
--- BROKEN is a regression: a label that renders as a raw string id, or a
--- baseline that no longer describes reality. It fails.
+-- BROKEN is a defect: a label that renders as a raw string id in the shipped
+-- menu, or a string with nothing pointing at it.
 --
--- DEBT is untranslated text. It is work outstanding, not a defect, and it must
--- not fail a build by default -- but it is reported on every run rather than
--- being absorbed into "known", because a count that only ever goes up is the
--- one thing nobody notices.
+-- DEBT is untranslated text. It is work outstanding, not a defect, so it must
+-- not fail run.bat -- but it is reported on every run, because a count that
+-- only ever goes up is the one thing nobody notices.
 --
 -- A duplicate id and an orphaned rus string are defects, not debt: neither is
 -- work waiting on a translator. One drops a string the file was written to
 -- carry, the other is half a rename.
-local broken = #result.missing_eng.new + #result.literal.new
-             + #result.orphan.new + #result.groups + #result.stale
+local broken = #result.missing_eng + #result.literal
+             + #result.orphan + #result.groups
              + #result.duplicates + #result.parity.only_rus
-local debt = #result.parity.only_eng.new + #result.parity.only_eng.known
-local known = #result.missing_eng.known + #result.literal.known
-            + #result.orphan.known
+local debt = #result.parity.only_eng
 
 print("")
 print(C.gray .. RULE .. C.reset)
@@ -189,12 +169,10 @@ end
 
 if broken > 0 then
     print(C.red .. C.bold .. " BROKEN " .. C.reset ..
-          C.red .. string.format("%d regression(s)", broken) .. C.reset ..
-          debt_note ..
-          C.gray .. string.format("  (%d known)", known) .. C.reset)
+          C.red .. string.format("%d defect(s)", broken) .. C.reset ..
+          debt_note)
     print("")
-    print("  Fix it, or record it in harness/mcm_labels.lua if deliberate.")
-    print("  A stale baseline should be deleted, not updated to match.")
+    print("  Fix the localisation. There is no list to record these in.")
     os.exit(1)
 end
 
@@ -206,10 +184,8 @@ if debt > 0 and strict then
 end
 
 print(C.green .. C.bold .. " OK " .. C.reset ..
-      C.green .. "    no regressions" .. C.reset ..
-      debt_note ..
-      C.gray .. string.format("  (%d known, see harness/mcm_labels.lua)", known)
-      .. C.reset)
+      C.green .. "    nothing broken" .. C.reset ..
+      debt_note)
 
 if debt > 0 then
     print("")

--- a/tests/locals.lua
+++ b/tests/locals.lua
@@ -12,6 +12,10 @@
 -- already recorded in the baselines in harness/mcm_labels.lua -- or on a stale
 -- baseline entry, which is worse than a plain break because it masks the next
 -- one in that slot.
+--
+-- Also exit 1 while any string is untranslated. Pass --lax for the report
+-- without that; see the `strict` local below for why it is the default here
+-- and not in run.bat.
 
 package.path = "./?.lua;" .. package.path
 
@@ -20,9 +24,22 @@ local labels = require("harness.mcm_labels")
 
 -- Colour, matching the spec runner's conventions.
 local color = not os.getenv("NO_COLOR") and not os.getenv("SPEC_NO_COLOR")
-local strict = false
+
+-- Strict by default: untranslated strings fail this run.
+--
+-- Still NOT a defect, and run.bat still passes with them outstanding -- the
+-- split is deliberate. run.bat gates the build on things that are broken;
+-- locals.bat is the translation tool, and a tool you run to look at
+-- translation debt should not exit 0 while there is debt to look at. Reporting
+-- alone was too quiet: the count sat in the middle of the output and the last
+-- line on screen said PASS.
+--
+-- --lax restores the old behaviour for anyone who wants the report without the
+-- exit code. --strict is still accepted, and is now a no-op.
+local strict = true
 for _, a in ipairs(arg or {}) do
     if a == "--no-color" then color = false end
+    if a == "--lax" then strict = false end
     if a == "--strict" then strict = true end
 end
 
@@ -66,12 +83,6 @@ H.fakes.set_random_min()
 
 local result, tree = labels.inspect()
 
--- Set of keys whose Russian gap is NEW, for tinting the parity list.
-result.missing_rus_new = {}
-for _, entry in ipairs(result.missing_rus.new) do
-    result.missing_rus_new[entry:match("([%w_]+)$")] = true
-end
-
 local n_labels = #labels.labels(tree)
 
 print(RULE)
@@ -93,36 +104,39 @@ report("renders, but can never be translated", result.literal, C.red)
 heading("Translation has no node")
 report("usually a rename that left the old string behind", result.orphan, C.yellow)
 
+-- Whole-table, not just MCM labels: the label scan never sees messages, item
+-- names or menu strings, and a gap there is just as visible in game.
 heading("Untranslated")
 do
     local only_eng = result.parity.only_eng
     local only_rus = result.parity.only_rus
 
-    if #only_eng == 0 and #only_rus == 0 then
+    if #only_eng.new == 0 and #only_eng.known == 0 and #only_rus == 0 then
         print("  " .. C.green .. "eng and rus tables are in step" .. C.reset)
     end
 
-    -- Whole-table, not just MCM labels: the label scan never sees messages,
-    -- item names or menu strings, and a gap there is just as visible in game.
-    if #only_eng > 0 then
-        print(string.format("  %s%d string(s) in eng with no rus%s   %s",
-            C.bold, #only_eng, C.reset,
-            C.gray .. "a Russian player sees the raw id" .. C.reset))
-        for _, id in ipairs(only_eng) do
-            local tint = result.missing_rus_new[id] and (C.yellow .. "NEW  ")
-                          or (C.gray .. "     ")
-            print("      " .. tint .. id .. C.reset)
-        end
-    end
+    report(string.format("%d string(s) in eng with no rus",
+                         #only_eng.new + #only_eng.known),
+           only_eng, C.yellow, "a Russian player sees the raw id")
 
     if #only_rus > 0 then
         print("")
         print(string.format("  %s%d string(s) in rus with no eng%s   %s",
             C.bold, #only_rus, C.reset,
-            C.gray .. "usually a stale entry left after a rename" .. C.reset))
+            C.gray .. "a rename applied to one table only" .. C.reset))
         for _, id in ipairs(only_rus) do
-            print("      " .. C.yellow .. id .. C.reset)
+            print("      " .. C.red .. id .. C.reset)
         end
+    end
+end
+
+if #result.duplicates > 0 then
+    heading("String id declared more than once")
+    print("    " .. C.gray ..
+          "the engine keeps one <text> and drops the rest, so the id resolves " ..
+          "and every other check here stays green" .. C.reset)
+    for _, entry in ipairs(result.duplicates) do
+        print("      " .. C.red .. entry .. C.reset)
     end
 end
 
@@ -154,9 +168,14 @@ end
 -- not fail a build by default -- but it is reported on every run rather than
 -- being absorbed into "known", because a count that only ever goes up is the
 -- one thing nobody notices.
+--
+-- A duplicate id and an orphaned rus string are defects, not debt: neither is
+-- work waiting on a translator. One drops a string the file was written to
+-- carry, the other is half a rename.
 local broken = #result.missing_eng.new + #result.literal.new
              + #result.orphan.new + #result.groups + #result.stale
-local debt = #result.parity.only_eng + #result.parity.only_rus
+             + #result.duplicates + #result.parity.only_rus
+local debt = #result.parity.only_eng.new + #result.parity.only_eng.known
 local known = #result.missing_eng.known + #result.literal.known
             + #result.orphan.known
 
@@ -182,7 +201,7 @@ end
 if debt > 0 and strict then
     print(C.red .. C.bold .. " DEBT " .. C.reset ..
           C.red .. string.format("  %d untranslated string(s)", debt) .. C.reset ..
-          C.gray .. "  (--strict)" .. C.reset)
+          C.gray .. "  (nothing is broken; pass --lax to report only)" .. C.reset)
     os.exit(1)
 end
 
@@ -195,8 +214,7 @@ print(C.green .. C.bold .. " OK " .. C.reset ..
 if debt > 0 then
     print("")
     print("  " .. C.gray ..
-          "Untranslated strings do not fail this run. Pass --strict to change that."
-          .. C.reset)
+          "Untranslated strings are reported without failing (--lax)." .. C.reset)
 end
 
 os.exit(0)

--- a/tests/locals.lua
+++ b/tests/locals.lua
@@ -1,0 +1,202 @@
+-- Localisation report. Compares every MCM option label against the shipped
+-- string tables, in both directions, and prints what it finds.
+--
+--   locals.bat
+--   tools\luajit.exe locals.lua
+--
+-- Not a test suite -- unit/mcm_localization.spec.lua asserts the same thing.
+-- This exists because when you are ADDING an option, "18 passing" tells you
+-- nothing; you want the list.
+--
+-- Exit 0 when nothing new is broken. Exit 1 on a regression, i.e. anything not
+-- already recorded in the baselines in harness/mcm_labels.lua -- or on a stale
+-- baseline entry, which is worse than a plain break because it masks the next
+-- one in that slot.
+
+package.path = "./?.lua;" .. package.path
+
+local H = require("harness.init")
+local labels = require("harness.mcm_labels")
+
+-- Colour, matching the spec runner's conventions.
+local color = not os.getenv("NO_COLOR") and not os.getenv("SPEC_NO_COLOR")
+local strict = false
+for _, a in ipairs(arg or {}) do
+    if a == "--no-color" then color = false end
+    if a == "--strict" then strict = true end
+end
+
+local C = color and {
+    reset = "\27[0m", bold = "\27[1m", red = "\27[31m",
+    green = "\27[32m", yellow = "\27[33m", cyan = "\27[36m", gray = "\27[90m",
+} or setmetatable({}, { __index = function() return "" end })
+
+local RULE = string.rep("-", 66)
+
+local function heading(text)
+    print("")
+    print(C.bold .. C.cyan .. text .. C.reset)
+end
+
+--- One category. `tint` colours the new (regression) entries.
+local function report(title, group, tint, note)
+    local n_new, n_known = #group.new, #group.known
+
+    if n_new == 0 and n_known == 0 then
+        print(string.format("  %s%s%s  %s-%s",
+            C.gray, title, C.reset, C.gray, C.reset))
+        return
+    end
+
+    print(string.format("  %s%s%s", C.bold, title, C.reset))
+    if note then print("    " .. C.gray .. note .. C.reset) end
+
+    for _, entry in ipairs(group.new) do
+        print("      " .. tint .. "NEW  " .. entry .. C.reset)
+    end
+    for _, entry in ipairs(group.known) do
+        print("      " .. C.gray .. "     " .. entry .. C.reset)
+    end
+end
+
+-- ------------------------------------------------------------------- run
+
+H.boot{ load = { "soulslike_classes", "soulslike", "soulslike_mcm" } }
+H.fakes.set_random_min()
+
+local result, tree = labels.inspect()
+
+-- Set of keys whose Russian gap is NEW, for tinting the parity list.
+result.missing_rus_new = {}
+for _, entry in ipairs(result.missing_rus.new) do
+    result.missing_rus_new[entry:match("([%w_]+)$")] = true
+end
+
+local n_labels = #labels.labels(tree)
+
+print(RULE)
+print(C.bold .. " MCM localisation" .. C.reset)
+print(RULE)
+print(string.format("  %d option labels   %d eng strings   %d rus strings",
+                    n_labels, result.counts.eng, result.counts.rus))
+print("")
+print("  " .. C.gray ..
+      "derived key = ui_mcm_<root>_<group>_<option>, unless the node sets text" ..
+      C.reset)
+
+heading("Node has no English translation")
+report("renders as the raw string id in the menu", result.missing_eng, C.red)
+
+heading("Node hardcodes English instead of a string id")
+report("renders, but can never be translated", result.literal, C.red)
+
+heading("Translation has no node")
+report("usually a rename that left the old string behind", result.orphan, C.yellow)
+
+heading("Untranslated")
+do
+    local only_eng = result.parity.only_eng
+    local only_rus = result.parity.only_rus
+
+    if #only_eng == 0 and #only_rus == 0 then
+        print("  " .. C.green .. "eng and rus tables are in step" .. C.reset)
+    end
+
+    -- Whole-table, not just MCM labels: the label scan never sees messages,
+    -- item names or menu strings, and a gap there is just as visible in game.
+    if #only_eng > 0 then
+        print(string.format("  %s%d string(s) in eng with no rus%s   %s",
+            C.bold, #only_eng, C.reset,
+            C.gray .. "a Russian player sees the raw id" .. C.reset))
+        for _, id in ipairs(only_eng) do
+            local tint = result.missing_rus_new[id] and (C.yellow .. "NEW  ")
+                          or (C.gray .. "     ")
+            print("      " .. tint .. id .. C.reset)
+        end
+    end
+
+    if #only_rus > 0 then
+        print("")
+        print(string.format("  %s%d string(s) in rus with no eng%s   %s",
+            C.bold, #only_rus, C.reset,
+            C.gray .. "usually a stale entry left after a rename" .. C.reset))
+        for _, id in ipairs(only_rus) do
+            print("      " .. C.yellow .. id .. C.reset)
+        end
+    end
+end
+
+if #result.groups > 0 then
+    heading("Group heading has no translation")
+    for _, entry in ipairs(result.groups) do
+        print("      " .. C.red .. entry .. C.reset)
+    end
+end
+
+if #result.stale > 0 then
+    heading("Stale baseline entries")
+    print("    " .. C.gray ..
+          "these no longer describe reality, and mask the next break in that slot" ..
+          C.reset)
+    for _, entry in ipairs(result.stale) do
+        print("      " .. C.red .. entry .. C.reset)
+    end
+end
+
+-- ---------------------------------------------------------------- summary
+
+-- Two different things, deliberately not added together.
+--
+-- BROKEN is a regression: a label that renders as a raw string id, or a
+-- baseline that no longer describes reality. It fails.
+--
+-- DEBT is untranslated text. It is work outstanding, not a defect, and it must
+-- not fail a build by default -- but it is reported on every run rather than
+-- being absorbed into "known", because a count that only ever goes up is the
+-- one thing nobody notices.
+local broken = #result.missing_eng.new + #result.literal.new
+             + #result.orphan.new + #result.groups + #result.stale
+local debt = #result.parity.only_eng + #result.parity.only_rus
+local known = #result.missing_eng.known + #result.literal.known
+            + #result.orphan.known
+
+print("")
+print(C.gray .. RULE .. C.reset)
+
+local debt_note = ""
+if debt > 0 then
+    debt_note = C.yellow .. string.format("  %d untranslated", debt) .. C.reset
+end
+
+if broken > 0 then
+    print(C.red .. C.bold .. " BROKEN " .. C.reset ..
+          C.red .. string.format("%d regression(s)", broken) .. C.reset ..
+          debt_note ..
+          C.gray .. string.format("  (%d known)", known) .. C.reset)
+    print("")
+    print("  Fix it, or record it in harness/mcm_labels.lua if deliberate.")
+    print("  A stale baseline should be deleted, not updated to match.")
+    os.exit(1)
+end
+
+if debt > 0 and strict then
+    print(C.red .. C.bold .. " DEBT " .. C.reset ..
+          C.red .. string.format("  %d untranslated string(s)", debt) .. C.reset ..
+          C.gray .. "  (--strict)" .. C.reset)
+    os.exit(1)
+end
+
+print(C.green .. C.bold .. " OK " .. C.reset ..
+      C.green .. "    no regressions" .. C.reset ..
+      debt_note ..
+      C.gray .. string.format("  (%d known, see harness/mcm_labels.lua)", known)
+      .. C.reset)
+
+if debt > 0 then
+    print("")
+    print("  " .. C.gray ..
+          "Untranslated strings do not fail this run. Pass --strict to change that."
+          .. C.reset)
+end
+
+os.exit(0)

--- a/tests/probe.lua
+++ b/tests/probe.lua
@@ -1,0 +1,345 @@
+-- Reachability probe. Calls every non-UI mod function once and reports
+-- OK / FAIL. Not a test suite -- it asserts nothing about correctness, only
+-- that the harness can reach each function without an engine.
+--
+--   tools\luajit.exe probe.lua
+--
+-- Exit 0 when everything outside the two UI modules is reachable. That is the
+-- definition of "harness complete"; specs are written against it separately.
+
+package.path = "./?.lua;" .. package.path
+
+local H = require("harness.init")
+local B = H.builders
+local world = H.world
+local fakes = H.fakes
+
+local pass, fail = 0, 0
+local failures = {}
+
+local function probe(label, fn)
+    local ok, err = pcall(fn)
+    if ok then
+        pass = pass + 1
+        print(string.format("  ok   %s", label))
+    else
+        fail = fail + 1
+        local msg = tostring(err):gsub("^.-([%w_]+%.script:%d+)", "%1")
+        print(string.format("  FAIL %s\n         %s", label, msg))
+        failures[#failures + 1] = label .. "  --  " .. msg
+    end
+end
+
+local function section(name) print("\n" .. name) end
+
+-- --------------------------------------------------------------- fresh boot
+
+local MODULES = { "soulslike_classes", "soulslike", "soulslike_mcm",
+                  "soulslike_scenarios", "soulslike_scenario_logic_factory",
+                  "soulslike_message_factory", "soulslike_note" }
+
+local function fresh(opts)
+    opts = opts or {}
+    H.boot{
+        load = MODULES,
+        mods = opts.mods,
+        actor = { rank = 5000, reputation = 100, money = 5000,
+                  level_vertex_id = 111, game_vertex_id = 222 },
+        soulslike_mode = true,
+    }
+    fakes.set_random_const(1)
+    fakes.set_ltx("wpn_ak74", { kind = "w_rifle" })
+    fakes.set_ltx("bread", { kind = "i_food" })
+    fakes.set_ltx("letter", { kind = "letter" })
+    fakes.set_ltx("S_INVBOX", { class = "S_INVBOX" })
+    fakes.set_ltx("simulation_boar", { class = "SM_BOARW", kind = "SM_BOARW" })
+
+    -- A recorded spawn point; without one the mod hits vector():set(nil,...),
+    -- which the engine turns into a CTD. See the note at the end.
+    local st = soulslike.get_soulslike_state()
+    st.spawn_location = { level = "zaton", position = { x = 0, y = 0, z = 0 },
+                          angle = { x = 0, y = 0, z = 0 },
+                          level_vertex_id = 111, game_vertex_id = 222 }
+    return st
+end
+
+-- ============================================================ soulslike.script
+
+section("soulslike.script")
+fresh()
+
+probe("IsSoulslikeMode",            function() return IsSoulslikeMode() end)
+probe("IsToolkit",                  function() return IsToolkit(nil, "itm_basickit") end)
+probe("get_soulslike_state",        function() return soulslike.get_soulslike_state() end)
+probe("debug / info / warn / error",function()
+    soulslike.debug("x"); soulslike.info("x"); soulslike.warn("x"); soulslike.error("x")
+    soulslike.debug({ a = 1, b = { c = 2 } })      -- exercises print_table
+end)
+probe("debug_tip",                  function() soulslike.debug_tip("hi") end)
+probe("try",                        function() return soulslike.try(function() return 1 end) end)
+probe("set_spawn",                  function() soulslike.set_spawn(false) end)
+probe("set_spawn(show_message)",    function() soulslike.set_spawn(true) end)
+probe("force_save",                 function() soulslike.force_save("test") end)
+probe("find_closest_enemy",         function() return soulslike.find_closest_enemy() end)
+probe("find_closest_enemy_mutant",  function() return soulslike.find_closest_enemy_mutant() end)
+probe("find_closest_enemy_stalker", function() return soulslike.find_closest_enemy_stalker() end)
+probe("find_closest_friendly_stalker", function() return soulslike.find_closest_friendly_stalker() end)
+probe("dream_callback",             function() soulslike.dream_callback() end)
+
+-- ------------------------------------------------------- callback handlers
+
+section("soulslike.script -- registered callbacks")
+fresh()
+soulslike.on_game_start()
+
+probe("actor_on_before_hit", function()
+    local mon = world.spawn_npc("looter", { kind = "monster" })
+    SendScriptCallback("actor_on_before_hit",
+        { power = 0.5, type = hit.wound, impulse = 1, draftsman = mon }, 12, {})
+end)
+probe("actor_on_first_update",  function() SendScriptCallback("actor_on_first_update") end)
+probe("on_level_changing",      function() SendScriptCallback("on_level_changing") end)
+probe("save_state",             function() SendScriptCallback("save_state", {}) end)
+probe("load_state",             function() SendScriptCallback("load_state", {}) end)
+probe("on_game_load",           function() SendScriptCallback("on_game_load") end)
+probe("actor_on_sleep",         function() SendScriptCallback("actor_on_sleep", 8) end)
+probe("on_before_save_input",   function() SendScriptCallback("on_before_save_input", {}, 1, "n") end)
+probe("on_console_execute",     function() SendScriptCallback("on_console_execute", "save", "my save") end)
+probe("actor_on_stash_remove",  function() SendScriptCallback("actor_on_stash_remove", { stash_id = 1 }) end)
+
+probe("actor_on_item_take_from_box", function()
+    local box = world.container("box", { section = "inv_backpack" })
+    SendScriptCallback("actor_on_item_take_from_box", box,
+                       world.give("actor", "medkit"))
+end)
+
+probe("physic_object_on_use_callback", function()
+    local box = world.container("hidden", { kind = "invbox" })
+    SendScriptCallback("physic_object_on_use_callback", box, db.actor)
+end)
+
+probe("actor_on_before_death", function()
+    local mon = world.spawn_npc("looter", { kind = "monster" })
+    SendScriptCallback("actor_on_before_hit",
+        { power = 99, type = hit.wound, impulse = 1, draftsman = mon }, 12, {})
+    SendScriptCallback("actor_on_before_death", mon, {})
+    H.tick()
+end)
+
+probe("wakeup_callback (after a death)", function() soulslike.wakeup_callback() end)
+
+-- ================================================== scenario_logic_factory
+
+section("soulslike_scenario_logic_factory.script")
+fresh()
+
+probe("create_by_id x4", function()
+    for id = 1, 4 do
+        assert(soulslike_scenario_logic_factory.create_by_id(id), "nil for id " .. id)
+    end
+end)
+probe("compute_fatal_hit_info", function()
+    local f = H.loader.upvalue(soulslike_scenario_logic_factory.create_new,
+                               "compute_fatal_hit_info")
+    return f({})
+end)
+probe("find_backpack", function()
+    local f = H.loader.upvalue(soulslike_scenario_logic_factory.create_new,
+                               "find_backpack")
+    return f()
+end)
+probe("create_new (no hits)",  function()
+    return soulslike_scenario_logic_factory.create_new({})
+end)
+probe("create_new (monster kill)", function()
+    local mon = world.spawn_npc("m", { kind = "monster" })
+    fakes.register_object(mon)
+    return soulslike_scenario_logic_factory.create_new({
+        { power = 50, is_fatal = true, time = 0, draftsman_id = mon:id() },
+    })
+end)
+
+-- ======================================================= soulslike_scenarios
+
+section("soulslike_scenarios.script -- base methods")
+fresh{ mods = { "item_parts", "item_radio", "treasure_manager",
+                "actor_status_thirst", "magazine_binder", "arszi_psy" } }
+
+local function scenario()
+    local s = DefaultSoulslikeScenarioLogic()
+    s:SetLevelName("zaton"); s:SetLootScalar(1); s:SetIsInDoor(false)
+    s:SetIsInWater(false)
+    return s
+end
+
+probe("setters (9)", function()
+    local s = scenario()
+    local npc = world.spawn_npc("n", { kind = "stalker" })
+    s:SetRescuer(npc); s:SetLooter(npc)
+    s:SetLooterType(soulslike.entity_type.Stalker)
+    s:SetKiller(npc); s:SetKillerType(soulslike.entity_type.Stalker)
+    s:SetFatalHitType(hit.wound)
+end)
+probe("HealActor",            function() scenario():HealActor() end)
+probe("ApplyRankLoss",        function() scenario():ApplyRankLoss() end)
+probe("ApplyReputationLoss",  function() scenario():ApplyReputationLoss() end)
+probe("ApplyMoneyLoss",       function() scenario():ApplyMoneyLoss() end)
+probe("IsItemLossAllowed",    function()
+    return scenario():IsItemLossAllowed(world.give("actor", "wpn_ak74", { kind = "weapon" }))
+end)
+probe("ApplyItemConditionLoss (weapon)", function()
+    scenario():ApplyItemConditionLoss(
+        world.give("actor", "wpn_ak74", { kind = "weapon" }), nil, 0.5)
+end)
+probe("ApplyItemConditionLoss (other)", function()
+    scenario():ApplyItemConditionLoss(world.give("actor", "medkit"), nil, 0.5)
+end)
+probe("ApplyTransferItemsPreConditions", function()
+    scenario():ApplyTransferItemsPreConditions()
+end)
+probe("TryStalkerLooter", function()
+    local s = scenario()
+    s.logic_state.allow_npc_looting = true
+    return s:TryStalkerLooter(world.give("actor", "medkit"), nil,
+                              world.spawn_npc("looter", { kind = "stalker" }))
+end)
+probe("TryMonsterLooter", function()
+    local s = scenario()
+    s.logic_state.allow_npc_looting = true
+    fakes.set_ltx("meat", { kind = "i_mutant_raw" })
+    return s:TryMonsterLooter(world.give("actor", "meat"), nil,
+                              world.spawn_npc("mon", { kind = "monster" }))
+end)
+probe("TryTarkovLooter", function()
+    local s = scenario()
+    return s:TryTarkovLooter(world.give("actor", "medkit"),
+                             world.container("st"),
+                             world.spawn_npc("l2", { kind = "stalker" }))
+end)
+probe("TransferItem", function()
+    local s = scenario()
+    return s:TransferItem(world.give("actor", "medkit"), world.container("st2"), nil)
+end)
+probe("TransferItems", function()
+    local s = scenario()
+    world.give("actor", "medkit")
+    local box = world.container("st3")
+    s:TransferItems(box:id())
+    H.tick()
+end)
+probe("CreateStash x4", function()
+    for _, cls in ipairs({ "DefaultSoulslikeScenarioLogic",
+                           "RFDetectorSoulslikeScenarioLogic",
+                           "HiddenStashSoulslikeScenarioLogic",
+                           "NoLossSoulslikeScenarioLogic" }) do
+        local s = _G[cls]()
+        s:SetLevelName("zaton"); s:SetLootScalar(1)
+        s:CreateStash()
+    end
+end)
+probe("ApplyTransferItemsPostConditions x4", function()
+    for _, cls in ipairs({ "DefaultSoulslikeScenarioLogic",
+                           "RFDetectorSoulslikeScenarioLogic",
+                           "HiddenStashSoulslikeScenarioLogic",
+                           "NoLossSoulslikeScenarioLogic" }) do
+        local s = _G[cls]()
+        s.logic_state.stash_id = world.container("pc_" .. cls):id()
+        s:ApplyTransferItemsPostConditions()
+    end
+end)
+probe("GiveFoodAndWater",  function() scenario():GiveFoodAndWater() end)
+probe("GiveMeds/Weapon/Outfit/Mask", function()
+    local s = scenario()
+    s:GiveMeds(); s:GiveWeapon(); s:GiveOutfit(); s:GiveMask()
+end)
+probe("TrackAmbusher", function()
+    scenario():TrackAmbusher(1, anim.look_around, move.standing, move.stand,
+                             look.search, { x = 0, y = 0, z = 0 }, 1, 1)
+end)
+probe("SpawnAmbush (mutant)", function()
+    local s = scenario()
+    s.logic_state.killer_type = soulslike.entity_type.Monster
+    s.logic_state.has_mutant_bait = true
+    s.logic_state.mutant_ambush_chance = 1
+    s.logic_state.death_location = { position = { x = 0, y = 0, z = 0 },
+                                     level_vertex_id = 1, game_vertex_id = 1 }
+    s:SpawnAmbush()
+end)
+probe("StopSurgeAndStorm",  function() scenario():StopSurgeAndStorm() end)
+probe("AdvanceTime",        function() scenario():AdvanceTime() end)
+probe("SendWakeupMessage",  function() scenario():SendWakeupMessage() end)
+probe("RespawnActor",       function() scenario():RespawnActor(); H.tick() end)
+probe("HandleItemsAndRespawn", function()
+    world.give("actor", "medkit")
+    scenario():HandleItemsAndRespawn()
+    H.tick()
+end)
+probe("TransferAndRespawn", function()
+    scenario():TransferAndRespawn(world.container("st4"):id()); H.tick()
+end)
+probe("OnDeath",    function() scenario():OnDeath(); H.tick() end)
+probe("OnComplete", function() scenario():OnComplete() end)
+probe("OnRespawn",  function() scenario():OnRespawn() end)
+probe("destroy",    function() scenario():destroy() end)
+probe("ignore_list (file-local)", function()
+    local f = H.loader.upvalue(soulslike_scenarios.SoulslikeScenarioLogic
+                               and nil or _G.NoLossSoulslikeScenarioLogic.IsItemLossAllowed,
+                               "ignore_list")
+    return f and f("bolt")
+end)
+probe("NoLoss overrides", function()
+    local s = NoLossSoulslikeScenarioLogic()
+    s:TransferItems(nil)
+    return s:IsItemLossAllowed(world.give("actor", "medkit"))
+end)
+
+-- ==================================================== message factory + note
+
+section("soulslike_message_factory.script / soulslike_note.script")
+fresh()
+
+probe("create (rescuer)",    function()
+    return soulslike_message_factory.create(true, { gave_food_or_water = true })
+end)
+probe("create (no rescuer)", function()
+    return soulslike_message_factory.create(nil, {})
+end)
+probe("menu_read", function()
+    local note = world.give("actor", "letter")
+    note._parent = db.actor:id()
+    return soulslike_note.menu_read(note)
+end)
+probe("func_radio_freq", function()
+    local note = world.give("actor", "letter")
+    local st = soulslike.get_soulslike_state()
+    st.note_message_data[note:id()] = { freq = "121.5", level_name = "zaton" }
+    return soulslike_note.func_radio_freq(note)
+end)
+
+-- ============================================================= soulslike_mcm
+
+section("soulslike_mcm.script")
+fresh()
+
+probe("on_mcm_load", function() return soulslike_mcm.on_mcm_load() end)
+probe("every getter", function()
+    local n = 0
+    for name, fn in pairs(soulslike_mcm) do
+        if type(fn) == "function" and name ~= "on_mcm_load" then
+            fn("ignore_bolt")     -- the one getter taking an argument
+            n = n + 1
+        end
+    end
+    assert(n > 50, "expected 50+ getters, saw " .. n)
+end)
+
+-- ==================================================================== report
+
+print("")
+print(string.rep("-", 66))
+print(string.format("%d reachable, %d unreachable", pass, fail))
+if fail > 0 then
+    print("")
+    for i, f in ipairs(failures) do print(string.format("  %d) %s", i, f)) end
+end
+os.exit(fail == 0 and 0 or 1)

--- a/tests/probe.lua
+++ b/tests/probe.lua
@@ -281,11 +281,17 @@ probe("OnDeath",    function() scenario():OnDeath(); H.tick() end)
 probe("OnComplete", function() scenario():OnComplete() end)
 probe("OnRespawn",  function() scenario():OnRespawn() end)
 probe("destroy",    function() scenario():destroy() end)
+-- TransferItem is the only caller of both file-local guards, so it is the
+-- anchor that actually carries them as upvalues. (This previously reached for
+-- NoLoss:IsItemLossAllowed, which is a bare `return false` and closes over
+-- nothing -- the probe resolved nil and called it.)
 probe("ignore_list (file-local)", function()
-    local f = H.loader.upvalue(soulslike_scenarios.SoulslikeScenarioLogic
-                               and nil or _G.NoLossSoulslikeScenarioLogic.IsItemLossAllowed,
-                               "ignore_list")
-    return f and f("bolt")
+    local f = H.loader.upvalue(_G.SoulslikeScenarioLogic.TransferItem, "ignore_list")
+    return assert(f, "ignore_list is no longer an upvalue of TransferItem")("bolt")
+end)
+probe("is_equipped (file-local)", function()
+    local f = H.loader.upvalue(_G.SoulslikeScenarioLogic.TransferItem, "is_equipped")
+    return assert(f, "is_equipped is no longer an upvalue of TransferItem")(1)
 end)
 probe("NoLoss overrides", function()
     local s = NoLossSoulslikeScenarioLogic()

--- a/tests/run.bat
+++ b/tests/run.bat
@@ -1,10 +1,16 @@
 @echo off
 REM Soulslike spec suite.
-REM   run.bat                  all specs (self-tests gate the unit specs)
+REM   run.bat                  all specs (self-tests gate unit and e2e)
 REM   run.bat self             harness self-tests only
 REM   run.bat unit             unit specs only
+REM   run.bat e2e              end-to-end journeys only
+REM   run.bat --file ambush    only spec files whose path contains "ambush"
+REM   run.bat -t "keep roll"   only tests whose full name contains "keep roll"
 REM   run.bat --no-color       plain output
 REM   run.bat --ascii          ok/XX instead of the tick and cross
+REM
+REM Spec files are discovered from self\, unit\ and e2e\ -- a new *.spec.lua
+REM needs no registration. Either filter skips the self-test gate.
 
 setlocal
 cd /d "%~dp0"

--- a/tests/run.bat
+++ b/tests/run.bat
@@ -1,0 +1,37 @@
+@echo off
+REM Soulslike spec suite.
+REM   run.bat                  all specs (self-tests gate the unit specs)
+REM   run.bat self             harness self-tests only
+REM   run.bat unit             unit specs only
+REM   run.bat --no-color       plain output
+REM   run.bat --ascii          ok/XX instead of the tick and cross
+
+setlocal
+cd /d "%~dp0"
+
+set LUA=
+where luajit.exe >nul 2>&1 && set LUA=luajit.exe
+if "%LUA%"=="" if exist "tools\luajit.exe" set LUA=tools\luajit.exe
+
+if "%LUA%"=="" (
+    echo.
+    echo ERROR: no LuaJIT found.
+    echo Put luajit.exe on PATH or at tests\tools\luajit.exe.
+    echo A Lua 5.1-compatible VM is required -- the module loader uses setfenv,
+    echo which was removed in Lua 5.2.
+    exit /b 2
+)
+
+REM The tick and cross are UTF-8, so the console needs code page 65001.
+REM Remember the current one and put it back on the way out -- chcp changes
+REM outlive the batch file otherwise.
+set "_OLDCP="
+for /f "tokens=2 delims=:" %%a in ('chcp') do set "_OLDCP=%%a"
+set "_OLDCP=%_OLDCP: =%"
+chcp 65001 >nul 2>&1
+
+"%LUA%" run.lua %*
+set "_RC=%ERRORLEVEL%"
+
+if defined _OLDCP chcp %_OLDCP% >nul 2>&1
+exit /b %_RC%

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -1,0 +1,81 @@
+-- Test entry point. Run via run.bat, or:
+--   tools\luajit.exe run.lua            (all specs)
+--   tools\luajit.exe run.lua self       (harness self-tests only)
+--   tools\luajit.exe run.lua unit       (unit specs only)
+--
+-- Flags:
+--   --no-color   plain output (also honours NO_COLOR / SPEC_NO_COLOR)
+--   --ascii      ok/XX instead of the tick and cross, for a non-UTF-8 console
+
+package.path = "./?.lua;" .. package.path
+
+local spec = require("harness.spec")
+
+-- Loaded with dofile rather than require: `.spec.lua` is the TS-idiomatic
+-- filename but the dots do not map onto require's module paths.
+local SELF = {
+    "self/class.spec.lua",
+    "self/loader.spec.lua",
+    "self/dispatch.spec.lua",
+    "self/timeevents.spec.lua",
+    "self/world.spec.lua",
+    "self/mods.spec.lua",
+}
+
+local UNIT = {
+    "unit/helpers.spec.lua",
+    "unit/timed_queue.spec.lua",
+    "unit/state_shape.spec.lua",
+    "unit/message_factory.spec.lua",
+    "unit/fatal_hit.spec.lua",
+}
+
+-- Flags anywhere in the args; the first non-flag word selects the suite.
+local which = "all"
+for _, a in ipairs(arg or {}) do
+    if a == "--no-color" then
+        spec.configure{ color = false }
+    elseif a == "--ascii" then
+        spec.configure{ unicode = false }
+    elseif a ~= "" and a:sub(1, 2) ~= "--" then
+        which = a
+    end
+end
+
+local function load_all(files)
+    for _, path in ipairs(files) do
+        local ok, err = pcall(dofile, path)
+        if not ok then
+            print("")
+            print("!! failed to load " .. path)
+            print("   " .. tostring(type(err) == "table" and err.msg or err))
+            os.exit(2)
+        end
+    end
+end
+
+if which == "self" then
+    load_all(SELF)
+    os.exit(spec.run() == 0 and 0 or 1)
+end
+
+if which == "unit" then
+    load_all(UNIT)
+    os.exit(spec.run() == 0 and 0 or 1)
+end
+
+-- Full run. Self-tests gate the unit specs: if the harness is not faithful,
+-- unit results mean nothing, so a self-test failure aborts before unit/ runs.
+load_all(SELF)
+local self_failed = spec.run()
+if self_failed > 0 then
+    print("")
+    print("!! harness self-tests failed -- unit specs skipped.")
+    print("   Fix the harness first; unit results would not be trustworthy.")
+    os.exit(1)
+end
+
+print("")
+spec.reset()
+load_all(UNIT)
+os.exit(spec.run() == 0 and 0 or 1)

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -2,80 +2,176 @@
 --   tools\luajit.exe run.lua            (all specs)
 --   tools\luajit.exe run.lua self       (harness self-tests only)
 --   tools\luajit.exe run.lua unit       (unit specs only)
+--   tools\luajit.exe run.lua e2e        (end-to-end journeys only)
 --
 -- Flags:
---   --no-color   plain output (also honours NO_COLOR / SPEC_NO_COLOR)
---   --ascii      ok/XX instead of the tick and cross, for a non-UTF-8 console
+--   --no-color        plain output (also honours NO_COLOR / SPEC_NO_COLOR)
+--   --ascii           ok/XX instead of the tick and cross, for a non-UTF-8 console
+--   --file <substr>   only load spec files whose path contains <substr>
+--   -t, --test <substr>
+--                     only run tests whose full name contains <substr>
+--
+-- Spec files are discovered from the suite directories, so a new *.spec.lua is
+-- picked up without editing this file. MANIFEST below is a fallback for hosts
+-- where the directory listing is unavailable (io.popen disabled, or a shell
+-- that is not cmd) -- keep it current enough to run, but discovery is the
+-- normal path.
 
 package.path = "./?.lua;" .. package.path
 
 local spec = require("harness.spec")
 
--- Loaded with dofile rather than require: `.spec.lua` is the TS-idiomatic
--- filename but the dots do not map onto require's module paths.
-local SELF = {
-    "self/class.spec.lua",
-    "self/loader.spec.lua",
-    "self/dispatch.spec.lua",
-    "self/timeevents.spec.lua",
-    "self/world.spec.lua",
-    "self/mods.spec.lua",
+local SUITES = { "self", "unit", "e2e" }
+
+local MANIFEST = {
+    self = {
+        "self/class.spec.lua",
+        "self/loader.spec.lua",
+        "self/dispatch.spec.lua",
+        "self/timeevents.spec.lua",
+        "self/world.spec.lua",
+        "self/mods.spec.lua",
+    },
+    unit = {
+        "unit/helpers.spec.lua",
+        "unit/timed_queue.spec.lua",
+        "unit/state_shape.spec.lua",
+        "unit/message_factory.spec.lua",
+        "unit/fatal_hit.spec.lua",
+    },
+    e2e = {},
 }
 
-local UNIT = {
-    "unit/helpers.spec.lua",
-    "unit/timed_queue.spec.lua",
-    "unit/state_shape.spec.lua",
-    "unit/message_factory.spec.lua",
-    "unit/fatal_hit.spec.lua",
-}
+-- Discovery via `dir /b`, which lists bare filenames and nothing else. Sorted
+-- explicitly: cmd already returns alphabetical order, but relying on that
+-- across shells would make test order host-dependent.
+local function discover(dir)
+    local ok, pipe = pcall(io.popen, 'dir /b /a-d "' .. dir .. '\\*.spec.lua" 2>nul')
+    if not ok or not pipe then return nil end
 
--- Flags anywhere in the args; the first non-flag word selects the suite.
-local which = "all"
-for _, a in ipairs(arg or {}) do
+    local found = {}
+    for line in pipe:lines() do
+        local name = line:gsub("%s+$", "")
+        if name ~= "" then found[#found + 1] = dir .. "/" .. name end
+    end
+    pipe:close()
+
+    if #found == 0 then return nil end
+    table.sort(found)
+    return found
+end
+
+local function files_for(suite)
+    return discover(suite) or MANIFEST[suite] or {}
+end
+
+-- ------------------------------------------------------------------- args
+
+local which, file_filter, name_filter = "all", nil, nil
+
+local args = arg or {}
+local i = 1
+while i <= #args do
+    local a = args[i]
     if a == "--no-color" then
         spec.configure{ color = false }
     elseif a == "--ascii" then
         spec.configure{ unicode = false }
-    elseif a ~= "" and a:sub(1, 2) ~= "--" then
-        which = a
-    end
-end
-
-local function load_all(files)
-    for _, path in ipairs(files) do
-        local ok, err = pcall(dofile, path)
-        if not ok then
-            print("")
-            print("!! failed to load " .. path)
-            print("   " .. tostring(type(err) == "table" and err.msg or err))
+    elseif a == "--file" then
+        i = i + 1
+        file_filter = args[i]
+        if not file_filter then
+            print("!! --file needs a value")
             os.exit(2)
         end
+    elseif a == "-t" or a == "--test" then
+        i = i + 1
+        local t = args[i]
+        if not t then
+            print("!! " .. a .. " needs a value")
+            os.exit(2)
+        end
+        name_filter = t
+        spec.filter(t)
+    elseif a ~= "" and a:sub(1, 1) ~= "-" then
+        which = a
     end
+    i = i + 1
 end
 
-if which == "self" then
-    load_all(SELF)
+-- ---------------------------------------------------------------- loading
+
+-- Loaded with dofile rather than require: `.spec.lua` is the TS-idiomatic
+-- filename but the dots do not map onto require's module paths.
+local function load_all(files)
+    local loaded = 0
+    for _, path in ipairs(files) do
+        if not file_filter or path:find(file_filter, 1, true) then
+            local ok, err = pcall(dofile, path)
+            if not ok then
+                print("")
+                print("!! failed to load " .. path)
+                print("   " .. tostring(type(err) == "table" and err.msg or err))
+                os.exit(2)
+            end
+            loaded = loaded + 1
+        end
+    end
+    return loaded
+end
+
+local function load_suite(suite)
+    return load_all(files_for(suite))
+end
+
+if which ~= "all" and not MANIFEST[which] then
+    print("!! unknown suite '" .. which .. "' -- expected one of: " ..
+          table.concat(SUITES, ", "))
+    os.exit(2)
+end
+
+-- A --file filter that matches no spec file is a typo, and would otherwise
+-- report as a green run of zero tests.
+local function require_loaded(count, what)
+    if count > 0 then return end
+    if file_filter then
+        print("!! no spec files matched --file " .. string.format("%q", file_filter))
+    else
+        print("!! no spec files found in " .. (what or "the requested suite") ..
+              "/ -- nothing to run")
+    end
+    os.exit(2)
+end
+
+if which ~= "all" then
+    require_loaded(load_suite(which), which)
     os.exit(spec.run() == 0 and 0 or 1)
 end
 
-if which == "unit" then
-    load_all(UNIT)
+-- Either filter turns this into a "run just these" invocation: load every
+-- suite into one registry and report once. The self-test gate is skipped
+-- deliberately -- gating would either drag the whole self-suite into a
+-- targeted run, or (for -t) abort because the filter selected nothing from
+-- self/, which the runner cannot distinguish from a real harness failure.
+if file_filter or name_filter then
+    local n = 0
+    for _, suite in ipairs(SUITES) do n = n + load_suite(suite) end
+    require_loaded(n)
     os.exit(spec.run() == 0 and 0 or 1)
 end
 
--- Full run. Self-tests gate the unit specs: if the harness is not faithful,
--- unit results mean nothing, so a self-test failure aborts before unit/ runs.
-load_all(SELF)
+-- Full run. Self-tests gate the rest: if the harness is not faithful, unit and
+-- e2e results mean nothing, so a self-test failure aborts before they run.
+require_loaded(load_suite("self"), "self")
 local self_failed = spec.run()
 if self_failed > 0 then
     print("")
-    print("!! harness self-tests failed -- unit specs skipped.")
-    print("   Fix the harness first; unit results would not be trustworthy.")
+    print("!! harness self-tests failed -- unit and e2e specs skipped.")
+    print("   Fix the harness first; their results would not be trustworthy.")
     os.exit(1)
 end
 
 print("")
 spec.reset()
-load_all(UNIT)
+require_loaded(load_suite("unit") + load_suite("e2e"), "unit and e2e")
 os.exit(spec.run() == 0 and 0 or 1)

--- a/tests/self/builders.spec.lua
+++ b/tests/self/builders.spec.lua
@@ -1,0 +1,320 @@
+-- Harness self-test: the scenario fixtures and the engine-fidelity behavior
+-- baked into make_actor.
+--
+-- The drift guard in "make_logic_state() / schema" is the load-bearing one. The
+-- fixture is a hand-written literal, so a field added to or removed from the
+-- mod's logic_state would otherwise leave every scenario spec asserting against
+-- a shape the mod no longer has.
+
+local H = require("harness.init")
+local B = H.builders
+
+local MOD_SCRIPTS = {
+    "soulslike_classes", "soulslike", "soulslike_mcm",
+    "soulslike_message_factory", "soulslike_scenarios",
+    "soulslike_scenario_logic_factory",
+}
+
+local function keys_of(t)
+    local out = {}
+    for k in pairs(t) do out[#out + 1] = k end
+    table.sort(out)
+    return out
+end
+
+describe("harness/builders", function()
+
+    describe("make_logic_state()", function()
+
+        beforeEach(function() H.boot() end)
+
+        describe("given no options", function()
+            it("returns the MCM defaults", function()
+                local s = B.make_logic_state()
+                expect(s.item_loss_scalar).toBeCloseTo(0.2)
+                expect(s.health_loss_percent).toBeCloseTo(0.75)
+                expect(s.allow_weapon_loss).toBe(true)
+                expect(s.keep_equipped_items_on_death).toBe(false)
+            end)
+
+            it("gives death_location a real position, not the mod's nils", function()
+                local s = B.make_logic_state()
+                expect(s.death_location.position.x).toBe(0)
+            end)
+        end)
+
+        describe("given top-level overrides", function()
+            it("applies them over the defaults", function()
+                local s = B.make_logic_state{ allow_weapon_loss = false, rank = 5000 }
+                expect(s.allow_weapon_loss).toBe(false)
+                expect(s.rank).toBe(5000)
+            end)
+
+            it("leaves the untouched fields at their defaults", function()
+                local s = B.make_logic_state{ allow_weapon_loss = false }
+                expect(s.allow_outfit_loss).toBe(true)
+            end)
+
+            it("accepts false without falling back to the default", function()
+                local s = B.make_logic_state{ allow_npc_looting = false }
+                expect(s.allow_npc_looting).toBe(false)
+            end)
+        end)
+
+        describe("given a story override", function()
+            it("merges one level deep rather than replacing the table", function()
+                local s = B.make_logic_state{ story = { items_were_lost = true } }
+                expect(s.story.items_were_lost).toBe(true)
+                -- Still present, i.e. the whole story table was not swapped out.
+                expect(s.story).toBeDefined()
+                local has_level_name = false
+                for k in pairs(B.make_logic_state().story) do
+                    if k == "level_name" then has_level_name = true end
+                end
+                expect(has_level_name).toBe(false)  -- declared nil, so absent
+            end)
+        end)
+
+        describe("given death_location = false", function()
+            it("clears the coordinates, for the no-location-recorded case", function()
+                local s = B.make_logic_state{ death_location = false }
+                expect(s.death_location.position.x).toBeNil()
+                expect(s.death_location.game_vertex_id).toBeNil()
+            end)
+        end)
+
+        describe("given a partial death_location", function()
+            it("merges the position without dropping the other axes", function()
+                local s = B.make_logic_state{ death_location = { position = { x = 12 } } }
+                expect(s.death_location.position.x).toBe(12)
+                expect(s.death_location.position.y).toBe(0)
+            end)
+        end)
+
+        describe("schema", function()
+            -- Drift guard. If this fails, the mod's logic_state changed and
+            -- default_logic_state() in builders.lua has to change with it.
+            it("has the same keys the mod's __init builds", function()
+                H.boot{ load = MOD_SCRIPTS }
+                H.fakes.set_random_min()
+
+                local real = _G.DefaultSoulslikeScenarioLogic().logic_state
+                local mine = B.make_logic_state()
+
+                -- scenario_id is stamped by the subclass after __init runs, so
+                -- it is not part of the base shape the fixture models.
+                real.scenario_id = nil
+
+                expect(keys_of(mine)).toEqual(keys_of(real))
+            end)
+
+            it("has the same story keys", function()
+                H.boot{ load = MOD_SCRIPTS }
+                H.fakes.set_random_min()
+                local real = _G.DefaultSoulslikeScenarioLogic().logic_state
+                expect(keys_of(B.make_logic_state().story)).toEqual(keys_of(real.story))
+            end)
+        end)
+    end)
+
+    describe("make_spawn_location()", function()
+
+        beforeEach(function() H.boot() end)
+
+        it("defaults to a usable level and origin", function()
+            local s = B.make_spawn_location()
+            expect(s.level).toBe("zaton")
+            expect(s.position.x).toBe(0)
+            expect(s.angle.z).toBe(0)
+        end)
+
+        it("takes overrides", function()
+            local s = B.make_spawn_location{ level = "jupiter", position = { x = 3, z = 4 } }
+            expect(s.level).toBe("jupiter")
+            expect(s.position.x).toBe(3)
+            expect(s.position.z).toBe(4)
+            expect(s.position.y).toBe(0)
+        end)
+    end)
+
+    describe("make_scenario()", function()
+
+        beforeEach(function()
+            H.boot{ load = MOD_SCRIPTS }
+            H.fakes.set_random_min()
+        end)
+
+        it("defaults to the Default scenario", function()
+            expect(B.make_scenario().logic_state.scenario_id).toBe(1)
+        end)
+
+        it("constructs the requested subclass", function()
+            local s = B.make_scenario{ class = "NoLossSoulslikeScenarioLogic" }
+            expect(H.class.is_instance(s, _G.NoLossSoulslikeScenarioLogic)).toBe(true)
+        end)
+
+        it("applies the setters create_new would", function()
+            local s = B.make_scenario{ level_name = "jupiter", loot_scalar = 0.25 }
+            expect(s.logic_state.story.level_name).toBe("jupiter")
+            expect(s.logic_state.scenario_loot_scalar).toBeCloseTo(0.25)
+        end)
+
+        it("merges state overrides into logic_state", function()
+            local s = B.make_scenario{ state = { allow_weapon_loss = false } }
+            expect(s.logic_state.allow_weapon_loss).toBe(false)
+        end)
+
+        it("merges story overrides without replacing the table", function()
+            local s = B.make_scenario{ state = { story = { items_were_lost = true } } }
+            expect(s.logic_state.story.items_were_lost).toBe(true)
+            expect(s.logic_state.story.level_name).toBe("zaton")
+        end)
+
+        it("raises a useful error when the scripts are not loaded", function()
+            H.boot()
+            expect(function() B.make_scenario() end).toThrow("no class")
+        end)
+    end)
+
+    describe("make_se_npc()", function()
+
+        beforeEach(function() H.boot() end)
+
+        -- Server objects expose id and position as FIELDS
+        -- (xrServer_Objects_script.cpp:110-124); client objects use methods.
+        -- soulslike.find_closest_enemy:317 reads se_obj.position directly.
+        it("exposes id as a field, not a method", function()
+            expect(B.make_se_npc().id).toBeType("number")
+        end)
+
+        it("exposes position as a field with distance methods", function()
+            local se = B.make_se_npc{ position = { x = 3, y = 0, z = 4 } }
+            expect(se.position.x).toBe(3)
+            expect(se.position:distance_to({ x = 0, y = 0, z = 0 })).toBeCloseTo(5)
+        end)
+
+        it("carries the accessors the alife scan calls", function()
+            local se = B.make_se_npc{ community = "bandit" }
+            expect(se:community()).toBe("bandit")
+            expect(se:alive()).toBe(true)
+            expect(se:section_name()).toBe("sim_default_stalker")
+            expect(se.m_game_vertex_id).toBe(1)
+        end)
+
+        it("returns a clsid the Is* predicates classify", function()
+            expect(_G.IsStalker(nil, B.make_se_npc{ kind = "stalker" }:clsid())).toBe(true)
+            expect(_G.IsMonster(nil, B.make_se_npc{ kind = "monster" }:clsid())).toBe(true)
+            expect(_G.IsStalker(nil, B.make_se_npc{ kind = "monster" }:clsid())).toBe(false)
+        end)
+    end)
+
+    describe("stub_finders()", function()
+
+        beforeEach(function()
+            H.boot{ load = MOD_SCRIPTS }
+        end)
+
+        it("returns the object it was given", function()
+            local friend = B.make_stalker()
+            B.stub_finders{ friendly_stalker = friend }
+            expect(_G.soulslike.find_closest_friendly_stalker()).toBe(friend)
+        end)
+
+        it("returns nil for a finder that was not stubbed", function()
+            B.stub_finders{}
+            expect(_G.soulslike.find_closest_enemy()).toBeNil()
+        end)
+
+        it("accepts the full function name as the key", function()
+            local e = B.make_monster()
+            B.stub_finders{ find_closest_enemy_mutant = e }
+            expect(_G.soulslike.find_closest_enemy_mutant()).toBe(e)
+        end)
+
+        -- Which finder ran distinguishes selection branches that otherwise look
+        -- identical (soulslike_scenario_logic_factory.script:256 vs :272).
+        it("counts calls per finder", function()
+            B.stub_finders{}
+            _G.soulslike.find_closest_enemy_stalker()
+            _G.soulslike.find_closest_enemy_stalker()
+            expect(B.finder_count("enemy_stalker")).toBe(2)
+            expect(B.finder_count("enemy_mutant")).toBe(0)
+        end)
+
+        it("resets the counts on each call", function()
+            B.stub_finders{}
+            _G.soulslike.find_closest_enemy()
+            B.stub_finders{}
+            expect(B.finder_count("enemy")).toBe(0)
+        end)
+
+        it("stubs the real scan, which would walk 65534 alife slots", function()
+            B.stub_finders{}
+            -- No alife sim configured; the real helper would still return nil,
+            -- so prove the stub ran by way of the counter.
+            _G.soulslike.find_closest_enemy()
+            expect(B.finder_count("enemy")).toBe(1)
+        end)
+    end)
+
+    describe("make_actor() engine fidelity", function()
+
+        beforeEach(function() H.boot() end)
+
+        describe("rank and reputation", function()
+            -- Both are int-typed and luabind truncates TOWARD ZERO via
+            -- static_cast (policy.hpp:377), which is not floor for negatives.
+            it("truncates a positive float toward zero", function()
+                _G.db.actor:set_character_rank(5.9)
+                expect(_G.db.actor:character_rank()).toBe(5)
+            end)
+
+            it("truncates a negative float toward zero, not down", function()
+                _G.db.actor:set_character_rank(-5.9)
+                expect(_G.db.actor:character_rank()).toBe(-5)
+            end)
+
+            it("does not clamp -- nothing in the engine bounds these", function()
+                _G.db.actor:set_character_reputation(-9000)
+                expect(_G.db.actor:character_reputation()).toBe(-9000)
+            end)
+        end)
+
+        describe("money", function()
+            it("adds and subtracts", function()
+                local a = H.set_actor{ money = 1000 }
+                a:give_money(-250)
+                expect(a:money()).toBe(750)
+            end)
+
+            -- give_money takes an int and set_money takes u32, with no clamp
+            -- (InventoryOwner.cpp:630-645). Deducting more than the actor holds
+            -- underflows rather than flooring at zero.
+            it("underflows instead of clamping at zero", function()
+                local a = H.set_actor{ money = 100 }
+                a:give_money(-101)
+                expect(a:money()).toBe(4294967295)
+            end)
+        end)
+
+        describe("item_in_slot", function()
+            -- Slot 0 is NO_ACTIVE_SLOT and is rejected outright
+            -- (Inventory.cpp:658-664).
+            it("returns nil for slot 0", function()
+                local a = H.set_actor{ slots = { [0] = B.make_item{ section = "x" } } }
+                expect(a:item_in_slot(0)).toBeNil()
+            end)
+
+            -- LAST_SLOT is CUSTOM_SLOT_5 = 18 because MORE_INVENTORY_SLOTS is
+            -- defined in this build (inventory_space.h:40).
+            it("serves slots past HELMET(12), up to LAST_SLOT(18)", function()
+                local pack = B.make_item{ section = "itm_actor_backpack" }
+                local a = H.set_actor{ slots = { [13] = pack } }
+                expect(a:item_in_slot(13)).toBe(pack)
+                expect(a.LAST_SLOT).toBe(18)
+            end)
+        end)
+    end)
+end)
+
+return true

--- a/tests/self/class.spec.lua
+++ b/tests/self/class.spec.lua
@@ -231,6 +231,42 @@ describe("harness/class", function()
             expect(H.class.is_instance(P3(), Unrelated)).toBeFalsy()
         end)
     end)
+
+    describe("registration lifetime", function()
+        -- `class "X"` writes a true global and nothing in Lua removes it. Left
+        -- alone, a spec that never loaded soulslike_scenarios would still find
+        -- the class a PREVIOUS spec left on _G, and pass for the wrong reason.
+        -- A fresh game has no classes until the declaring script runs.
+        describe("given a class was declared before a re-boot", function()
+            it("is gone from _G afterwards", function()
+                class "LeakCanary" ; function LeakCanary:__init() end
+                expect(_G.LeakCanary).toBeDefined()
+                H.boot()
+                expect(_G.LeakCanary).toBeNil()
+            end)
+
+            it("drops it from the registered list", function()
+                class "LeakCanary2" ; function LeakCanary2:__init() end
+                H.boot()
+                expect(H.class.registered_names()).toEqual({})
+            end)
+        end)
+
+        describe("given classes declared in this boot", function()
+            it("reports them", function()
+                class "Alpha" ; class "Beta"
+                expect(H.class.registered_names()).toEqual({ "Alpha", "Beta" })
+            end)
+        end)
+
+        it("does not disturb unrelated globals", function()
+            _G.__not_a_class = 7
+            class "Gamma"
+            H.boot()
+            expect(_G.__not_a_class).toBe(7)
+            _G.__not_a_class = nil
+        end)
+    end)
 end)
 
 return true

--- a/tests/self/class.spec.lua
+++ b/tests/self/class.spec.lua
@@ -1,0 +1,236 @@
+-- Harness self-test: the luabind `class` shim.
+-- If these fail, every spec that constructs a scenario object is meaningless.
+
+local H = require("harness.init")
+
+describe("harness/class", function()
+
+    beforeEach(function() H.boot() end)
+
+    describe("class(name)", function()
+
+        describe("given a name", function()
+            it("installs a constructor-callable global under that name", function()
+                class "Widget"
+                expect(_G.Widget).toBeDefined()
+                expect(_G.Widget).toBeType("table")
+            end)
+
+            it("rejects a non-string name", function()
+                expect(function() class({}) end).toThrow("expected class name")
+            end)
+        end)
+
+        describe("given a declared __init", function()
+            it("runs it on construction with the constructor arguments", function()
+                class "Widget"
+                function Widget:__init(a, b) self.a, self.b = a, b end
+
+                local w = Widget(1, 2)
+                expect(w.a).toBe(1)
+                expect(w.b).toBe(2)
+            end)
+        end)
+
+        describe("given no __init at all", function()
+            it("still constructs an instance", function()
+                class "Bare"
+                expect(Bare()).toBeDefined()
+            end)
+        end)
+    end)
+
+    describe("instance member lookup", function()
+
+        it("resolves methods declared on the class", function()
+            class "Greeter"
+            function Greeter:__init(n) self.n = n end
+            function Greeter:hello() return "hi " .. self.n end
+
+            expect(Greeter("bob"):hello()).toBe("hi bob")
+        end)
+
+        it("keeps per-instance state separate", function()
+            class "Counter"
+            function Counter:__init() self.items = {} end
+            function Counter:add(v) table.insert(self.items, v) end
+
+            local a, b = Counter(), Counter()
+            a:add(1)
+            expect(a.items).toHaveLength(1)
+            expect(b.items).toHaveLength(0)
+        end)
+    end)
+
+    describe("class(name)(Base)", function()
+
+        describe("given a base class", function()
+            it("makes the base's methods reachable from the derived instance", function()
+                class "Base1"
+                function Base1:__init() self.tag = "base" end
+                function Base1:shared() return "from-base" end
+
+                class "Derived1" (Base1)
+                function Derived1:__init() super() end
+
+                expect(Derived1():shared()).toBe("from-base")
+            end)
+
+            it("rejects a base that is not a class table", function()
+                class "Derived1b"
+                expect(function() _G.class("Bad")("not a class") end)
+                    .toThrow("expected class to derive from")
+            end)
+        end)
+
+        describe("given the base declares __init", function()
+            -- create_class.cpp:36-62 skips __init and __finalize when copying
+            -- the base member table down.
+            it("does NOT inherit __init", function()
+                class "Base4"
+                function Base4:__init() self.ran = true end
+
+                class "Derived4" (Base4)   -- deliberately no __init
+
+                expect(Derived4().ran).toBeNil()
+            end)
+
+            it("does NOT inherit __finalize", function()
+                class "Base5"
+                function Base5:__init() end
+                function Base5:__finalize() end
+
+                class "Derived5" (Base5)
+                function Derived5:__init() super() end
+
+                expect(rawget(Derived5, "__finalize")).toBeNil()
+            end)
+        end)
+    end)
+
+    describe("super()", function()
+
+        describe("given a two-level chain", function()
+            it("runs the base __init", function()
+                class "Base2"
+                function Base2:__init() self.tag = "base" end
+
+                class "Derived2" (Base2)
+                function Derived2:__init() super() end
+
+                expect(Derived2().tag).toBe("base")
+            end)
+
+            it("forwards its arguments to the base __init", function()
+                class "Base2b"
+                function Base2b:__init(state) self.state = state end
+
+                class "Derived2b" (Base2b)
+                function Derived2b:__init(state)
+                    super(state)
+                    self.extra = "d"
+                end
+
+                local d = Derived2b({ k = "v" })
+                expect(d.state.k).toBe("v")
+                expect(d.extra).toBe("d")
+            end)
+        end)
+
+        describe("given a three-level chain", function()
+            -- The subtle one. A naive "parent of the instance's class"
+            -- implementation calls A twice and never runs B.
+            it("resolves against the class whose __init is running", function()
+                local order = {}
+
+                class "A3"
+                function A3:__init() order[#order + 1] = "A" end
+
+                class "B3" (A3)
+                function B3:__init() super(); order[#order + 1] = "B" end
+
+                class "C3" (B3)
+                function C3:__init() super(); order[#order + 1] = "C" end
+
+                C3()
+                expect(order).toEqual({ "A", "B", "C" })
+            end)
+        end)
+
+        describe("after construction completes", function()
+            it("is removed from the global scope", function()
+                class "Base6"
+                function Base6:__init() end
+                class "Derived6" (Base6)
+                function Derived6:__init() super() end
+
+                Derived6()
+                expect(rawget(_G, "super")).toBeNil()
+            end)
+        end)
+    end)
+
+    describe("error handling", function()
+
+        describe("given __init raises", function()
+            it("propagates the original error to the caller", function()
+                class "Boom"
+                function Boom:__init() error("kaboom") end
+
+                expect(function() Boom() end).toThrow("kaboom")
+            end)
+
+            it("still restores super", function()
+                class "Boom2"
+                function Boom2:__init() error("kaboom") end
+
+                pcall(function() Boom2() end)
+                expect(rawget(_G, "super")).toBeNil()
+            end)
+        end)
+    end)
+
+    describe("interaction with a local named `class`", function()
+        -- soulslike_scenarios.script:738 does exactly this:
+        --     local class = ini_sys:r_string_ex(section,"class")
+        describe("given a method shadows `class` with a local", function()
+            it("does not disturb the shadowing method", function()
+                class "Shadower"
+                function Shadower:__init() end
+                function Shadower:doit()
+                    local class = "just a string"
+                    return class
+                end
+
+                expect(Shadower():doit()).toBe("just a string")
+            end)
+
+            it("leaves the global usable afterwards", function()
+                class "AfterShadow"
+                function AfterShadow:__init() self.ok = true end
+                expect(AfterShadow().ok).toBeTruthy()
+            end)
+        end)
+    end)
+
+    describe("is_instance()", function()
+        it("matches the instance's own class", function()
+            class "P" ; function P:__init() end
+            expect(H.class.is_instance(P(), P)).toBeTruthy()
+        end)
+
+        it("matches an ancestor class", function()
+            class "P2" ; function P2:__init() end
+            class "Q2" (P2) ; function Q2:__init() super() end
+            expect(H.class.is_instance(Q2(), P2)).toBeTruthy()
+        end)
+
+        it("does not match an unrelated class", function()
+            class "P3" ; function P3:__init() end
+            class "Unrelated" ; function Unrelated:__init() end
+            expect(H.class.is_instance(P3(), Unrelated)).toBeFalsy()
+        end)
+    end)
+end)
+
+return true

--- a/tests/self/dispatch.spec.lua
+++ b/tests/self/dispatch.spec.lua
@@ -1,0 +1,200 @@
+-- Harness self-test: the callback registry behind RegisterScriptCallback /
+-- SendScriptCallback (transcribed from axr_main.script:240-285).
+
+local H = require("harness.init")
+local dispatch = H.dispatch
+
+describe("harness/dispatch", function()
+
+    beforeEach(function() H.boot() end)
+
+    describe("RegisterScriptCallback()", function()
+
+        describe("given the intercept was never added", function()
+            -- The trap: axr_main requires callback_add before callback_set.
+            -- Without it, registration is dropped with only a printf. A
+            -- harness that "helpfully" auto-created the intercept would hide a
+            -- real class of mod bug.
+            it("does not create the intercept implicitly", function()
+                RegisterScriptCallback("never_added_xyz", function() end)
+                expect(dispatch.exists("never_added_xyz")).toBeFalsy()
+            end)
+
+            it("reports the dropped registration", function()
+                RegisterScriptCallback("never_added_xyz", function() end)
+                expect(dispatch.warnings).toHaveLength(1)
+            end)
+
+            it("leaves the handler unreachable", function()
+                local fired = false
+                RegisterScriptCallback("never_added_xyz", function() fired = true end)
+                SendScriptCallback("never_added_xyz")
+                expect(fired).toBeFalsy()
+            end)
+        end)
+
+        describe("given a nil handler", function()
+            it("rejects it", function()
+                dispatch.add("evt")
+                RegisterScriptCallback("evt", nil)
+                expect(dispatch.handler_count("evt")).toBe(0)
+            end)
+
+            it("reports the rejection", function()
+                dispatch.add("evt")
+                RegisterScriptCallback("evt", nil)
+                expect(dispatch.warnings).toHaveLength(1)
+            end)
+        end)
+
+        describe("given the same function registered twice", function()
+            it("stores it once, because intercepts is a set", function()
+                dispatch.add("evt")
+                local fn = function() end
+                RegisterScriptCallback("evt", fn)
+                RegisterScriptCallback("evt", fn)
+                expect(dispatch.handler_count("evt")).toBe(1)
+            end)
+
+            it("invokes it once per send", function()
+                dispatch.add("evt")
+                local count = 0
+                local fn = function() count = count + 1 end
+                RegisterScriptCallback("evt", fn)
+                RegisterScriptCallback("evt", fn)
+                SendScriptCallback("evt")
+                expect(count).toBe(1)
+            end)
+        end)
+    end)
+
+    describe("SendScriptCallback()", function()
+
+        describe("given a registered function handler", function()
+            it("invokes it", function()
+                dispatch.add("evt")
+                local seen
+                RegisterScriptCallback("evt", function(a) seen = a end)
+                SendScriptCallback("evt", "payload")
+                expect(seen).toBe("payload")
+            end)
+
+            it("forwards every argument, preserving arity across a nil", function()
+                dispatch.add("evt")
+                local got
+                RegisterScriptCallback("evt", function(...)
+                    got = { n = select("#", ...), ... }
+                end)
+                SendScriptCallback("evt", 1, nil, "three")
+                expect(got.n).toBe(3)
+                expect(got[1]).toBe(1)
+                expect(got[3]).toBe("three")
+            end)
+        end)
+
+        describe("given several handlers on one name", function()
+            it("invokes all of them", function()
+                dispatch.add("evt")
+                local count = 0
+                RegisterScriptCallback("evt", function() count = count + 1 end)
+                RegisterScriptCallback("evt", function() count = count + 1 end)
+                SendScriptCallback("evt")
+                expect(count).toBe(2)
+            end)
+        end)
+
+        describe("given an object carrying a method of the same name", function()
+            -- make_callback's second branch:
+            --   func_or_userdata[name](func_or_userdata, ...)
+            it("calls the method with the object as self", function()
+                dispatch.add("on_thing")
+                local obj = { hits = 0 }
+                function obj:on_thing(v) self.hits = self.hits + 1; self.last = v end
+
+                RegisterScriptCallback("on_thing", obj)
+                SendScriptCallback("on_thing", "x")
+
+                expect(obj.hits).toBe(1)
+                expect(obj.last).toBe("x")
+            end)
+        end)
+
+        describe("given axr_main declares a function of the same name", function()
+            it("invokes that too", function()      -- _g.script:120-123
+                dispatch.add("evt")
+                local via_axr
+                axr_main.evt = function(v) via_axr = v end
+                SendScriptCallback("evt", "direct")
+                expect(via_axr).toBe("direct")
+                axr_main.evt = nil
+            end)
+        end)
+
+        describe("given an unknown name", function()
+            it("does not raise", function()
+                expect(function() SendScriptCallback("nope_not_here") end).never.toThrow()
+            end)
+
+            it("reports it", function()
+                SendScriptCallback("nope_not_here")
+                expect(dispatch.warnings).toHaveLength(1)
+            end)
+        end)
+
+        describe("given any send", function()
+            it("logs it for assertion", function()
+                dispatch.add("evt")
+                SendScriptCallback("evt", 42)
+                local sends = dispatch.sends_of("evt")
+                expect(sends).toHaveLength(1)
+                expect(sends[1].args[1]).toBe(42)
+            end)
+        end)
+    end)
+
+    describe("UnregisterScriptCallback()", function()
+        describe("given a registered handler", function()
+            it("removes it", function()
+                dispatch.add("evt")
+                local fn = function() end
+                RegisterScriptCallback("evt", fn)
+                UnregisterScriptCallback("evt", fn)
+                expect(dispatch.handler_count("evt")).toBe(0)
+            end)
+
+            it("stops it being invoked", function()
+                dispatch.add("evt")
+                local count = 0
+                local fn = function() count = count + 1 end
+                RegisterScriptCallback("evt", fn)
+                UnregisterScriptCallback("evt", fn)
+                SendScriptCallback("evt")
+                expect(count).toBe(0)
+            end)
+        end)
+    end)
+
+    describe("pre-registered intercepts", function()
+        -- soulslike.on_game_start (soulslike.script:948-965) registers these.
+        -- If any is missing from CALLBACK_NAMES its handler is silently
+        -- dropped and every integration spec built on it passes vacuously.
+        local required = {
+            "actor_on_stash_remove", "actor_on_first_update",
+            "actor_on_item_take_from_box", "actor_on_before_death",
+            "on_before_save_input", "save_state", "load_state",
+            "on_level_changing", "on_game_load", "actor_on_sleep",
+            "on_console_execute", "actor_on_before_hit",
+            "physic_object_on_use_callback",
+        }
+
+        describe("given a freshly booted harness", function()
+            for _, name in ipairs(required) do
+                it("has an intercept for " .. name, function()
+                    expect(dispatch.exists(name)).toBeTruthy()
+                end)
+            end
+        end)
+    end)
+end)
+
+return true

--- a/tests/self/fakes.spec.lua
+++ b/tests/self/fakes.spec.lua
@@ -1,0 +1,197 @@
+-- Harness self-test: RNG accounting, the clsid registry, the save-file shim
+-- and the online-stalker registry.
+--
+-- The save-FS specs matter because on_console_execute's pruning walk
+-- (soulslike.script:658-695) does a real io.open on each sibling save before
+-- decoding it. Without a working shim the loop body never runs, and a spec
+-- asserting "no save was deleted" would pass for the wrong reason.
+
+local H = require("harness.init")
+local F = H.fakes
+
+describe("harness/fakes", function()
+
+    describe("random_count()", function()
+
+        beforeEach(function() H.boot() end)
+
+        it("starts at zero", function()
+            expect(F.random_count()).toBe(0)
+        end)
+
+        it("counts every roll", function()
+            F.set_random_const(0.5)
+            math.random(); math.random(); math.random()
+            expect(F.random_count()).toBe(3)
+        end)
+
+        it("counts ranged rolls too", function()
+            F.set_random_const(1)
+            math.random(1, 100)
+            expect(F.random_count()).toBe(1)
+        end)
+
+        -- Reading the count must not consume a queued value, or an exact-budget
+        -- assertion would change the behavior it is measuring.
+        it("does not consume a queued value", function()
+            F.set_random_sequence{ 0.1, 0.2 }
+            F.random_count(); F.random_count()
+            expect(math.random()).toBeCloseTo(0.1)
+        end)
+
+        it("resets on boot", function()
+            F.set_random_const(0.5)
+            math.random()
+            H.boot()
+            expect(F.random_count()).toBe(0)
+        end)
+    end)
+
+    describe("math.random enforcement", function()
+
+        beforeEach(function() H.boot() end)
+
+        it("raises when a spec has not pinned it", function()
+            expect(function() math.random() end).toThrow("set_random")
+        end)
+
+        it("raises past the end of a queued sequence", function()
+            F.set_random_sequence{ 0.5 }
+            math.random()
+            expect(function() math.random() end).toThrow("only 1 values were queued")
+        end)
+    end)
+
+    describe("clsid registry", function()
+
+        beforeEach(function() H.boot() end)
+
+        -- The real predicates resolve `cls or obj:clsid()` (_g.script:3081), and
+        -- soulslike.find_closest_enemy:307 calls them with obj=nil and an
+        -- explicit clsid, so dispatching on the tag alone is not enough.
+        it("classifies by clsid when the object is nil", function()
+            expect(_G.IsStalker(nil, F.clsid_for("stalker"))).toBe(true)
+            expect(_G.IsMonster(nil, F.clsid_for("monster"))).toBe(true)
+        end)
+
+        it("still classifies by the _kind tag when no clsid is given", function()
+            expect(_G.IsMonster(H.builders.make_monster())).toBe(true)
+        end)
+
+        it("lets the clsid argument win over the object", function()
+            local stalker = H.builders.make_stalker()
+            expect(_G.IsMonster(stalker, F.clsid_for("monster"))).toBe(true)
+        end)
+
+        it("is false for a nil object with no clsid", function()
+            expect(_G.IsStalker(nil)).toBe(false)
+        end)
+
+        it("returns an opaque value, never a number", function()
+            -- Engine clsids are runtime ordinals of the sorted class registry
+            -- (object_factory_script.cpp:85), so a numeric fixture would be
+            -- asserting a fiction.
+            expect(F.clsid_for("weapon")).toBeType("string")
+        end)
+
+        -- Grenades derive from CMissile, not CWeapon (Grenade.h:6), and Anomaly's
+        -- weapon_classes table holds no grenade clsids (_g.script:3081-3149).
+        it("keeps grenades disjoint from weapons", function()
+            expect(_G.IsWeapon(nil, F.clsid_for("grenade"))).toBe(false)
+            expect(_G.IsGrenade(nil, F.clsid_for("grenade"))).toBe(true)
+        end)
+    end)
+
+    describe("save file shim", function()
+
+        beforeEach(function()
+            H.boot()
+            F.install_save_fs()
+        end)
+
+        it("serves a staged save through io.open", function()
+            F.set_save("autosave", { soulslike = { uuid = "abc" } })
+            local f = io.open("saves/autosave.scoc", "rb")
+            expect(f).toBeDefined()
+            expect(_G.alife_storage_manager.decode(f:read("*all")).soulslike.uuid).toBe("abc")
+        end)
+
+        it("returns nil for a save that was never staged", function()
+            expect(io.open("saves/missing.scoc", "rb")).toBeNil()
+        end)
+
+        it("models an unreadable file when staged with nil", function()
+            F.set_save("corrupt", nil)
+            expect(io.open("saves/corrupt.scoc", "rb")).toBeNil()
+        end)
+
+        -- The module loader reads .script files off disk with io.open
+        -- (loader.lua:83), so the shim must not swallow ordinary paths.
+        it("delegates non-save paths to the real io.open", function()
+            local f = io.open("run.lua", "r")
+            expect(f).toBeDefined()
+            expect(f:read("*l")).toContain("Test entry point")
+            f:close()
+        end)
+
+        it("is uninstalled by the next boot", function()
+            F.set_save("autosave", { soulslike = {} })
+            H.boot()
+            expect(io.open("saves/autosave.scoc", "rb")).toBeNil()
+        end)
+
+        it("survives being installed twice", function()
+            F.install_save_fs()
+            F.set_save("s", { soulslike = { uuid = "u" } })
+            expect(io.open("saves/s.scoc", "rb")).toBeDefined()
+        end)
+    end)
+
+    describe("set_online_stalkers()", function()
+
+        beforeEach(function() H.boot() end)
+
+        -- db.OnlineStalkers plus db.storage are the only inputs to
+        -- find_closest_enemy_stalker / _friendly_stalker (soulslike.script:370).
+        it("fills OnlineStalkers with the ids", function()
+            local a, b = H.builders.make_stalker(), H.builders.make_stalker()
+            F.set_online_stalkers{ a, b }
+            expect(_G.db.OnlineStalkers).toEqual({ a:id(), b:id() })
+        end)
+
+        it("puts each npc in db.storage", function()
+            local a = H.builders.make_stalker()
+            F.set_online_stalkers{ a }
+            expect(_G.db.storage[a:id()].object).toBe(a)
+        end)
+
+        it("registers them for level.object_by_id", function()
+            local a = H.builders.make_stalker()
+            F.set_online_stalkers{ a }
+            expect(_G.level.object_by_id(a:id())).toBe(a)
+        end)
+
+        it("replaces the previous list rather than appending", function()
+            F.set_online_stalkers{ H.builders.make_stalker() }
+            F.set_online_stalkers{}
+            expect(#_G.db.OnlineStalkers).toBe(0)
+        end)
+    end)
+
+    describe("set_level()", function()
+
+        beforeEach(function() H.boot() end)
+
+        it("changes what level.name() reports", function()
+            F.set_level("jupiter")
+            expect(_G.level.name()).toBe("jupiter")
+        end)
+
+        it("defaults to zaton, which is a valid outdoor level", function()
+            expect(_G.level.name()).toBe("zaton")
+            expect(_G.level_weathers.valid_levels[_G.level.name()]).toBe(true)
+        end)
+    end)
+end)
+
+return true

--- a/tests/self/fixtures/fixture_auto.script
+++ b/tests/self/fixtures/fixture_auto.script
@@ -1,0 +1,1 @@
+MARKER = "autoloaded"

--- a/tests/self/fixtures/fixture_circular_a.script
+++ b/tests/self/fixtures/fixture_circular_a.script
@@ -1,0 +1,3 @@
+-- Reads its partner at file scope; the partner reads back.
+local partner = fixture_circular_b
+A_SAW_PARTNER = partner ~= nil

--- a/tests/self/fixtures/fixture_circular_b.script
+++ b/tests/self/fixtures/fixture_circular_b.script
@@ -1,0 +1,2 @@
+local partner = fixture_circular_a
+B_SAW_PARTNER = partner ~= nil

--- a/tests/self/fixtures/fixture_counter.script
+++ b/tests/self/fixtures/fixture_counter.script
@@ -1,0 +1,2 @@
+-- A fresh table each execution, so a double-load is detectable by identity.
+instance = {}

--- a/tests/self/fixtures/fixture_lines.script
+++ b/tests/self/fixtures/fixture_lines.script
@@ -1,0 +1,3 @@
+-- line 1
+-- line 2
+error("raised from source line 3")

--- a/tests/self/fixtures/fixture_scope.script
+++ b/tests/self/fixtures/fixture_scope.script
@@ -1,0 +1,19 @@
+-- Exercises where names land under the engine's namespace wrapper.
+
+MODULE_LOCAL = "yes"
+
+function _G.fixture_explicit_global()
+    return "global"
+end
+
+function math.fixture_added()
+    return "mutated"
+end
+
+function read_outer()
+    return OUTER_VALUE
+end
+
+function who()
+    return script_name()
+end

--- a/tests/self/fixtures/fixture_upvalue.script
+++ b/tests/self/fixtures/fixture_upvalue.script
@@ -1,0 +1,12 @@
+-- `hidden_helper` is file-local and never exported, mirroring
+-- compute_fatal_hit_info in soulslike_scenario_logic_factory.script:8.
+-- Because `exported` references it, it becomes an upvalue of `exported`
+-- and is reachable via debug.getupvalue.
+
+local function hidden_helper(n)
+    return n * 2
+end
+
+function exported(n)
+    return hidden_helper(n) + 1
+end

--- a/tests/self/init.spec.lua
+++ b/tests/self/init.spec.lua
@@ -1,0 +1,124 @@
+-- Harness self-test: boot/reboot lifecycle and the spawn-point fixture.
+--
+-- H.reboot is what makes the save/load round-trip testable at all: a plain
+-- H.boot wipes the save table, so a "reload" would have nothing to restore
+-- from. It models a level change -- every script re-executes and every module
+-- table is discarded, but alife_storage_manager's state survives.
+
+local H = require("harness.init")
+
+local MOD_SCRIPTS = { "soulslike_classes", "soulslike" }
+
+describe("harness/init", function()
+
+    describe("boot{ state = ... }", function()
+        -- fakes.game_state is the whole save table; the mod's own state lives
+        -- under the "soulslike" key (soulslike.script:210), which is what
+        -- opts.state seeds.
+        it("seeds the mod's sub-table of the save", function()
+            H.boot{ state = { created_stashes = { [42] = { examine = true } } } }
+            expect(H.fakes.game_state.soulslike.created_stashes[42].examine).toBe(true)
+        end)
+
+        it("is visible to get_soulslike_state()", function()
+            H.boot{ load = MOD_SCRIPTS, state = { uuid = "seeded" } }
+            expect(soulslike.get_soulslike_state().uuid).toBe("seeded")
+        end)
+
+        it("still gets the missing collections repaired onto it", function()
+            H.boot{ load = MOD_SCRIPTS, state = { uuid = "seeded" } }
+            expect(soulslike.get_soulslike_state().created_stashes).toBeDefined()
+        end)
+
+        it("is wiped by a plain boot", function()
+            H.boot{ state = { uuid = "seeded" } }
+            H.boot()
+            expect(H.fakes.game_state.soulslike).toBeNil()
+        end)
+    end)
+
+    describe("set_spawn()", function()
+
+        beforeEach(function() H.boot{ load = MOD_SCRIPTS } end)
+
+        it("records a spawn point into the save", function()
+            H.set_spawn{ level = "jupiter" }
+            expect(soulslike.get_soulslike_state().spawn_location.level).toBe("jupiter")
+        end)
+
+        -- Without this, RespawnActor builds a vector out of nil coordinates,
+        -- which strict_vectors raises on and the engine hard-crashes on
+        -- (soulslike_scenarios.script:845).
+        it("gives the position real coordinates", function()
+            local s = H.set_spawn{ position = { x = 10, y = 2, z = 30 } }
+            expect(s.position.x).toBe(10)
+            expect(s.position.z).toBe(30)
+        end)
+
+        it("returns the recorded table", function()
+            expect(H.set_spawn()).toBe(soulslike.get_soulslike_state().spawn_location)
+        end)
+    end)
+
+    describe("reboot()", function()
+
+        beforeEach(function()
+            H.boot{ load = MOD_SCRIPTS, soulslike_mode = true }
+        end)
+
+        it("preserves the save table across the restart", function()
+            soulslike.get_soulslike_state().uuid = "survives"
+            H.reboot{ load = MOD_SCRIPTS, soulslike_mode = true }
+            expect(soulslike.get_soulslike_state().uuid).toBe("survives")
+        end)
+
+        it("preserves persisted vars, which live in the save too", function()
+            save_var(db.actor, "grw_in_water", true)
+            H.reboot{ load = MOD_SCRIPTS, soulslike_mode = true }
+            expect(load_var(db.actor, "grw_in_water")).toBe(true)
+        end)
+
+        it("preserves info portions", function()
+            give_info_portion("npcx_beh_test")
+            H.reboot{ load = MOD_SCRIPTS, soulslike_mode = true }
+            expect(has_alife_info("npcx_beh_test")).toBe(true)
+        end)
+
+        -- The point of the distinction: module state is NOT persistent. A level
+        -- change re-executes every script, so file-scope locals start over.
+        it("discards module tables, as a level change does", function()
+            local before = soulslike
+            H.reboot{ load = MOD_SCRIPTS, soulslike_mode = true }
+            expect(soulslike).never.toBe(before)
+        end)
+
+        it("clears the world model", function()
+            H.world.give("actor", "wpn_ak74")
+            H.reboot{ load = MOD_SCRIPTS, soulslike_mode = true }
+            expect(H.world.count("actor")).toBe(0)
+        end)
+
+        it("re-applies soulslike mode when asked", function()
+            H.reboot{ load = MOD_SCRIPTS, soulslike_mode = true }
+            expect(soulslike.IsSoulslikeMode()).toBeTruthy()
+        end)
+    end)
+
+    describe("tick()", function()
+        beforeEach(function() H.boot() end)
+
+        it("drains time events before applying world mutations", function()
+            local box = H.world.container("stash")
+            local ak = H.world.give("actor", "wpn_ak74")
+            CreateTimeEvent("t", "a", 0, function()
+                db.actor:transfer_item(ak, box)
+                return true
+            end)
+            expect(H.world.where(ak)).toBe("actor")
+            H.tick()
+            expect(H.world.where(ak)).toBe("stash")
+        end)
+    end)
+end)
+
+return true

--- a/tests/self/loader.spec.lua
+++ b/tests/self/loader.spec.lua
@@ -200,6 +200,48 @@ describe("harness/loader", function()
             end)
         end)
     end)
+
+    describe("load_string_table()", function()
+        -- Backs the MCM localisation spec, which is the only thing standing
+        -- between a renamed option id and a raw string id showing in the menu.
+
+        beforeEach(function() H.boot() end)
+
+        it("derives the text directory from script_dir", function()
+            expect(loader.text_dir()).toContain("configs/text")
+        end)
+
+        it("finds the shipped English tables", function()
+            expect(#loader.string_table_files("eng")).toBeGreaterThan(0)
+        end)
+
+        it("reads string ids out of them", function()
+            expect(loader.load_string_table("eng")["ui_mcm_menu_soulslike"]).toBe(true)
+        end)
+
+        it("reads the Russian tables too", function()
+            expect(loader.load_string_table("rus")["ui_mcm_menu_soulslike"]).toBe(true)
+        end)
+
+        it("returns an id the mod actually declares", function()
+            local ids = loader.load_string_table("eng")
+            expect(ids["ui_mcm_soulslike_items_allow_weapon_loss"]).toBe(true)
+        end)
+
+        it("does not invent ids", function()
+            expect(loader.load_string_table("eng")["ui_mcm_soulslike_not_a_real_key"]).toBeNil()
+        end)
+
+        -- A mod need not ship every language, so an absent directory is empty
+        -- rather than an error.
+        it("returns an empty set for a language that is not shipped", function()
+            expect(loader.load_string_table("zzz")).toEqual({})
+        end)
+
+        it("ignores a file that does not exist", function()
+            expect(loader.load_string_table("eng", { "no_such_file.xml" })).toEqual({})
+        end)
+    end)
 end)
 
 return true

--- a/tests/self/loader.spec.lua
+++ b/tests/self/loader.spec.lua
@@ -1,0 +1,205 @@
+-- Harness self-test: the engine module-namespace loader.
+--
+-- The spec that earns its keep. It pins the exact semantics that let mod
+-- source load unmodified. If the loader drifts, unit specs keep passing while
+-- testing something the game would never execute.
+
+local H = require("harness.init")
+local loader = H.loader
+
+-- Synthetic .script files, so loader semantics are tested against
+-- known-minimal inputs rather than the real mod.
+local FIXTURES = "self/fixtures"
+
+describe("harness/loader", function()
+
+    beforeEach(function()
+        H.boot{ script_dir = FIXTURES }
+        -- boot() resets loader and fakes state but deliberately does not wipe
+        -- _G, so stdlib tables a module mutated stay mutated. Clear the one
+        -- field these fixtures write, or the "shared table" spec below sees a
+        -- leftover from an earlier case.
+        math.fixture_added = nil
+    end)
+
+    describe("parse_namespace()", function()
+        -- Mirrors CScriptStorage::parse_namespace, script_storage.cpp:575.
+
+        describe("given a flat namespace name", function()
+            it("returns the assignment fragment", function()
+                local b = loader.parse_namespace("soulslike")
+                expect(b).toBe("soulslike=")
+            end)
+
+            it("returns an empty closing fragment", function()
+                local _, c = loader.parse_namespace("soulslike")
+                expect(c).toBe("")
+            end)
+        end)
+
+        describe("given a dotted namespace name", function()
+            it("opens a nested table in the assignment fragment", function()
+                local b = loader.parse_namespace("a.b")
+                expect(b).toBe("a={b=")
+            end)
+
+            it("returns the matching closing brace", function()
+                local _, c = loader.parse_namespace("a.b")
+                expect(c).toBe("}")
+            end)
+        end)
+    end)
+
+    describe("build_prologue()", function()
+        describe("given any module name", function()
+            it("emits no newlines, so source line numbers stay aligned", function()
+                -- file_header_old (script_storage.cpp:22) is one C string built
+                -- from backslash continuations. Zero newlines keeps every stack
+                -- trace pointing at the real line.
+                expect(loader.build_prologue("thing")).never.toContain("\n")
+            end)
+        end)
+    end)
+
+    describe("load()", function()
+
+        describe("given a script that raises on its own line 3", function()
+            it("reports the error at line 3", function()
+                expect(function() loader.load("fixture_lines") end).toThrow(":3:")
+            end)
+        end)
+
+        describe("given a script that assigns a bare global", function()
+            it("stores it on the module table", function()
+                loader.load("fixture_scope")
+                expect(_G.fixture_scope.MODULE_LOCAL).toBe("yes")
+            end)
+
+            it("does not leak it into _G", function()
+                loader.load("fixture_scope")
+                expect(rawget(_G, "MODULE_LOCAL")).toBeNil()
+            end)
+        end)
+
+        describe("given a script that declares function _G.X", function()
+            it("installs it as a real global", function()
+                loader.load("fixture_scope")
+                expect(rawget(_G, "fixture_explicit_global")).toBeType("function")
+                expect(_G.fixture_explicit_global()).toBe("global")
+            end)
+        end)
+
+        describe("given a script that writes a field on a global table", function()
+            -- `function math.clamp(...)` in soulslike.script: the READ of
+            -- `math` falls through __index to _G.math, then the WRITE lands on
+            -- that real table. The mod genuinely extends the stdlib.
+            it("mutates the shared table, not a copy", function()
+                expect(math.fixture_added).toBeNil()      -- precondition
+                loader.load("fixture_scope")
+                expect(math.fixture_added).toBeType("function")
+                expect(math.fixture_added()).toBe("mutated")
+            end)
+        end)
+
+        describe("given a script that reads an outer global", function()
+            it("falls through to _G", function()
+                _G.OUTER_VALUE = "from-globals"
+                loader.load("fixture_scope")
+                expect(_G.fixture_scope.read_outer()).toBe("from-globals")
+                _G.OUTER_VALUE = nil
+            end)
+        end)
+
+        describe("given any loaded script", function()
+            it("exposes script_name() returning the module name", function()
+                loader.load("fixture_scope")
+                expect(_G.fixture_scope.who()).toBe("fixture_scope")
+            end)
+
+            it("installs the module table in _G under its own name", function()
+                loader.load("fixture_scope")
+                expect(rawget(_G, "fixture_scope")).toBeType("table")
+            end)
+        end)
+
+        describe("given a script already loaded", function()
+            it("does not re-execute it", function()
+                loader.load("fixture_counter")
+                local first = _G.fixture_counter.instance
+                loader.load("fixture_counter")
+                expect(_G.fixture_counter.instance).toBe(first)
+            end)
+
+            it("records only one entry in load_order", function()
+                loader.load("fixture_counter")
+                loader.load("fixture_counter")
+
+                local n = 0
+                for _, name in ipairs(loader.load_order) do
+                    if name == "fixture_counter" then n = n + 1 end
+                end
+                expect(n).toBe(1)
+            end)
+        end)
+
+        describe("given two scripts that reference each other at file scope", function()
+            it("does not recurse infinitely", function()
+                expect(function() loader.load("fixture_circular_a") end).never.toThrow()
+            end)
+
+            it("still installs the module", function()
+                loader.load("fixture_circular_a")
+                expect(_G.fixture_circular_a).toBeDefined()
+            end)
+        end)
+    end)
+
+    describe("autoload via the _G metatable", function()
+        -- auto_load, script_engine.cpp:257, installed at :270.
+
+        describe("given a global with no matching script", function()
+            it("resolves to nil rather than raising", function()
+                -- Mod code leans on this: soulslike_scenarios.script:113 does
+                -- `local dte = demonized_time_events` for an optional mod.
+                local v
+                expect(function() v = _G.definitely_not_a_real_script_name end)
+                    .never.toThrow()
+                expect(v).toBeNil()
+            end)
+
+            it("records the miss so it stops retrying", function()
+                local _ = _G.no_such_module_xyz
+                expect(loader.missing["no_such_module_xyz"]).toBe(true)
+            end)
+        end)
+
+        describe("given a global with a matching script", function()
+            it("loads it on first touch", function()
+                expect(rawget(_G, "fixture_auto")).toBeNil()   -- precondition
+                expect(_G.fixture_auto.MARKER).toBe("autoloaded")
+            end)
+        end)
+    end)
+
+    describe("upvalue()", function()
+        -- What makes compute_fatal_hit_info testable without editing the mod.
+
+        describe("given an exported function that references a file-local", function()
+            it("returns the file-local function", function()
+                loader.load("fixture_upvalue")
+                local hidden = loader.upvalue(_G.fixture_upvalue.exported, "hidden_helper")
+                expect(hidden).toBeType("function")
+                expect(hidden(3)).toBe(6)
+            end)
+        end)
+
+        describe("given a name that is not an upvalue", function()
+            it("returns nil", function()
+                loader.load("fixture_upvalue")
+                expect(loader.upvalue(_G.fixture_upvalue.exported, "nope")).toBeNil()
+            end)
+        end)
+    end)
+end)
+
+return true

--- a/tests/self/mods.spec.lua
+++ b/tests/self/mods.spec.lua
@@ -1,0 +1,155 @@
+-- Harness self-test: the optional-mod registry.
+
+local H = require("harness.init")
+local mods = H.mods
+
+describe("harness/mods", function()
+
+    beforeEach(function() H.boot() end)
+
+    describe("default state", function()
+        describe("given a freshly booted harness", function()
+            it("installs the base-Anomaly scripts", function()
+                -- These ship with Anomaly, so every install has them. Two are
+                -- even called unguarded (actor_status_thirst at
+                -- soulslike_scenarios.script:590, treasure_manager at :1335),
+                -- so "absent" is not a state the mod survives.
+                for _, name in ipairs(mods.BASE) do
+                    expect(rawget(_G, name)).toBeDefined()
+                end
+            end)
+
+            it("leaves the third-party ones absent", function()
+                -- Absent is what most installs look like, and it keeps the
+                -- `if <mod> and ...` guard branches exercised by default.
+                for _, name in ipairs(mods.OPTIONAL) do
+                    expect(rawget(_G, name)).toBeNil()
+                end
+            end)
+        end)
+    end)
+
+    describe("boot{ without = {...} }", function()
+        describe("given a base script is excluded", function()
+            it("removes it, so the guard branch can be tested", function()
+                -- ApplyItemConditionLoss bails early when item_parts is nil
+                -- (soulslike_scenarios.script:434).
+                H.boot{ without = { "item_parts" } }
+                expect(rawget(_G, "item_parts")).toBeNil()
+            end)
+        end)
+    end)
+
+    describe("enable()", function()
+        describe("given a known soft dependency", function()
+            it("installs it as a global", function()
+                mods.enable("item_parts")
+                expect(_G.item_parts).toBeDefined()
+            end)
+
+            it("marks it enabled", function()
+                mods.enable("item_parts")
+                expect(mods.is_enabled("item_parts")).toBeTruthy()
+            end)
+
+            it("provides the functions the mod calls", function()
+                mods.enable("item_parts")
+                expect(item_parts.get_parts_con).toBeType("function")
+                expect(item_parts.set_parts_con).toBeType("function")
+            end)
+        end)
+
+        describe("given overrides", function()
+            it("merges them over the default stub", function()
+                mods.enable("magazine_binder", {
+                    is_magazine = function() return true end,
+                })
+                expect(magazine_binder.is_magazine()).toBe(true)
+                expect(magazine_binder.validate_loadout).toBeType("function")
+            end)
+        end)
+
+        describe("given an unknown name", function()
+            it("raises with the list of known names", function()
+                expect(function() mods.enable("not_a_mod") end)
+                    .toThrow("unknown soft dependency")
+            end)
+        end)
+
+        describe("given demonized_time_events", function()
+            it("also installs the dte alias", function()
+                mods.enable("demonized_time_events")
+                expect(_G.dte).toBeDefined()
+            end)
+
+            it("refuses once soulslike_scenarios has loaded", function()
+                -- soulslike_scenarios.script:113 captures `local dte` at file
+                -- scope, so a later enable() would silently have no effect.
+                H.boot{ load = { "soulslike_classes", "soulslike", "soulslike_mcm",
+                                 "soulslike_scenarios" } }
+                expect(function() mods.enable("demonized_time_events") end)
+                    .toThrow("must run BEFORE")
+            end)
+        end)
+    end)
+
+    describe("boot{ mods = {...} }", function()
+        describe("given mods listed at boot", function()
+            it("enables them before the mod scripts load", function()
+                H.boot{ mods = { "demonized_time_events" },
+                        load = { "soulslike_classes", "soulslike", "soulslike_mcm",
+                                 "soulslike_scenarios" } }
+                expect(mods.is_enabled("demonized_time_events")).toBeTruthy()
+            end)
+        end)
+    end)
+
+    describe("disable()", function()
+        it("removes the global", function()
+            mods.enable("arszi_psy")
+            mods.disable("arszi_psy")
+            expect(rawget(_G, "arszi_psy")).toBeNil()
+        end)
+    end)
+
+    describe("patched()", function()
+        -- RFDetectorSoulslikeScenarioLogic:CreateStash monkey-patches
+        -- treasure_manager.box_in_same_map and restores it afterwards
+        -- (soulslike_scenarios.script:1335-1341). An early return between the
+        -- two would leak the patch.
+        describe("given nothing has been patched", function()
+            it("reports no differences", function()
+                mods.enable("treasure_manager")
+                expect(mods.patched("treasure_manager")).toEqual({})
+            end)
+        end)
+
+        describe("given a field was replaced and not restored", function()
+            it("names that field", function()
+                mods.enable("treasure_manager")
+                treasure_manager.box_in_same_map = function() return false end
+                expect(mods.patched("treasure_manager")).toEqual({ "box_in_same_map" })
+            end)
+        end)
+
+        describe("given a field was replaced and then restored", function()
+            it("reports no differences", function()
+                mods.enable("treasure_manager")
+                local original = treasure_manager.box_in_same_map
+                treasure_manager.box_in_same_map = function() return false end
+                treasure_manager.box_in_same_map = original
+                expect(mods.patched("treasure_manager")).toEqual({})
+            end)
+        end)
+    end)
+
+    describe("reset()", function()
+        it("clears everything a previous spec enabled", function()
+            mods.enable("item_radio")
+            mods.reset()
+            expect(rawget(_G, "item_radio")).toBeNil()
+        end)
+    end)
+end)
+
+return true

--- a/tests/self/timeevents.spec.lua
+++ b/tests/self/timeevents.spec.lua
@@ -1,0 +1,135 @@
+-- Harness self-test: the deferred time-event pump.
+--
+-- The mod continues work on a later frame via CreateTimeEvent, so the
+-- death->respawn flow does not complete synchronously. If this drains
+-- incorrectly, every e2e spec either hangs or asserts against a half-finished
+-- flow.
+
+local H = require("harness.init")
+local te = H.timeevents
+
+describe("harness/timeevents", function()
+
+    beforeEach(function() H.boot() end)
+
+    describe("CreateTimeEvent()", function()
+
+        describe("given an event is created", function()
+            it("does not run it immediately", function()
+                local ran = false
+                CreateTimeEvent(0, "e", 0, function() ran = true; return true end)
+                expect(ran).toBeFalsy()
+            end)
+
+            it("queues it", function()
+                CreateTimeEvent(0, "e", 0, function() return true end)
+                expect(te.pending()).toBe(1)
+            end)
+        end)
+
+        describe("given extra arguments", function()
+            it("forwards them to the callback", function()
+                local got
+                CreateTimeEvent(0, "e", 0, function(a, b) got = { a, b }; return true end,
+                                "x", 42)
+                te.pump()
+                expect(got).toEqual({ "x", 42 })
+            end)
+        end)
+    end)
+
+    describe("pump()", function()
+
+        describe("given a callback returning true", function()
+            it("runs it", function()
+                local ran = false
+                CreateTimeEvent(0, "e", 0, function() ran = true; return true end)
+                te.pump()
+                expect(ran).toBeTruthy()
+            end)
+
+            it("drops it from the queue", function()
+                CreateTimeEvent(0, "e", 0, function() return true end)
+                te.pump()
+                expect(te.pending()).toBe(0)
+            end)
+        end)
+
+        describe("given a callback returning false", function()
+            -- The real contract, from wait_for_stash_creation
+            -- (soulslike_scenarios.script:535): false means "not ready, retry".
+            it("keeps retrying until it returns true", function()
+                local calls = 0
+                CreateTimeEvent(0, "e", 0, function()
+                    calls = calls + 1
+                    return calls >= 3
+                end)
+                te.pump()
+                expect(calls).toBe(3)
+                expect(te.pending()).toBe(0)
+            end)
+        end)
+
+        describe("given a callback that never returns true", function()
+            it("raises rather than spinning forever", function()
+                CreateTimeEvent(0, "stuck", 0, function() return false end)
+                expect(function() te.pump() end).toThrow("still queued after")
+            end)
+        end)
+
+        describe("given an event that queues another event", function()
+            it("settles the whole chain in one pump", function()
+                local order = {}
+                CreateTimeEvent(0, "a", 0, function()
+                    order[#order + 1] = "a"
+                    CreateTimeEvent(0, "b", 0, function()
+                        order[#order + 1] = "b"; return true
+                    end)
+                    return true
+                end)
+                te.pump()
+                expect(order).toEqual({ "a", "b" })
+                expect(te.pending()).toBe(0)
+            end)
+        end)
+
+        describe("given an empty queue", function()
+            it("does nothing and reports zero", function()
+                expect(te.pump()).toBe(0)
+            end)
+        end)
+    end)
+
+    describe("RemoveTimeEvent()", function()
+        describe("given a queued event with a matching key", function()
+            it("removes it", function()
+                CreateTimeEvent(0, "gone", 0, function() return true end)
+                RemoveTimeEvent(0, "gone")
+                expect(te.pending()).toBe(0)
+            end)
+
+            it("leaves other events alone", function()
+                CreateTimeEvent(0, "gone", 0, function() return true end)
+                CreateTimeEvent(0, "kept", 0, function() return true end)
+                RemoveTimeEvent(0, "gone")
+                expect(te.peek()).toEqual({ "0/kept" })
+            end)
+        end)
+    end)
+
+    describe("H.tick()", function()
+        it("drains time events and then applies world mutations", function()
+            -- Ordering matters: an event that transfers an item must have its
+            -- queued mutation applied in the same tick.
+            local item = H.world.give("actor", "medkit")
+            CreateTimeEvent(0, "move", 0, function()
+                H.world.queue_transfer(item, "stash")
+                return true
+            end)
+            H.tick()
+            expect(H.world.where(item)).toBe("stash")
+        end)
+    end)
+end)
+
+return true

--- a/tests/self/world.spec.lua
+++ b/tests/self/world.spec.lua
@@ -1,0 +1,222 @@
+-- Harness self-test: the item/container world model.
+--
+-- The deferred-mutation specs below are the load-bearing ones. If the model
+-- ever silently starts snapshotting or applying immediately, item-placement
+-- assertions in every scenario spec become claims about behavior the game does
+-- not have.
+
+local H = require("harness.init")
+local world = H.world
+
+describe("harness/world", function()
+
+    local actor
+
+    beforeEach(function()
+        H.boot()
+        actor = _G.db.actor
+    end)
+
+    describe("give()", function()
+        describe("given a section and container", function()
+            it("places the item there", function()
+                local ak = world.give("actor", "wpn_ak74")
+                expect(world.where(ak)).toBe("actor")
+            end)
+
+            it("shows up in contents()", function()
+                world.give("actor", "wpn_ak74")
+                world.give("actor", "medkit")
+                expect(world.contents("actor")).toEqual({ "wpn_ak74", "medkit" })
+            end)
+
+            it("gives the item the engine accessors the mod calls", function()
+                local ak = world.give("actor", "wpn_ak74", { condition = 0.8 })
+                expect(ak:section()).toBe("wpn_ak74")
+                expect(ak:condition()).toBeCloseTo(0.8)
+                expect(ak:id()).toBeType("number")
+            end)
+        end)
+    end)
+
+    describe("iterate_inventory()", function()
+
+        describe("given several items", function()
+            it("visits each one", function()
+                world.give("actor", "a"); world.give("actor", "b")
+                local seen = {}
+                actor:iterate_inventory(function(_, item)
+                    seen[#seen + 1] = item:section()
+                end)
+                expect(seen).toEqual({ "a", "b" })
+            end)
+        end)
+
+        describe("given the callback returns true", function()
+            it("stops early, matching IterateInventory", function()
+                world.give("actor", "a"); world.give("actor", "b")
+                local seen = {}
+                actor:iterate_inventory(function(_, item)
+                    seen[#seen + 1] = item:section()
+                    return true
+                end)
+                expect(seen).toEqual({ "a" })
+            end)
+        end)
+    end)
+
+    describe("deferred mutation", function()
+        -- The engine walks the LIVE m_all container with raw iterators
+        -- (script_game_object_inventory_owner.cpp:266), which is only safe
+        -- because transfer_item sends GE_TRADE_* network events and
+        -- alife_release queues an alife release -- both land on a later frame.
+
+        describe("given alife_release is called inside the loop", function()
+            it("leaves the item visible for the rest of that loop", function()
+                -- If this fails, the model applied the removal immediately or
+                -- snapshotted -- either way it no longer matches the engine.
+                world.give("actor", "a")
+                world.give("actor", "b")
+                world.give("actor", "c")
+
+                local seen = {}
+                actor:iterate_inventory(function(_, item)
+                    seen[#seen + 1] = item:section()
+                    alife_release(item)          -- release every item as we go
+                end)
+
+                expect(seen).toEqual({ "a", "b", "c" })
+            end)
+
+            it("still holds the items until the next tick", function()
+                local a = world.give("actor", "a")
+                alife_release(a)
+                expect(world.where(a)).toBe("actor")
+            end)
+
+            it("removes them once ticked", function()
+                local a = world.give("actor", "a")
+                alife_release(a)
+                H.tick()
+                expect(world.where(a)).toBeNil()
+            end)
+
+            it("reports them as destroyed", function()
+                world.give("actor", "a")
+                alife_release(world.item_by_section("a"))
+                H.tick()
+                expect(world.destroyed()).toEqual({ "a" })
+            end)
+        end)
+
+        describe("given transfer_item is called inside the loop", function()
+            it("does not move anything until the tick", function()
+                world.container("stash")
+                local a = world.give("actor", "a")
+                actor:transfer_item(a, "stash")
+                expect(world.where(a)).toBe("actor")
+            end)
+
+            it("moves everything on the tick", function()
+                local stash = world.container("stash")
+                world.give("actor", "a"); world.give("actor", "b")
+
+                actor:iterate_inventory(function(_, item)
+                    actor:transfer_item(item, stash)
+                end)
+                H.tick()
+
+                expect(world.contents("stash")).toEqual({ "a", "b" })
+                expect(world.contents("actor")).toEqual({})
+            end)
+        end)
+
+        describe("given an item is both transferred and released", function()
+            it("applies them in queue order, so the release wins", function()
+                world.container("stash")
+                local a = world.give("actor", "a")
+                actor:transfer_item(a, "stash")
+                alife_release(a)
+                H.tick()
+                expect(world.where(a)).toBeNil()
+            end)
+        end)
+    end)
+
+    describe("containers", function()
+        describe("given an empty container", function()
+            it("reports itself empty", function()
+                local box = world.container("stash")
+                expect(box:is_inv_box_empty()).toBeTruthy()
+            end)
+        end)
+
+        describe("given a container with items", function()
+            it("reports itself non-empty", function()
+                local box = world.container("stash")
+                world.give("stash", "a")
+                expect(box:is_inv_box_empty()).toBeFalsy()
+            end)
+
+            it("iterates its contents", function()
+                local box = world.container("stash")
+                world.give("stash", "a"); world.give("stash", "b")
+                local seen = {}
+                box:iterate_inventory_box(function(_, item)
+                    seen[#seen + 1] = item:section()
+                end)
+                expect(seen).toEqual({ "a", "b" })
+            end)
+        end)
+    end)
+
+    describe("alife_create()", function()
+        describe("given a section", function()
+            it("returns a server object with an id", function()
+                local se = alife_create("inv_backpack", actor:position(), 1, 1)
+                expect(se.id).toBeType("number")
+                expect(se.section).toBe("inv_backpack")
+            end)
+
+            it("makes it findable via level.object_by_id", function()
+                local se = alife_create("inv_backpack", actor:position(), 1, 1)
+                expect(level.object_by_id(se.id)).toBeDefined()
+            end)
+
+            it("records the creation for assertion", function()
+                alife_create("inv_backpack", actor:position(), 1, 1)
+                expect(world.created).toHaveLength(1)
+            end)
+        end)
+    end)
+
+    describe("hide()", function()
+        -- Exercises the "stash is not online yet" retry in
+        -- HandleItemsAndRespawn (soulslike_scenarios.script:536).
+        describe("given a created object is hidden", function()
+            it("becomes invisible to level.object_by_id", function()
+                local se = alife_create("inv_backpack", actor:position(), 1, 1)
+                world.hide(se.id)
+                expect(level.object_by_id(se.id)).toBeNil()
+            end)
+
+            it("reappears when revealed", function()
+                local se = alife_create("inv_backpack", actor:position(), 1, 1)
+                world.hide(se.id)
+                world.reveal(se.id)
+                expect(level.object_by_id(se.id)).toBeDefined()
+            end)
+        end)
+    end)
+
+    describe("alife_create_item()", function()
+        describe("given an owner", function()
+            it("puts the item in that owner's container", function()
+                alife_create_item("bread", actor)
+                expect(world.contents("actor")).toContain("bread")
+            end)
+        end)
+    end)
+end)
+
+return true

--- a/tests/self/world.spec.lua
+++ b/tests/self/world.spec.lua
@@ -215,6 +215,137 @@ describe("harness/world", function()
                 alife_create_item("bread", actor)
                 expect(world.contents("actor")).toContain("bread")
             end)
+
+            -- Must be the SERVER object. RFDetectorSoulslikeScenarioLogic keys
+            -- note_message_data by se_note.id (soulslike_scenarios.script:1400);
+            -- handing back a client object makes `.id` a function and silently
+            -- produces a function-keyed table that nothing can ever look up.
+            it("returns a server object whose id is a field", function()
+                local se = alife_create_item("bread", actor)
+                expect(se.id).toBeType("number")
+            end)
+
+            it("shares its id with the client object", function()
+                local se = alife_create_item("bread", actor)
+                expect(level.object_by_id(se.id):section()).toBe("bread")
+            end)
+        end)
+    end)
+
+    describe("alife():register()", function()
+        -- register() frees the object handed to it and returns a NEW pointer
+        -- (alife_simulator_script.cpp:396-413). Modelled by swapping in a fresh
+        -- table, so a spec reusing the old reference sees it go stale.
+        describe("given an unregistered object", function()
+            it("returns a different object", function()
+                local se = alife_create("wpn_ak74", actor:position(), 1, 1, actor:id(), false)
+                expect(alife():register(se)).never.toBe(se)
+            end)
+
+            it("marks it registered", function()
+                local se = alife_create("wpn_ak74", actor:position(), 1, 1, actor:id(), false)
+                expect(alife():register(se).registered).toBe(true)
+            end)
+
+            it("keeps the same id", function()
+                local se = alife_create("wpn_ak74", actor:position(), 1, 1, actor:id(), false)
+                expect(alife():register(se).id).toBe(se.id)
+            end)
+
+            it("replaces what alife():object() returns", function()
+                local se = alife_create("wpn_ak74", actor:position(), 1, 1, actor:id(), false)
+                local fresh = alife():register(se)
+                expect(alife():object(se.id)).toBe(fresh)
+            end)
+
+            it("records the call", function()
+                local se = alife_create("wpn_ak74", actor:position(), 1, 1, actor:id(), false)
+                alife():register(se)
+                expect(world.registered).toEqual({ se.id })
+            end)
+        end)
+    end)
+
+    describe("alife_create() with a register flag", function()
+        describe("given register = false", function()
+            it("records the object as unregistered", function()
+                alife_create("wpn_ak74", actor:position(), 1, 1, actor:id(), false)
+                expect(world.created[1].registered).toBe(false)
+            end)
+
+            it("records the parent id", function()
+                alife_create("wpn_ak74", actor:position(), 1, 1, actor:id(), false)
+                expect(world.created[1].parent_id).toBe(actor:id())
+            end)
+        end)
+
+        describe("given the flag is omitted", function()
+            it("registers by default", function()
+                alife_create("inv_backpack", actor:position(), 1, 1)
+                expect(world.created[1].registered).toBe(true)
+            end)
+        end)
+    end)
+
+    describe("squads", function()
+        -- SpawnAmbush creates the squad object itself and then iterates
+        -- squad_members() (soulslike_scenarios.script:763), so members cannot be
+        -- supplied the way world.container's can.
+        describe("given a section registered in world.squads", function()
+            beforeEach(function()
+                world.squads["simulation_boar"] = {
+                    { kind = "monster", section = "boar_weak" },
+                    { kind = "monster", section = "boar_normal" },
+                }
+            end)
+
+            it("gives the created object iterable members", function()
+                local se = alife_create("simulation_boar", actor:position(), 1, 1)
+                local seen = {}
+                for m in se:squad_members() do seen[#seen + 1] = m:section_name() end
+                expect(seen).toEqual({ "boar_weak", "boar_normal" })
+            end)
+
+            it("exposes create_npc as a recorder", function()
+                local se = alife_create("simulation_boar", actor:position(), 1, 1)
+                se:create_npc(se.id)
+                expect(H.fakes.call_count("se.create_npc")).toBe(1)
+            end)
+
+            it("makes each member reachable through alife():object()", function()
+                local se = alife_create("simulation_boar", actor:position(), 1, 1)
+                for m in se:squad_members() do
+                    expect(alife():object(m.id)).toBe(m)
+                end
+            end)
+        end)
+
+        describe("given an unregistered section", function()
+            it("yields no members", function()
+                local se = alife_create("simulation_flesh", actor:position(), 1, 1)
+                local n = 0
+                for _ in se:squad_members() do n = n + 1 end
+                expect(n).toBe(0)
+            end)
+        end)
+    end)
+
+    describe("spawn_se_npc()", function()
+        -- find_closest_enemy / _enemy_mutant scan sim:object(i) for i in
+        -- 1..65534 (soulslike.script:300). Ids start at 10000, inside that range.
+        it("is reachable through alife():object()", function()
+            local se = world.spawn_se_npc{ kind = "monster" }
+            expect(alife():object(se.id)).toBe(se)
+        end)
+
+        it("is found by a scan over the alife id range", function()
+            local se = world.spawn_se_npc{ kind = "monster" }
+            local found = nil
+            for i = 1, 65534 do
+                local o = alife():object(i)
+                if o and o.id == se.id then found = o break end
+            end
+            expect(found).toBe(se)
         end)
     end)
 end)

--- a/tests/unit/create_new.spec.lua
+++ b/tests/unit/create_new.spec.lua
@@ -1,0 +1,622 @@
+-- soulslike_scenario_logic_factory.create_new (:141-403)
+--
+-- A 14-arm first-match-wins tree that decides which scenario the death runs,
+-- how much loot is at stake, and who rescues or loots the player. Each arm is
+-- distinguished not only by the scenario it pushes but by WHICH finder it calls
+-- for the looter, so the specs assert on stub_finders' call counts as well as
+-- on the resulting ids.
+--
+-- strict_vectors stays on throughout: two arms build a vector from
+-- spawn_location, and passing nil coordinates is an access violation in a
+-- release build (class_rep.cpp:688 with the NDEBUG guard compiled out), not a
+-- catchable error.
+
+local H = require("harness.init")
+local B = H.builders
+
+local MOD_SCRIPTS = {
+    "soulslike_classes", "soulslike", "soulslike_mcm",
+    "soulslike_message_factory", "soulslike_scenarios",
+    "soulslike_scenario_logic_factory",
+}
+
+local factory = nil
+local friendly, enemy, enemy_stalker, enemy_mutant
+
+--- Boot with a recorded spawn at the origin and all four finders stubbed.
+--- `distance` places the actor that far from the spawn along z.
+local function boot(distance)
+    H.boot{ load = MOD_SCRIPTS }
+    H.fakes.set_random_min()
+    H.set_spawn{ level = "zaton", position = { x = 0, y = 0, z = 0 } }
+    H.set_actor{ position = { x = 0, y = 0, z = distance or 300 } }
+
+    friendly      = B.make_stalker{ name = "friendly" }
+    enemy         = B.make_stalker{ name = "enemy" }
+    enemy_stalker = B.make_stalker{ name = "enemy_stalker" }
+    enemy_mutant  = B.make_monster{ name = "enemy_mutant" }
+
+    B.stub_finders{
+        friendly_stalker = friendly,
+        enemy            = enemy,
+        enemy_stalker    = enemy_stalker,
+        enemy_mutant     = enemy_mutant,
+    }
+
+    factory = _G.soulslike_scenario_logic_factory
+    return factory
+end
+
+--- One hit whose draftsman resolves to `obj`, flagged fatal.
+local function fatal_hit_from(obj)
+    if obj then H.fakes.register_object(obj) end
+    return { B.make_hit{
+        power = 100,
+        is_fatal = true,
+        time = 1000,
+        draftsman_id = obj and obj:id() or nil,
+    } }
+end
+
+local SCENARIOS
+
+describe("soulslike_scenario_logic_factory.create_new()", function()
+
+    beforeEach(function()
+        boot()
+        SCENARIOS = _G.soulslike.SCENARIOS
+    end)
+
+    describe("given the noloss debug flag", function()
+        local function debug_noloss()
+            H.fakes.set_mcm("debug/is_enabled", true)
+            H.fakes.set_mcm("debug/debug_the_noloss_scenario", true)
+            return factory.create_new(fatal_hit_from(enemy_mutant))
+        end
+
+        it("forces the NoLoss scenario", function()
+            expect(debug_noloss().logic_state.scenario_id).toBe(SCENARIOS.NoLoss)
+        end)
+
+        it("puts nothing at stake", function()
+            expect(debug_noloss().logic_state.scenario_loot_scalar).toBe(0)
+        end)
+
+        it("finds a rescuer", function()
+            expect(debug_noloss().logic_state.rescuer_id).toBe(friendly:id())
+        end)
+
+        it("assigns no looter", function()
+            expect(debug_noloss().logic_state.looter_id).toBeNil()
+        end)
+    end)
+
+    describe("given the default debug flag", function()
+        local function debug_default()
+            H.fakes.set_mcm("debug/is_enabled", true)
+            H.fakes.set_mcm("debug/debug_the_default_scenario", true)
+            return factory.create_new(fatal_hit_from(enemy_mutant))
+        end
+
+        it("forces the Default scenario", function()
+            expect(debug_default().logic_state.scenario_id).toBe(SCENARIOS.Default)
+        end)
+
+        it("puts everything at stake", function()
+            expect(debug_default().logic_state.scenario_loot_scalar).toBe(1)
+        end)
+
+        it("takes the looter from the generic enemy finder", function()
+            debug_default()
+            expect(B.finder_count("enemy")).toBe(1)
+            expect(B.finder_count("enemy_mutant")).toBe(0)
+        end)
+    end)
+
+    -- DEAD CODE: debug_the_rf_scenario and debug_the_hidden_stash_scenario
+    -- hard-return false (soulslike_mcm.script:1138, :1142) with the real
+    -- expression commented out, so these two arms cannot be reached. Those
+    -- scenarios are only ever constructed via create_by_id on a save reload.
+    describe("DEAD CODE: the rf and hidden-stash debug flags", function()
+        it("does not reach the rf arm even with the flag set", function()
+            H.fakes.set_mcm("debug/is_enabled", true)
+            H.fakes.set_mcm("debug/debug_the_rf_scenario", true)
+            local s = factory.create_new(fatal_hit_from(enemy_mutant))
+            expect(s.logic_state.scenario_id).never.toBe(SCENARIOS.RFDetectorStash)
+        end)
+
+        it("does not reach the hidden-stash arm even with the flag set", function()
+            H.fakes.set_mcm("debug/is_enabled", true)
+            H.fakes.set_mcm("debug/debug_the_hidden_stash_scenario", true)
+            local s = factory.create_new(fatal_hit_from(enemy_mutant))
+            expect(s.logic_state.scenario_id).never.toBe(SCENARIOS.HiddenStash)
+        end)
+
+        it("keeps the getters hard-returning false", function()
+            H.fakes.set_mcm("debug/is_enabled", true)
+            H.fakes.set_mcm("debug/debug_the_rf_scenario", true)
+            H.fakes.set_mcm("debug/debug_the_hidden_stash_scenario", true)
+            expect(soulslike_mcm.debug_the_rf_scenario()).toBe(false)
+            expect(soulslike_mcm.debug_the_hidden_stash_scenario()).toBe(false)
+        end)
+    end)
+
+    describe("given the player died close to their spawn", function()
+        it("runs NoLoss at 50 metres", function()
+            boot(50)
+            local s = factory.create_new(fatal_hit_from(enemy_mutant))
+            expect(s.logic_state.scenario_id).toBe(SCENARIOS.NoLoss)
+            expect(s.logic_state.scenario_loot_scalar).toBe(0)
+        end)
+
+        it("assigns no looter", function()
+            boot(50)
+            local s = factory.create_new(fatal_hit_from(enemy_mutant))
+            expect(s.logic_state.looter_id).toBeNil()
+        end)
+
+        it("still finds a rescuer", function()
+            boot(50)
+            local s = factory.create_new(fatal_hit_from(enemy_mutant))
+            expect(s.logic_state.rescuer_id).toBe(friendly:id())
+        end)
+    end)
+
+    describe("given the player died in the middle band", function()
+        it("scales the stake with distance", function()
+            boot(125)   -- (125 - 50) / 150 = 0.5
+            local s = factory.create_new(fatal_hit_from(enemy_mutant))
+            expect(s.logic_state.scenario_loot_scalar).toBeCloseTo(0.5)
+        end)
+
+        it("puts nothing at stake just past the close band", function()
+            boot(50.001)
+            local s = factory.create_new(fatal_hit_from(enemy_mutant))
+            expect(s.logic_state.scenario_loot_scalar).toBeCloseTo(0, 0.001)
+        end)
+
+        it("puts everything at stake at the far edge", function()
+            boot(200)
+            local s = factory.create_new(fatal_hit_from(enemy_mutant))
+            expect(s.logic_state.scenario_loot_scalar).toBeCloseTo(1)
+        end)
+
+        it("falls through past 200 metres", function()
+            boot(200.001)
+            local s = factory.create_new(fatal_hit_from(enemy_mutant))
+            -- The monster arm, not the distance arm.
+            expect(B.finder_count("enemy_mutant")).toBe(1)
+        end)
+    end)
+
+    describe("given the player died indoors", function()
+        it("runs NoLoss", function()
+            H.fakes.set_level("underground_lab")
+            local s = factory.create_new(fatal_hit_from(enemy_mutant))
+            expect(s.logic_state.scenario_id).toBe(SCENARIOS.NoLoss)
+        end)
+
+        it("records that the death was indoors", function()
+            H.fakes.set_level("underground_lab")
+            local s = factory.create_new(fatal_hit_from(enemy_mutant))
+            expect(s.logic_state.player_died_indoor).toBe(true)
+        end)
+
+        it("calls no finder at all", function()
+            H.fakes.set_level("underground_lab")
+            factory.create_new(fatal_hit_from(enemy_mutant))
+            expect(B.finder_count("friendly_stalker")).toBe(0)
+            expect(B.finder_count("enemy")).toBe(0)
+        end)
+
+        -- CHARACTERIZATION: this arm leaves scenario_loot_scalar at its
+        -- initialiser of 1.0 (:157) even though it forces NoLoss, unlike every
+        -- other no-loss arm which sets 0. Harmless today because NoLoss's
+        -- TransferItems is a no-op, but it is inconsistent and would matter if
+        -- the indoor case ever grew a real scenario.
+        it("CHARACTERIZATION: leaves the loot scalar at 1.0", function()
+            H.fakes.set_level("underground_lab")
+            local s = factory.create_new(fatal_hit_from(enemy_mutant))
+            expect(s.logic_state.scenario_loot_scalar).toBe(1.0)
+        end)
+    end)
+
+    describe("given the player killed themselves", function()
+        local function suicide()
+            return factory.create_new(fatal_hit_from(db.actor))
+        end
+
+        it("puts three quarters at stake", function()
+            expect(suicide().logic_state.scenario_loot_scalar).toBeCloseTo(0.75)
+        end)
+
+        it("records the killer type as self", function()
+            expect(suicide().logic_state.killer_type).toBe(soulslike.entity_type.Self)
+        end)
+
+        describe("and carries a backpack", function()
+            it("can run the Default scenario", function()
+                H.fakes.set_ltx("itm_actor_backpack", { kind = "i_backpack" })
+                H.world.give("actor", "itm_actor_backpack")
+                H.fakes.set_random_const(0.99)   -- weight the roll to Default
+                expect(suicide().logic_state.scenario_id).toBe(SCENARIOS.Default)
+            end)
+        end)
+
+        describe("and carries no backpack", function()
+            it("can only run NoLoss", function()
+                H.fakes.set_random_const(0.99)
+                expect(suicide().logic_state.scenario_id).toBe(SCENARIOS.NoLoss)
+            end)
+        end)
+    end)
+
+    describe("given a friendly stalker killed the player", function()
+        -- FIXES: D9. This arm set `rescuer = hit.draftsman`, but
+        -- compute_fatal_hit_info builds its aggregate as
+        -- {draftsman_type, power, fatal_hit} (:59-65, :81-83) and never puts
+        -- `draftsman` on it. The rescuer was therefore always nil, so the
+        -- wakeup message fell back to its "it's a mystery" path even though the
+        -- mod knew exactly who was standing over the body.
+        local function friendly_fire()
+            local killer = B.make_stalker{ name = "remorseful", goodwill = 500 }
+            local s = factory.create_new(fatal_hit_from(killer))
+            return s, killer
+        end
+
+        it("runs NoLoss", function()
+            local s = friendly_fire()
+            expect(s.logic_state.scenario_id).toBe(SCENARIOS.NoLoss)
+        end)
+
+        it("puts nothing at stake", function()
+            local s = friendly_fire()
+            expect(s.logic_state.scenario_loot_scalar).toBe(0.0)
+        end)
+
+        it("makes the killer the rescuer", function()
+            local s, killer = friendly_fire()
+            expect(s.logic_state.rescuer_id).toBe(killer:id())
+        end)
+
+        it("assigns no looter", function()
+            local s = friendly_fire()
+            expect(s.logic_state.looter_id).toBeNil()
+        end)
+
+        -- The rescuer comes from the killer, so the finder must not be
+        -- consulted -- that is what distinguishes this arm from the enemy one.
+        it("does not search for a nearby friendly", function()
+            friendly_fire()
+            expect(B.finder_count("friendly_stalker")).toBe(0)
+        end)
+
+        it("treats exactly neutral goodwill as friendly", function()
+            local killer = B.make_stalker{ name = "neutral", goodwill = 0 }
+            local s = factory.create_new(fatal_hit_from(killer))
+            expect(s.logic_state.scenario_id).toBe(SCENARIOS.NoLoss)
+            expect(s.logic_state.rescuer_id).toBe(killer:id())
+        end)
+    end)
+
+    describe("given an enemy stalker killed the player", function()
+        local function murdered()
+            local killer = B.make_stalker{ name = "bandit", goodwill = -1000 }
+            return factory.create_new(fatal_hit_from(killer)), killer
+        end
+
+        it("puts everything at stake", function()
+            local s = murdered()
+            expect(s.logic_state.scenario_loot_scalar).toBe(1.0)
+        end)
+
+        it("takes the looter from the enemy-stalker finder", function()
+            murdered()
+            expect(B.finder_count("enemy_stalker")).toBe(1)
+            expect(B.finder_count("enemy")).toBe(0)
+            expect(B.finder_count("enemy_mutant")).toBe(0)
+        end)
+
+        it("finds a separate rescuer", function()
+            local s = murdered()
+            expect(s.logic_state.rescuer_id).toBe(friendly:id())
+        end)
+
+        it("records the looter as a stalker", function()
+            local s = murdered()
+            expect(s.logic_state.looter_type).toBe(soulslike.entity_type.Stalker)
+        end)
+
+        it("records the killer", function()
+            local s, killer = murdered()
+            expect(s.logic_state.killer_id).toBe(killer:id())
+            expect(s.logic_state.killer_type).toBe(soulslike.entity_type.Stalker)
+        end)
+    end)
+
+    describe("given a mutant killed the player", function()
+        local function mauled()
+            local killer = B.make_monster{ name = "boar" }
+            return factory.create_new(fatal_hit_from(killer))
+        end
+
+        it("puts everything at stake", function()
+            expect(mauled().logic_state.scenario_loot_scalar).toBe(1.0)
+        end)
+
+        it("takes the looter from the mutant finder", function()
+            mauled()
+            expect(B.finder_count("enemy_mutant")).toBe(1)
+            expect(B.finder_count("enemy_stalker")).toBe(0)
+        end)
+
+        it("records the looter as a monster", function()
+            expect(mauled().logic_state.looter_type).toBe(soulslike.entity_type.Monster)
+        end)
+    end)
+
+    describe("given an anomaly killed the player", function()
+        local function burned()
+            local killer = B.make_anomaly{ name = "burner" }
+            return factory.create_new(fatal_hit_from(killer))
+        end
+
+        it("puts a quarter at stake", function()
+            expect(burned().logic_state.scenario_loot_scalar).toBeCloseTo(0.25)
+        end)
+
+        it("takes the looter from the generic enemy finder", function()
+            burned()
+            expect(B.finder_count("enemy")).toBe(1)
+        end)
+    end)
+
+    describe("given the player bled out", function()
+        -- No draftsman at all: damage-over-time resolves to the Other bucket.
+        local function bled_out()
+            return factory.create_new{ B.make_hit{
+                power = 50, is_fatal = true, time = 1000,
+            } }
+        end
+
+        it("puts a quarter at stake", function()
+            expect(bled_out().logic_state.scenario_loot_scalar).toBeCloseTo(0.25)
+        end)
+
+        it("records no killer", function()
+            expect(bled_out().logic_state.killer_id).toBeNil()
+        end)
+
+        it("still records the fatal hit type", function()
+            expect(bled_out().logic_state.fatal_hit_type).toBeDefined()
+        end)
+    end)
+
+    describe("given no hits at all", function()
+        it("falls through to the catch-all arm", function()
+            local s = factory.create_new{}
+            expect(s.logic_state.scenario_loot_scalar).toBeCloseTo(0.25)
+        end)
+
+        it("leaves the killer unset", function()
+            local s = factory.create_new{}
+            expect(s.logic_state.killer_type).toBeNil()
+        end)
+
+        it("does not raise", function()
+            expect(function() factory.create_new{} end).never.toThrow()
+        end)
+    end)
+
+    describe("first match wins", function()
+        it("prefers the close-range arm over the mutant arm", function()
+            boot(30)
+            local s = factory.create_new(fatal_hit_from(B.make_monster{}))
+            expect(s.logic_state.scenario_id).toBe(SCENARIOS.NoLoss)
+            expect(B.finder_count("enemy_mutant")).toBe(0)
+        end)
+
+        it("prefers the indoor arm over the mutant arm", function()
+            H.fakes.set_level("underground_lab")
+            factory.create_new(fatal_hit_from(B.make_monster{}))
+            expect(B.finder_count("enemy_mutant")).toBe(0)
+        end)
+
+        it("prefers a debug flag over everything", function()
+            boot(30)
+            H.fakes.set_mcm("debug/is_enabled", true)
+            H.fakes.set_mcm("debug/debug_the_default_scenario", true)
+            local s = factory.create_new(fatal_hit_from(B.make_monster{}))
+            expect(s.logic_state.scenario_id).toBe(SCENARIOS.Default)
+        end)
+    end)
+
+    describe("distance measurement", function()
+        it("uses the graph distance when the spawn is on another level", function()
+            boot()
+            H.set_spawn{ level = "jupiter", position = { x = 0, y = 0, z = 0 } }
+            H.fakes.graph_distance = 30      -- inside the close band
+
+            local s = factory.create_new(fatal_hit_from(B.make_monster{}))
+            expect(s.logic_state.scenario_id).toBe(SCENARIOS.NoLoss)
+            expect(s.logic_state.scenario_loot_scalar).toBe(0)
+        end)
+
+        -- FIXES: D6. With no spawn ever recorded, the fallback built a vector
+        -- from nil coordinates. That is not a catchable Lua error in a release
+        -- build: NDEBUG compiles out luabind's no-matching-overload guard
+        -- (config.hpp:81-91), so execution runs off the end of the overload
+        -- table (class_rep.cpp:688). An access violation on the death path.
+        describe("given no spawn was ever recorded", function()
+            beforeEach(function()
+                boot()
+                soulslike.get_soulslike_state().spawn_location = {
+                    level = nil,
+                    position = { x = nil, y = nil, z = nil },
+                    angle = { x = nil, y = nil, z = nil },
+                    level_vertex_id = nil,
+                    game_vertex_id = nil,
+                }
+            end)
+
+            it("does not raise", function()
+                expect(function()
+                    factory.create_new(fatal_hit_from(B.make_monster{}))
+                end).never.toThrow()
+            end)
+
+            it("still returns a scenario", function()
+                expect(factory.create_new(fatal_hit_from(B.make_monster{}))).toBeDefined()
+            end)
+
+            -- Degrading to "far from spawn" is the safe default: it runs the
+            -- normal death scenario rather than silently gifting a no-loss.
+            it("treats the death as far from spawn", function()
+                factory.create_new(fatal_hit_from(B.make_monster{}))
+                expect(B.finder_count("enemy_mutant")).toBe(1)
+            end)
+        end)
+    end)
+
+    describe("dying in water", function()
+        it("halves the stake", function()
+            save_var(db.actor, "grw_in_water", true)
+            local s = factory.create_new(fatal_hit_from(B.make_anomaly{}))
+            expect(s.logic_state.scenario_loot_scalar).toBeCloseTo(0.125)
+        end)
+
+        it("records that the death was in water", function()
+            save_var(db.actor, "grw_in_water", true)
+            local s = factory.create_new(fatal_hit_from(B.make_anomaly{}))
+            expect(s.logic_state.player_died_in_water).toBe(true)
+        end)
+
+        it("leaves the stake alone otherwise", function()
+            local s = factory.create_new(fatal_hit_from(B.make_anomaly{}))
+            expect(s.logic_state.scenario_loot_scalar).toBeCloseTo(0.25)
+        end)
+    end)
+
+    describe("the applied setters", function()
+        it("records the level name", function()
+            local s = factory.create_new(fatal_hit_from(B.make_monster{}))
+            expect(s.logic_state.story.level_name).toBe("zaton")
+        end)
+
+        it("spends exactly one roll on the scenario pick", function()
+            local before = H.fakes.random_count()
+            factory.create_new(fatal_hit_from(B.make_monster{}))
+            expect(H.fakes.random_count() - before).toBe(1)
+        end)
+    end)
+end)
+
+describe("soulslike_scenario_logic_factory.create_by_id()", function()
+
+    beforeEach(function()
+        boot()
+        SCENARIOS = _G.soulslike.SCENARIOS
+    end)
+
+    local CASES = {
+        { id = "Default",         class = "DefaultSoulslikeScenarioLogic" },
+        { id = "RFDetectorStash", class = "RFDetectorSoulslikeScenarioLogic" },
+        { id = "HiddenStash",     class = "HiddenStashSoulslikeScenarioLogic" },
+        { id = "NoLoss",          class = "NoLossSoulslikeScenarioLogic" },
+    }
+
+    for _, case in ipairs(CASES) do
+        describe("given the " .. case.id .. " id", function()
+            it("constructs " .. case.class, function()
+                local s = factory.create_by_id(SCENARIOS[case.id])
+                expect(H.class.is_instance(s, _G[case.class])).toBe(true)
+            end)
+
+            it("stamps the scenario id onto the state", function()
+                local s = factory.create_by_id(SCENARIOS[case.id])
+                expect(s.logic_state.scenario_id).toBe(SCENARIOS[case.id])
+            end)
+        end)
+    end
+
+    describe("given an unrecognised id", function()
+        it("falls back to the Default scenario", function()
+            local s = factory.create_by_id(9999)
+            expect(H.class.is_instance(s, _G.DefaultSoulslikeScenarioLogic)).toBe(true)
+        end)
+    end)
+
+    describe("given no id at all", function()
+        it("falls back to the Default scenario", function()
+            expect(factory.create_by_id(nil).logic_state.scenario_id).toBe(SCENARIOS.Default)
+        end)
+    end)
+
+    describe("given a saved state", function()
+        -- The state is forwarded verbatim into __init, which takes the
+        -- restore branch and re-reads no MCM (soulslike_scenarios.script:227).
+        it("adopts it by reference", function()
+            local state = B.make_logic_state{ rank = 4242 }
+            local s = factory.create_by_id(SCENARIOS.Default, state)
+            expect(s.logic_state).toBe(state)
+        end)
+
+        it("does not rebuild the state from MCM", function()
+            H.fakes.set_mcm("items/item_loss_scalar", 0.99)
+            local state = B.make_logic_state{ item_loss_scalar = 0.2 }
+            local s = factory.create_by_id(SCENARIOS.Default, state)
+            expect(s.logic_state.item_loss_scalar).toBeCloseTo(0.2)
+        end)
+    end)
+end)
+
+describe("find_backpack()", function()
+
+    local find_backpack
+
+    beforeEach(function()
+        boot()
+        find_backpack = H.loader.upvalue(
+            _G.soulslike_scenario_logic_factory.create_new, "find_backpack")
+        H.fakes.set_ltx("itm_actor_backpack", { kind = "i_backpack" })
+    end)
+
+    it("is reachable as an upvalue of create_new", function()
+        expect(find_backpack).toBeType("function")
+    end)
+
+    describe("given the actor carries a backpack", function()
+        it("finds it", function()
+            H.world.give("actor", "itm_actor_backpack")
+            expect(find_backpack()).toBe(true)
+        end)
+
+        it("finds it among other items", function()
+            H.world.give("actor", "medkit")
+            H.world.give("actor", "itm_actor_backpack")
+            H.world.give("actor", "bread")
+            expect(find_backpack()).toBe(true)
+        end)
+
+        -- The inner callback reassigns has_backpack for every item, so it only
+        -- reports true because it stops on the first match (:94).
+        it("stops iterating at the backpack", function()
+            H.world.give("actor", "itm_actor_backpack")
+            H.world.give("actor", "medkit")
+            expect(find_backpack()).toBe(true)
+        end)
+    end)
+
+    describe("given the actor carries no backpack", function()
+        it("returns false", function()
+            H.world.give("actor", "medkit")
+            expect(find_backpack()).toBe(false)
+        end)
+
+        it("returns false on an empty inventory", function()
+            expect(find_backpack()).toBe(false)
+        end)
+    end)
+end)
+
+return true

--- a/tests/unit/economy.spec.lua
+++ b/tests/unit/economy.spec.lua
@@ -1,0 +1,385 @@
+-- The four irreversible player-facing deductions:
+--   ApplyRankLoss           (soulslike_scenarios.script:390-404)
+--   ApplyReputationLoss     (:406-420)
+--   ApplyItemConditionLoss  (:422-478)
+--   ApplyMoneyLoss          (:1227-1241)
+--
+-- Rank and reputation land in int-typed engine fields via a setter that does
+-- not clamp and truncates toward zero (character_info_defs.h:8,
+-- policy.hpp:377), so what the mod computes is what the player is left with.
+
+local H = require("harness.init")
+local B = H.builders
+
+local MOD_SCRIPTS = {
+    "soulslike_classes", "soulslike", "soulslike_mcm",
+    "soulslike_message_factory", "soulslike_scenarios",
+}
+
+local function boot(opts)
+    H.boot(opts or { load = MOD_SCRIPTS })
+    H.fakes.set_random_min()
+end
+
+describe("SoulslikeScenarioLogic:ApplyRankLoss()", function()
+
+    beforeEach(function() boot() end)
+
+    describe("given rank loss is disabled", function()
+        it("leaves the rank alone", function()
+            H.fakes.set_mcm("character/allow_rank_loss", false)
+            local actor = H.set_actor{ rank = 5000 }
+            B.make_scenario{}:ApplyRankLoss()
+            expect(actor:character_rank()).toBe(5000)
+        end)
+
+        it("does not notify the statistics system", function()
+            H.fakes.set_mcm("character/allow_rank_loss", false)
+            H.set_actor{ rank = 5000 }
+            B.make_scenario{}:ApplyRankLoss()
+            expect(H.fakes.call_count("check_for_rank_change")).toBe(0)
+        end)
+    end)
+
+    describe("given a positive rank", function()
+        it("deducts the configured percentage", function()
+            local actor = H.set_actor{ rank = 5000 }
+            B.make_scenario{ state = { rank_loss_percent = 0.02 } }:ApplyRankLoss()
+            expect(actor:character_rank()).toBe(4900)
+        end)
+
+        it("notifies the statistics system exactly once", function()
+            H.set_actor{ rank = 5000 }
+            B.make_scenario{}:ApplyRankLoss()
+            expect(H.fakes.call_count("check_for_rank_change")).toBe(1)
+        end)
+
+        -- FIXES: D11. The engine stores an int, so a fractional result is
+        -- truncated on the way in; the mod should decide the value rather than
+        -- leaving rounding to luabind's static_cast.
+        it("stores an integer", function()
+            local actor = H.set_actor{ rank = 1001 }
+            B.make_scenario{ state = { rank_loss_percent = 0.02 } }:ApplyRankLoss()
+            expect(actor:character_rank() % 1).toBe(0)
+        end)
+    end)
+
+    describe("given a rank of zero", function()
+        it("leaves it at zero", function()
+            local actor = H.set_actor{ rank = 0 }
+            B.make_scenario{}:ApplyRankLoss()
+            expect(actor:character_rank()).toBe(0)
+        end)
+    end)
+
+    describe("given a negative rank", function()
+        -- FIXES: D11. math.abs made the loss positive regardless of sign, so a
+        -- negative rank was driven further negative -- a penalty that grows
+        -- without bound instead of a percentage deduction. Nothing in the
+        -- engine clamps it back (InventoryOwner.cpp:450-491).
+        it("does not push the rank further negative", function()
+            local actor = H.set_actor{ rank = -1000 }
+            B.make_scenario{ state = { rank_loss_percent = 0.02 } }:ApplyRankLoss()
+            expect(actor:character_rank()).never.toBeLessThan(-1000)
+        end)
+
+        it("clamps the result at zero rather than going deeper", function()
+            local actor = H.set_actor{ rank = -1000 }
+            B.make_scenario{ state = { rank_loss_percent = 0.02 } }:ApplyRankLoss()
+            expect(actor:character_rank()).toBe(0)
+        end)
+    end)
+
+    describe("given a loss percent of zero", function()
+        it("changes nothing", function()
+            local actor = H.set_actor{ rank = 5000 }
+            B.make_scenario{ state = { rank_loss_percent = 0 } }:ApplyRankLoss()
+            expect(actor:character_rank()).toBe(5000)
+        end)
+    end)
+end)
+
+describe("SoulslikeScenarioLogic:ApplyReputationLoss()", function()
+
+    beforeEach(function() boot() end)
+
+    describe("given reputation loss is disabled", function()
+        it("leaves the reputation alone", function()
+            H.fakes.set_mcm("character/allow_rep_loss", false)
+            local actor = H.set_actor{ reputation = 400 }
+            B.make_scenario{}:ApplyReputationLoss()
+            expect(actor:character_reputation()).toBe(400)
+        end)
+    end)
+
+    describe("given a positive reputation", function()
+        it("deducts the configured percentage", function()
+            local actor = H.set_actor{ reputation = 400 }
+            B.make_scenario{ state = { rep_loss_percent = 0.05 } }:ApplyReputationLoss()
+            expect(actor:character_reputation()).toBe(380)
+        end)
+
+        it("notifies the statistics system exactly once", function()
+            H.set_actor{ reputation = 400 }
+            B.make_scenario{}:ApplyReputationLoss()
+            expect(H.fakes.call_count("check_for_reputation_change")).toBe(1)
+        end)
+
+        it("stores an integer", function()
+            local actor = H.set_actor{ reputation = 401 }
+            B.make_scenario{ state = { rep_loss_percent = 0.05 } }:ApplyReputationLoss()
+            expect(actor:character_reputation() % 1).toBe(0)
+        end)
+    end)
+
+    describe("given a negative reputation", function()
+        -- FIXES: D11. Reputation legitimately runs negative for a hated actor,
+        -- so this is the sign case that actually happens in play. The old
+        -- math.abs form always subtracted, driving it further negative every
+        -- death without bound.
+        it("does not push it further negative", function()
+            local actor = H.set_actor{ reputation = -400 }
+            B.make_scenario{ state = { rep_loss_percent = 0.05 } }:ApplyReputationLoss()
+            expect(actor:character_reputation()).never.toBeLessThan(-400)
+        end)
+
+        -- Decays toward neutral rather than clamping at zero: clamping would
+        -- wipe out earned standing in one death, which is a reward, not a loss.
+        it("decays it toward zero by the same percentage", function()
+            local actor = H.set_actor{ reputation = -400 }
+            B.make_scenario{ state = { rep_loss_percent = 0.05 } }:ApplyReputationLoss()
+            expect(actor:character_reputation()).toBe(-380)
+        end)
+
+        it("never overshoots past neutral", function()
+            local actor = H.set_actor{ reputation = -10 }
+            B.make_scenario{ state = { rep_loss_percent = 1.0 } }:ApplyReputationLoss()
+            expect(actor:character_reputation()).toBe(0)
+        end)
+    end)
+
+    describe("given a reputation of zero", function()
+        it("leaves it at zero", function()
+            local actor = H.set_actor{ reputation = 0 }
+            B.make_scenario{}:ApplyReputationLoss()
+            expect(actor:character_reputation()).toBe(0)
+        end)
+    end)
+end)
+
+describe("SoulslikeScenarioLogic:ApplyMoneyLoss()", function()
+
+    beforeEach(function() boot() end)
+
+    describe("given money loss is disabled", function()
+        it("leaves the money alone", function()
+            H.fakes.set_mcm("items/allow_money_loss", false)
+            local actor = H.set_actor{ money = 10000 }
+            H.fakes.set_random_sequence{}
+            B.make_scenario{}:ApplyMoneyLoss()
+            expect(actor:money()).toBe(10000)
+        end)
+
+        it("spends no rolls", function()
+            H.fakes.set_mcm("items/allow_money_loss", false)
+            H.set_actor{ money = 10000 }
+            H.fakes.set_random_sequence{}
+            local before = H.fakes.random_count()
+            B.make_scenario{}:ApplyMoneyLoss()
+            expect(H.fakes.random_count() - before).toBe(0)
+        end)
+    end)
+
+    describe("given the chance roll fails", function()
+        it("leaves the money alone", function()
+            local actor = H.set_actor{ money = 10000 }
+            H.fakes.set_random_sequence{ 0.99 }     -- >= the 0.5 default
+            B.make_scenario{}:ApplyMoneyLoss()
+            expect(actor:money()).toBe(10000)
+        end)
+
+        it("spends exactly one roll", function()
+            H.set_actor{ money = 10000 }
+            H.fakes.set_random_sequence{ 0.99 }
+            local before = H.fakes.random_count()
+            B.make_scenario{}:ApplyMoneyLoss()
+            expect(H.fakes.random_count() - before).toBe(1)
+        end)
+    end)
+
+    describe("given the chance roll succeeds", function()
+        it("deducts floor(money * roll * max_percent)", function()
+            local actor = H.set_actor{ money = 10000 }
+            -- roll 1 passes the 0.5 chance; roll 2 scales the 0.10 max percent.
+            H.fakes.set_random_sequence{ 0.1, 0.5 }
+            B.make_scenario{}:ApplyMoneyLoss()
+            expect(actor:money()).toBe(9500)        -- 10000 - floor(10000*0.05)
+        end)
+
+        it("spends exactly two rolls", function()
+            H.set_actor{ money = 10000 }
+            H.fakes.set_random_sequence{ 0.1, 0.5 }
+            local before = H.fakes.random_count()
+            B.make_scenario{}:ApplyMoneyLoss()
+            expect(H.fakes.random_count() - before).toBe(2)
+        end)
+
+        it("never deducts more than the actor holds", function()
+            -- give_money does not clamp -- it underflows u32
+            -- (InventoryOwner.cpp:630-645) -- so an over-deduction would leave
+            -- the player with ~4.29 billion rubles rather than zero.
+            local actor = H.set_actor{ money = 10000 }
+            H.fakes.set_random_sequence{ 0.0, 1.0 }
+            H.fakes.set_mcm("items/money_loss_max_percent", 1.0)
+            B.make_scenario{}:ApplyMoneyLoss()
+            expect(actor:money()).toBeGreaterThan(-1)
+            expect(actor:money()).toBeLessThan(10001)
+        end)
+    end)
+
+    describe("given the actor is broke", function()
+        it("does not call give_money at all", function()
+            local actor = H.set_actor{ money = 0 }
+            H.fakes.set_random_sequence{ 0.1, 0.5 }
+            B.make_scenario{}:ApplyMoneyLoss()
+            expect(actor:money()).toBe(0)
+        end)
+    end)
+
+    describe("given the computed loss rounds down to zero", function()
+        it("leaves the money untouched", function()
+            local actor = H.set_actor{ money = 5 }
+            H.fakes.set_random_sequence{ 0.1, 0.01 }   -- 5 * 0.001 -> floor 0
+            B.make_scenario{}:ApplyMoneyLoss()
+            expect(actor:money()).toBe(5)
+        end)
+    end)
+
+    describe("given the NoLoss scenario", function()
+        -- NoLoss overrides TransferItems and IsItemLossAllowed but NOT
+        -- TransferAndRespawn, which is what calls this (:502). Money is lost
+        -- even in the no-item-loss scenario -- deliberate, and worth pinning so
+        -- it is not "fixed" by accident.
+        it("still loses money", function()
+            local actor = H.set_actor{ money = 10000 }
+            H.fakes.set_random_sequence{ 0.1, 0.5 }
+            B.make_scenario{ class = "NoLossSoulslikeScenarioLogic" }:ApplyMoneyLoss()
+            expect(actor:money()).toBe(9500)
+        end)
+    end)
+end)
+
+describe("SoulslikeScenarioLogic:ApplyItemConditionLoss()", function()
+
+    beforeEach(function() boot() end)
+
+    describe("given a weapon", function()
+        it("degrades every part by the percentage", function()
+            local ak = B.make_item{ section = "wpn_ak74", kind = "weapon" }
+            B.make_scenario{}:ApplyItemConditionLoss(ak, nil, 0.10)
+            local parts = item_parts.get_parts_con(ak)
+            expect(parts.barrel).toBe(90)
+            expect(parts.receiver).toBe(90)
+        end)
+
+        -- The clamp floor is 1, so condition loss alone can never destroy a
+        -- weapon (:460).
+        it("never floors a part below 1", function()
+            local ak = B.make_item{ section = "wpn_ak74", kind = "weapon" }
+            B.make_scenario{}:ApplyItemConditionLoss(ak, nil, 1.0)
+            expect(item_parts.get_parts_con(ak).barrel).toBe(1)
+        end)
+
+        it("leaves the item intact even at full loss", function()
+            local ak = H.world.give("actor", "wpn_ak74", { kind = "weapon" })
+            B.make_scenario{}:ApplyItemConditionLoss(ak, nil, 1.0)
+            H.tick()
+            expect(H.world.where(ak)).toBe("actor")
+        end)
+
+        -- CHARACTERIZATION: the weapon path never sets items_were_lost and
+        -- never appends to lost_items, because a weapon cannot be destroyed
+        -- this way. Only the non-weapon branch does (:471-474).
+        it("CHARACTERIZATION: does not mark items as lost", function()
+            local ak = B.make_item{ section = "wpn_ak74", kind = "weapon" }
+            local s = B.make_scenario{}
+            s:ApplyItemConditionLoss(ak, nil, 1.0)
+            expect(s.logic_state.story.items_were_lost).toBeNil()
+        end)
+    end)
+
+    describe("given a weapon and item_parts is absent", function()
+        it("returns without touching the item", function()
+            H.boot{ load = MOD_SCRIPTS, without = { "item_parts" } }
+            H.fakes.set_random_min()
+            local ak = H.world.give("actor", "wpn_ak74", { kind = "weapon" })
+            B.make_scenario{}:ApplyItemConditionLoss(ak, nil, 1.0)
+            H.tick()
+            expect(H.world.where(ak)).toBe("actor")
+        end)
+    end)
+
+    describe("given a degradable non-weapon", function()
+        it("degrades its condition", function()
+            local suit = H.world.give("actor", "novice_outfit",
+                                      { kind = "outfit", condition = 1.0 })
+            B.make_scenario{}:ApplyItemConditionLoss(suit, nil, 0.25)
+            expect(suit:condition()).toBeCloseTo(0.75)
+        end)
+
+        it("keeps it in the container while it survives", function()
+            local suit = H.world.give("actor", "novice_outfit",
+                                      { kind = "outfit", condition = 1.0 })
+            B.make_scenario{}:ApplyItemConditionLoss(suit, nil, 0.25)
+            H.tick()
+            expect(H.world.where(suit)).toBe("actor")
+        end)
+    end)
+
+    describe("given a non-weapon degraded to nothing", function()
+        -- utils_item.degrade releases the object at condition 0
+        -- (utils_item.script:708) -- that is Lua behavior, not the engine's.
+        it("destroys the item", function()
+            local suit = H.world.give("actor", "novice_outfit",
+                                      { kind = "outfit", condition = 1.0 })
+            B.make_scenario{}:ApplyItemConditionLoss(suit, nil, 1.0)
+            H.tick()
+            expect(H.world.where(suit)).toBeNil()
+        end)
+
+        it("marks the story as having lost items", function()
+            local suit = H.world.give("actor", "novice_outfit", { kind = "outfit" })
+            local s = B.make_scenario{}
+            s:ApplyItemConditionLoss(suit, nil, 1.0)
+            expect(s.logic_state.story.items_were_lost).toBe(true)
+        end)
+
+        it("appends the section to the stash's lost_items", function()
+            local stash = H.world.container("stash", { id = 777 })
+            local suit = H.world.give("actor", "novice_outfit", { kind = "outfit" })
+            local s = B.make_scenario{}
+            s.game_state.created_stashes[777] = { lost_items = {}, examine = false }
+
+            s:ApplyItemConditionLoss(suit, stash, 1.0)
+            expect(s.game_state.created_stashes[777].lost_items).toEqual({ "novice_outfit" })
+        end)
+
+        it("still marks the story when there is no stash to record into", function()
+            local suit = H.world.give("actor", "novice_outfit", { kind = "outfit" })
+            local s = B.make_scenario{}
+            s:ApplyItemConditionLoss(suit, nil, 1.0)
+            expect(s.logic_state.story.items_were_lost).toBe(true)
+        end)
+    end)
+
+    describe("given a non-degradable item that is not gear", function()
+        it("leaves it untouched", function()
+            H.fakes.set_ltx("bread", { degradable = false })
+            local bread = H.world.give("actor", "bread", { condition = 1.0 })
+            B.make_scenario{}:ApplyItemConditionLoss(bread, nil, 1.0)
+            expect(bread:condition()).toBeCloseTo(1.0)
+        end)
+    end)
+end)
+
+return true

--- a/tests/unit/fatal_hit.spec.lua
+++ b/tests/unit/fatal_hit.spec.lua
@@ -1,0 +1,308 @@
+-- compute_fatal_hit_info (soulslike_scenario_logic_factory.script:8).
+--
+-- The densest logic in the mod: it decides WHO killed you, which drives the
+-- whole scenario choice. File-local and never exported, so it is reached
+-- through the upvalues of create_new rather than by editing the mod.
+--
+-- Algorithm, for reference:
+--   fatal_hit = first hit in ipairs order with is_fatal
+--   time_span = max_time - min_time  (or 1 when all hits share a timestamp)
+--   weight    = single_hit and 1 or (hit.time - min_time) / time_span, clamped
+--   bucket[type].power += hit.power * weight * (hit.is_fatal and 2 or 1)
+--   result    = the bucket with the highest power
+
+local H = require("harness.init")
+local fakes = H.fakes
+local B = H.builders
+
+describe("compute_fatal_hit_info()", function()
+
+    local compute, ET
+
+    beforeEach(function()
+        H.boot{ load = { "soulslike_classes", "soulslike",
+                         "soulslike_scenario_logic_factory" } }
+
+        -- Extracted from the test environment, not from inside a module:
+        -- soulslike.script defines `function debug(output)`, which shadows the
+        -- stdlib debug table within that module's scope.
+        compute = H.loader.upvalue(
+            soulslike_scenario_logic_factory.create_new, "compute_fatal_hit_info")
+        assert(compute, "could not reach compute_fatal_hit_info via upvalue")
+
+        ET = soulslike.entity_type
+        fakes.set_time(10000)
+    end)
+
+    -- Registers an object with level.object_by_id and returns its id.
+    local function place(obj)
+        fakes.register_object(obj)
+        return obj:id()
+    end
+
+    describe("given no hits", function()
+        it("does not raise", function()
+            -- max_time stays -math.huge and falls back to time_global().
+            expect(function() compute({}) end).never.toThrow()
+        end)
+
+        it("returns nil", function()
+            expect(compute({})).toBeNil()
+        end)
+    end)
+
+    describe("draftsman classification", function()
+
+        describe("given a hit with no draftsman_id", function()
+            it("attributes it to Other", function()
+                local r = compute({ B.make_hit{ power = 50, is_fatal = true, time = 100 } })
+                expect(r.draftsman_type).toBe(ET.Other)
+            end)
+        end)
+
+        describe("given a draftsman_id that no longer resolves", function()
+            it("falls back to Other", function()
+                -- level.object_by_id returns nil for a despawned object.
+                local r = compute({ B.make_hit{ power = 50, is_fatal = true,
+                                                time = 100, draftsman_id = 999999 } })
+                expect(r.draftsman_type).toBe(ET.Other)
+            end)
+        end)
+
+        describe("given a stalker draftsman", function()
+            it("classifies as Stalker", function()
+                local id = place(B.make_stalker{})
+                local r = compute({ B.make_hit{ power = 10, is_fatal = true,
+                                                time = 0, draftsman_id = id } })
+                expect(r.draftsman_type).toBe(ET.Stalker)
+            end)
+        end)
+
+        describe("given a monster draftsman", function()
+            it("classifies as Monster", function()
+                local id = place(B.make_monster{})
+                local r = compute({ B.make_hit{ power = 10, is_fatal = true,
+                                                time = 0, draftsman_id = id } })
+                expect(r.draftsman_type).toBe(ET.Monster)
+            end)
+        end)
+
+        describe("given an anomaly draftsman", function()
+            it("classifies as Anomaly", function()
+                local id = place(B.make_anomaly{})
+                local r = compute({ B.make_hit{ power = 10, is_fatal = true,
+                                                time = 0, draftsman_id = id } })
+                expect(r.draftsman_type).toBe(ET.Anomaly)
+            end)
+        end)
+
+        describe("given the actor as draftsman", function()
+            it("classifies as Self", function()
+                -- Checked by id against AC_ID before any Is* predicate, so
+                -- self-inflicted damage wins over other classifications.
+                local actor = B.make_actor{}
+                place(actor)
+                local r = compute({ B.make_hit{ power = 10, is_fatal = true,
+                                                time = 0, draftsman_id = actor:id() } })
+                expect(r.draftsman_type).toBe(ET.Self)
+            end)
+        end)
+    end)
+
+    describe("power weighting", function()
+
+        describe("given a single hit", function()
+            it("gives it full weight", function()
+                -- raw_span == 0 -> single_hit -> weight forced to 1. Without
+                -- that guard the sole hit would weigh 0 and attribute nothing.
+                local id = place(B.make_monster{})
+                local r = compute({ B.make_hit{ power = 40, is_fatal = true,
+                                                time = 500, draftsman_id = id } })
+                expect(r.power).toBeCloseTo(80)   -- 40 * weight 1 * fatal 2x
+            end)
+        end)
+
+        describe("given several hits sharing one timestamp", function()
+            it("gives them all full weight", function()
+                local id = place(B.make_monster{})
+                local r = compute({
+                    B.make_hit{ power = 10, time = 500, draftsman_id = id },
+                    B.make_hit{ power = 20, time = 500, draftsman_id = id },
+                })
+                expect(r.power).toBeCloseTo(30)
+            end)
+        end)
+
+        describe("given a fatal hit", function()
+            it("doubles its contribution", function()
+                local id = place(B.make_monster{})
+                local plain = compute({ B.make_hit{ power = 25, time = 0, draftsman_id = id } })
+                local fatal = compute({ B.make_hit{ power = 25, time = 0,
+                                                    is_fatal = true, draftsman_id = id } })
+                expect(fatal.power).toBeCloseTo(plain.power * 2)
+            end)
+        end)
+
+        describe("given hits spread over time", function()
+            it("weights later hits more heavily", function()
+                local mon = place(B.make_monster{})
+                local r = compute({
+                    B.make_hit{ power = 100, time = 0,    draftsman_id = mon },
+                    B.make_hit{ power = 100, time = 500,  draftsman_id = mon },
+                    B.make_hit{ power = 100, time = 1000, draftsman_id = mon },
+                })
+                expect(r.power).toBeCloseTo(150)   -- weights 0, 0.5, 1
+            end)
+
+            it("CHARACTERIZATION: gives the earliest hit zero weight", function()
+                -- weight = (time - min_time)/time_span, so the oldest hit
+                -- always weighs 0 and adds nothing at all. A big opening shot
+                -- followed by a light finisher attributes the kill to the
+                -- finisher.
+                --
+                -- A real behavioral edge, not obviously intended. Pinned so a
+                -- deliberate change is visible; if the weighting is ever
+                -- revised (e.g. to a floor above 0), update this, don't delete
+                -- it.
+                local stalker = place(B.make_stalker{})
+                local monster = place(B.make_monster{})
+
+                local r = compute({
+                    B.make_hit{ power = 1000, time = 0,    draftsman_id = stalker },
+                    B.make_hit{ power = 1,    time = 1000, draftsman_id = monster,
+                                is_fatal = true },
+                })
+
+                expect(r.draftsman_type).toBe(ET.Monster)
+                expect(r.power).toBeCloseTo(2)   -- 1 * weight 1 * fatal 2x
+            end)
+        end)
+    end)
+
+    describe("aggregation", function()
+
+        describe("given two different objects of the same type", function()
+            it("sums them into one bucket", function()
+                local a = place(B.make_stalker{ name = "a" })
+                local b = place(B.make_stalker{ name = "b" })
+                local r = compute({
+                    B.make_hit{ power = 30, time = 100, draftsman_id = a },
+                    B.make_hit{ power = 30, time = 100, draftsman_id = b },
+                })
+                expect(r.draftsman_type).toBe(ET.Stalker)
+                expect(r.power).toBeCloseTo(60)
+            end)
+        end)
+
+        describe("given competing buckets", function()
+            it("returns the highest-power one", function()
+                local stalker = place(B.make_stalker{})
+                local monster = place(B.make_monster{})
+                local r = compute({
+                    B.make_hit{ power = 10, time = 100, draftsman_id = stalker },
+                    B.make_hit{ power = 90, time = 100, draftsman_id = monster },
+                })
+                expect(r.draftsman_type).toBe(ET.Monster)
+            end)
+        end)
+    end)
+
+    describe("the fatal hit", function()
+
+        describe("given one hit flagged fatal", function()
+            it("attaches it to the result", function()
+                local id = place(B.make_monster{})
+                local fatal = B.make_hit{ power = 5, time = 100, is_fatal = true,
+                                          draftsman_id = id }
+                local r = compute({ B.make_hit{ power = 5, time = 100,
+                                                draftsman_id = id }, fatal })
+                expect(r.fatal_hit).toBe(fatal)
+            end)
+
+            it("attaches the resolved draftsman object to it", function()
+                -- create_new() reads
+                -- hit.fatal_hit.draftsman:general_goodwill(...) at
+                -- soulslike_scenario_logic_factory.script:248, so the object
+                -- -- not just the id -- has to be on the record.
+                local stalker = B.make_stalker{}
+                place(stalker)
+                local fatal = B.make_hit{ power = 5, time = 0, is_fatal = true,
+                                          draftsman_id = stalker:id() }
+                expect(compute({ fatal }).fatal_hit.draftsman).toBe(stalker)
+            end)
+        end)
+
+        describe("given several hits flagged fatal", function()
+            it("picks the first, because the loop breaks on a match", function()
+                local id = place(B.make_monster{})
+                local first  = B.make_hit{ power = 5, time = 100, is_fatal = true,
+                                           draftsman_id = id }
+                local second = B.make_hit{ power = 5, time = 200, is_fatal = true,
+                                           draftsman_id = id }
+                expect(compute({ first, second }).fatal_hit).toBe(first)
+            end)
+        end)
+
+        describe("given no hit is flagged fatal", function()
+            -- Damage-over-time deaths: nothing is marked fatal, but
+            -- attribution must still pick a bucket.
+            it("still resolves a draftsman type", function()
+                local id = place(B.make_monster{})
+                expect(compute({ B.make_hit{ power = 5, time = 100,
+                                             draftsman_id = id } }).draftsman_type)
+                    .toBe(ET.Monster)
+            end)
+
+            it("leaves fatal_hit nil", function()
+                local id = place(B.make_monster{})
+                expect(compute({ B.make_hit{ power = 5, time = 100,
+                                             draftsman_id = id } }).fatal_hit)
+                    .toBeNil()
+            end)
+        end)
+    end)
+
+    describe("side effects", function()
+        describe("given any hit record", function()
+            it("CHARACTERIZATION: writes the draftsman back onto the caller's table", function()
+                -- soulslike.script keeps these in the TimedQueue, so after a
+                -- death the queued records hold live object references until
+                -- Clear() runs.
+                local id = place(B.make_monster{})
+                local rec = B.make_hit{ power = 5, time = 0, is_fatal = true,
+                                        draftsman_id = id }
+                expect(rec.draftsman).toBeNil()          -- precondition
+                compute({ rec })
+                expect(rec.draftsman).toBeDefined()
+            end)
+        end)
+    end)
+
+    describe("given a realistic mixed engagement", function()
+        local function run()
+            local stalker = place(B.make_stalker{})
+            local monster = place(B.make_monster{})
+            return compute({
+                B.make_hit{ power = 20, time = 0,    draftsman_id = stalker }, -- w 0.0  -> 0
+                B.make_hit{ power = 20, time = 1000, draftsman_id = stalker }, -- w 0.5  -> 10
+                B.make_hit{ power = 30, time = 1500, draftsman_id = monster }, -- w 0.75 -> 22.5
+                B.make_hit{ power = 30, time = 2000, draftsman_id = monster,
+                            is_fatal = true },                                 -- w 1 x2 -> 60
+            })
+        end
+
+        it("attributes to the dominant late damage", function()
+            expect(run().draftsman_type).toBe(ET.Monster)
+        end)
+
+        it("sums the winning bucket correctly", function()
+            expect(run().power).toBeCloseTo(82.5)
+        end)
+
+        it("reports the fatal hit", function()
+            expect(run().fatal_hit).toBeDefined()
+        end)
+    end)
+end)
+
+return true

--- a/tests/unit/helpers.spec.lua
+++ b/tests/unit/helpers.spec.lua
@@ -1,0 +1,152 @@
+-- The helper functions soulslike.script installs onto the shared stdlib
+-- tables (soulslike.script:74-93).
+--
+-- Trivial on their own. They earn their place by doubling as a live assertion
+-- that the loader's global-table-mutation semantics are right: if the wrapper
+-- ever stopped letting modules write through to the real `math` and `table`,
+-- these are the first thing that breaks.
+
+local H = require("harness.init")
+
+describe("soulslike helpers", function()
+
+    beforeEach(function()
+        H.boot{ load = { "soulslike_classes", "soulslike" } }
+    end)
+
+    describe("math.clamp()", function()
+
+        it("is installed on the shared math table", function()
+            expect(math.clamp).toBeType("function")
+        end)
+
+        describe("given a value inside the range", function()
+            it("returns it unchanged", function()
+                expect(math.clamp(5, 0, 10)).toBe(5)
+            end)
+        end)
+
+        describe("given a value below the range", function()
+            it("returns the minimum", function()
+                expect(math.clamp(-1, 0, 10)).toBe(0)
+            end)
+        end)
+
+        describe("given a value above the range", function()
+            it("returns the maximum", function()
+                expect(math.clamp(11, 0, 10)).toBe(10)
+            end)
+        end)
+
+        describe("given a value exactly on a bound", function()
+            it("returns that bound", function()
+                expect(math.clamp(0, 0, 10)).toBe(0)
+                expect(math.clamp(10, 0, 10)).toBe(10)
+            end)
+        end)
+
+        describe("given an inverted range", function()
+            it("returns min, because the x < min branch wins first", function()
+                -- Characterization, not endorsement. No caller does this today.
+                expect(math.clamp(5, 10, 0)).toBe(10)
+            end)
+        end)
+    end)
+
+    describe("table.get_length()", function()
+
+        describe("given an empty table", function()
+            it("returns 0", function()
+                expect(table.get_length({})).toBe(0)
+            end)
+        end)
+
+        describe("given a sequential array", function()
+            it("returns the element count", function()
+                expect(table.get_length({ 1, 2, 3 })).toBe(3)
+            end)
+        end)
+
+        describe("given a keyed table", function()
+            it("counts the hash part too", function()
+                expect(table.get_length({ a = 1, b = 2 })).toBe(2)
+                expect(table.get_length({ 1, 2, x = 3 })).toBe(3)
+            end)
+        end)
+
+        describe("given a sparse table", function()
+            it("counts every entry, unlike #", function()
+                -- Why the mod uses it: soulslike_scenarios.script:709 checks
+                -- table.get_length(spawns) rather than #spawns.
+                local sparse = {}
+                sparse[1] = "a"
+                sparse[5] = "b"
+                expect(table.get_length(sparse)).toBe(2)
+            end)
+        end)
+    end)
+
+    describe("table.has_value()", function()
+
+        describe("given a value in the array part", function()
+            it("returns true", function()
+                expect(table.has_value({ "a", "b" }, "b")).toBeTruthy()
+            end)
+        end)
+
+        describe("given a value that is absent", function()
+            it("returns false", function()
+                expect(table.has_value({ "a", "b" }, "c")).toBeFalsy()
+            end)
+        end)
+
+        describe("given an empty table", function()
+            it("returns false", function()
+                expect(table.has_value({}, "a")).toBeFalsy()
+            end)
+        end)
+
+        describe("given a value only in the hash part", function()
+            it("does not find it, because it walks with ipairs", function()
+                -- Worth pinning: a caller passing a keyed table gets a silent
+                -- false rather than an error.
+                expect(table.has_value({ x = "found-me" }, "found-me")).toBeFalsy()
+            end)
+        end)
+    end)
+
+    describe("soulslike.try()", function()
+
+        describe("given a function that succeeds", function()
+            it("returns its result", function()
+                expect(soulslike.try(function() return 42 end)).toBe(42)
+            end)
+
+            it("forwards extra arguments", function()
+                expect(soulslike.try(function(a, b) return a + b end, 2, 3)).toBe(5)
+            end)
+        end)
+
+        describe("given a function that raises", function()
+            it("does not propagate the error", function()
+                expect(function() soulslike.try(function() error("boom") end) end)
+                    .never.toThrow()
+            end)
+
+            it("returns false", function()
+                expect(soulslike.try(function() error("boom") end)).toBe(false)
+            end)
+        end)
+
+        describe("given a function that legitimately returns false", function()
+            it("is indistinguishable from a failure", function()
+                -- Characterization of a real sharp edge: callers cannot tell a
+                -- raised error from an honest false.
+                expect(soulslike.try(function() return false end)).toBe(false)
+                expect(soulslike.try(function() error("x") end)).toBe(false)
+            end)
+        end)
+    end)
+end)
+
+return true

--- a/tests/unit/item_loss.spec.lua
+++ b/tests/unit/item_loss.spec.lua
@@ -1,0 +1,279 @@
+-- SoulslikeScenarioLogic:IsItemLossAllowed (soulslike_scenarios.script:919-984)
+--
+-- Decides what the player permanently loses, so it is the single most
+-- consequential predicate in the mod. Pure: no side effects beyond debug
+-- logging, which makes it exhaustively table-testable.
+--
+-- Two structures worth keeping in mind while reading:
+--
+--   * The six category GATES read the logic_state snapshot taken at __init,
+--     but the four KEEP-ROLLS read live MCM. A spec that sets one and asserts
+--     the other will look correct and prove nothing.
+--
+--   * `and` short-circuits, so exactly 0 or 1 math.random() calls happen per
+--     invocation. The budget is asserted separately because a stray roll would
+--     desynchronise every subsequent roll in a real death sequence.
+
+local H = require("harness.init")
+local B = H.builders
+
+local MOD_SCRIPTS = {
+    "soulslike_classes", "soulslike", "soulslike_mcm",
+    "soulslike_message_factory", "soulslike_scenarios",
+}
+
+-- Kinds map onto the _kind tag the Is* predicates read. Toolkits are the
+-- exception: the mod replaces _G.IsToolkit with a tools_list section lookup
+-- (soulslike.script:196-201), so a toolkit case needs a REAL section and its
+-- kind tag is irrelevant.
+local TOOLKIT_SECTION = "itm_basickit"
+
+local function boot()
+    H.boot{ load = MOD_SCRIPTS }
+    H.fakes.set_random_min()
+end
+
+--- Build the scenario and the item for one case, then run the predicate.
+--- Returns allowed, rolls_spent.
+local function evaluate(case)
+    boot()
+
+    for key, value in pairs(case.mcm or {}) do
+        H.fakes.set_mcm(key, value)
+    end
+
+    local scenario = B.make_scenario{
+        class = case.class,
+        state = case.state or {},
+    }
+
+    local section = case.section or "itm_generic"
+    if case.backpack then
+        H.fakes.set_ltx(section, { kind = "i_backpack" })
+    end
+
+    local item = B.make_item{ section = section, kind = case.kind }
+
+    if case.rolls then
+        H.fakes.set_random_sequence(case.rolls)
+    else
+        -- No roll expected. An empty queue turns an unexpected roll into a
+        -- loud failure rather than a silently reused value.
+        H.fakes.set_random_sequence{}
+    end
+
+    local before = H.fakes.random_count()
+    local allowed = scenario:IsItemLossAllowed(item)
+    return allowed, H.fakes.random_count() - before
+end
+
+-- Each case is one row of the decision table. `budget` is the exact number of
+-- math.random() calls the case may spend.
+local CASES = {
+    {
+        name = "the player died in water",
+        why  = "the water short-circuit precedes every other check",
+        kind = "weapon", section = "wpn_ak74",
+        state = { player_died_in_water = true },
+        allowed = false, budget = 0,
+    },
+    {
+        name = "a weapon and weapon loss is disallowed",
+        kind = "weapon", section = "wpn_ak74",
+        state = { allow_weapon_loss = false },
+        allowed = false, budget = 0,
+    },
+    {
+        name = "an artefact and artefact loss is disallowed",
+        kind = "artefact", section = "af_medusa",
+        state = { allow_artifact_loss = false },
+        allowed = false, budget = 0,
+    },
+    {
+        name = "an outfit and outfit loss is disallowed",
+        kind = "outfit", section = "novice_outfit",
+        state = { allow_outfit_loss = false },
+        allowed = false, budget = 0,
+    },
+    {
+        name = "headgear and headgear loss is disallowed",
+        kind = "headgear", section = "helm_respirator",
+        state = { allow_headgear_loss = false },
+        allowed = false, budget = 0,
+    },
+    {
+        name = "a toolkit and toolkit loss is disallowed",
+        why  = "IsToolkit is a section lookup, not a kind tag",
+        section = TOOLKIT_SECTION,
+        state = { allow_toolkit_loss = false },
+        allowed = false, budget = 0,
+    },
+    {
+        name = "a backpack",
+        why  = "refused unconditionally -- there is no allow flag for it",
+        section = "itm_actor_backpack", backpack = true,
+        allowed = false, budget = 0,
+    },
+    {
+        name = "a grenade while weapon loss is disallowed",
+        why  = "grenades are not weapons, so the weapon gate does not apply",
+        kind = "grenade", section = "grenade_f1",
+        state = { allow_weapon_loss = false },
+        allowed = true, budget = 0,
+    },
+    {
+        name = "an outfit and the keep roll succeeds",
+        kind = "outfit", section = "novice_outfit",
+        rolls = { 0.10 },
+        allowed = false, budget = 1,
+    },
+    {
+        name = "an outfit and the keep roll fails",
+        kind = "outfit", section = "novice_outfit",
+        rolls = { 0.90 },
+        allowed = true, budget = 1,
+    },
+    {
+        name = "an outfit and the roll lands exactly on the keep chance",
+        why  = "the comparison is `<`, so the boundary loses the item",
+        kind = "outfit", section = "novice_outfit",
+        rolls = { 0.25 },
+        allowed = true, budget = 1,
+    },
+    {
+        name = "headgear and the keep roll succeeds",
+        kind = "headgear", section = "helm_respirator",
+        rolls = { 0.10 },
+        allowed = false, budget = 1,
+    },
+    {
+        name = "a weapon and the keep roll succeeds",
+        kind = "weapon", section = "wpn_ak74",
+        rolls = { 0.10 },
+        allowed = false, budget = 1,
+    },
+    {
+        name = "an artefact and the keep roll succeeds",
+        kind = "artefact", section = "af_medusa",
+        rolls = { 0.10 },
+        allowed = false, budget = 1,
+    },
+    {
+        name = "a weapon and a raised keep chance covers the roll",
+        why  = "the keep chances are read live from MCM, not from the snapshot",
+        kind = "weapon", section = "wpn_ak74",
+        mcm  = { ["items/weapon_keep_chance"] = 0.95 },
+        rolls = { 0.90 },
+        allowed = false, budget = 1,
+    },
+    {
+        name = "an ordinary item",
+        section = "medkit",
+        allowed = true, budget = 0,
+    },
+    {
+        name = "a toolkit and toolkit loss is allowed",
+        why  = "toolkits have an allow flag but no keep roll, unlike the other four",
+        section = TOOLKIT_SECTION,
+        allowed = true, budget = 0,
+    },
+}
+
+describe("SoulslikeScenarioLogic:IsItemLossAllowed()", function()
+
+    for _, case in ipairs(CASES) do
+        local context = "given " .. case.name
+        if case.why then context = context .. " (" .. case.why .. ")" end
+
+        describe(context, function()
+            it(case.allowed and "allows the loss" or "refuses the loss", function()
+                local allowed = evaluate(case)
+                expect(allowed).toBe(case.allowed)
+            end)
+
+            it("spends " .. case.budget .. " random roll(s)", function()
+                local _, spent = evaluate(case)
+                expect(spent).toBe(case.budget)
+            end)
+        end)
+    end
+
+    describe("the snapshot / live-MCM split", function()
+        -- The gates read logic_state, captured at construction. Changing MCM
+        -- afterwards must not move a gate.
+        it("ignores an MCM change to a category gate after construction", function()
+            boot()
+            local scenario = B.make_scenario{ state = { allow_weapon_loss = false } }
+            H.fakes.set_mcm("items/allow_weapon_loss", true)
+            H.fakes.set_random_sequence{}
+
+            local ak = B.make_item{ section = "wpn_ak74", kind = "weapon" }
+            expect(scenario:IsItemLossAllowed(ak)).toBe(false)
+        end)
+
+        -- The keep chances do NOT come from the snapshot, so changing MCM
+        -- after construction does move them.
+        it("honours an MCM change to a keep chance after construction", function()
+            boot()
+            local scenario = B.make_scenario{}
+            H.fakes.set_mcm("items/weapon_keep_chance", 1.0)
+            H.fakes.set_random_sequence{ 0.99 }
+
+            local ak = B.make_item{ section = "wpn_ak74", kind = "weapon" }
+            expect(scenario:IsItemLossAllowed(ak)).toBe(false)
+        end)
+    end)
+
+    describe("given the NoLoss scenario", function()
+        -- The subclass overrides the predicate outright
+        -- (soulslike_scenarios.script:1488).
+        it("refuses every item", function()
+            local allowed = evaluate{
+                class = "NoLossSoulslikeScenarioLogic",
+                kind = "weapon", section = "wpn_ak74",
+            }
+            expect(allowed).toBe(false)
+        end)
+
+        it("refuses even an ordinary item", function()
+            local allowed = evaluate{
+                class = "NoLossSoulslikeScenarioLogic",
+                section = "medkit",
+            }
+            expect(allowed).toBe(false)
+        end)
+
+        it("spends no rolls", function()
+            local _, spent = evaluate{
+                class = "NoLossSoulslikeScenarioLogic",
+                kind = "outfit", section = "novice_outfit",
+            }
+            expect(spent).toBe(0)
+        end)
+    end)
+
+    describe("gate ordering", function()
+        -- The water short-circuit is first, so it wins over a category that
+        -- would otherwise spend a roll.
+        it("lets the water check pre-empt an outfit keep roll", function()
+            local allowed, spent = evaluate{
+                kind = "outfit", section = "novice_outfit",
+                state = { player_died_in_water = true },
+            }
+            expect(allowed).toBe(false)
+            expect(spent).toBe(0)
+        end)
+
+        -- Gates run before rolls, so a disallowed category never reaches its
+        -- keep roll.
+        it("lets a category gate pre-empt that category's keep roll", function()
+            local _, spent = evaluate{
+                kind = "weapon", section = "wpn_ak74",
+                state = { allow_weapon_loss = false },
+            }
+            expect(spent).toBe(0)
+        end)
+    end)
+end)
+
+return true

--- a/tests/unit/mcm_defaults.spec.lua
+++ b/tests/unit/mcm_defaults.spec.lua
@@ -1,0 +1,336 @@
+-- soulslike_mcm's getter contract.
+--
+-- Every one of the 60-odd getters funnels through get_config
+-- (soulslike_mcm.script:939):
+--
+--   local opt = ui_mcm and ui_mcm.get("soulslike/"..key)
+--   if opt == nil then opt = default_when_nil end
+--
+-- Two things follow, and both matter. A key the player has never touched
+-- returns the getter's declared default, which is what a fresh install runs on.
+-- And the check is `== nil`, not falsiness, so an explicit `false` is honoured
+-- rather than being replaced by a `true` default -- which is the entire point,
+-- since most of these defaults ARE true.
+--
+-- Asserted as tables per category rather than one `it` per getter: sixty
+-- one-line specs would be noise, and a table diff names the offender anyway.
+
+local H = require("harness.init")
+
+local MOD_SCRIPTS = { "soulslike_classes", "soulslike", "soulslike_mcm" }
+
+local function boot()
+    H.boot{ load = MOD_SCRIPTS }
+    H.fakes.set_random_min()
+end
+
+--- Call each named getter and collect the results.
+local function values_of(names)
+    local out = {}
+    for _, name in ipairs(names) do
+        local fn = soulslike_mcm[name]
+        assert(type(fn) == "function", "no such getter: " .. name)
+        out[name] = fn()
+    end
+    return out
+end
+
+describe("soulslike_mcm defaults", function()
+
+    beforeEach(boot)
+
+    describe("given a fresh install with nothing configured", function()
+
+        it("defaults the hardcore options off", function()
+            expect(values_of{
+                "is_hardcore_save_enabled",
+                "override_campfire_hardcore_saves",
+                "lose_all_items_on_death",
+            }).toEqual{
+                is_hardcore_save_enabled = false,
+                override_campfire_hardcore_saves = false,
+                lose_all_items_on_death = false,
+            }
+        end)
+
+        it("defaults the item loss scalars", function()
+            expect(values_of{
+                "get_item_loss_scalar",
+                "get_item_condition_loss_percent",
+                "get_keep_equipped_items_on_death",
+                "ignore_rank_when_computing_item_loss_chance",
+                "ignore_rank_when_computing_item_condition_loss",
+            }).toEqual{
+                get_item_loss_scalar = 0.2,
+                get_item_condition_loss_percent = 0.05,
+                get_keep_equipped_items_on_death = false,
+                ignore_rank_when_computing_item_loss_chance = false,
+                ignore_rank_when_computing_item_condition_loss = false,
+            }
+        end)
+
+        it("defaults every keep chance to a quarter", function()
+            expect(values_of{
+                "get_keep_artifact_chance", "get_keep_headgear_chance",
+                "get_keep_outfit_chance", "get_keep_weapon_chance",
+            }).toEqual{
+                get_keep_artifact_chance = 0.25,
+                get_keep_headgear_chance = 0.25,
+                get_keep_outfit_chance   = 0.25,
+                get_keep_weapon_chance   = 0.25,
+            }
+        end)
+
+        it("permits every category of loss", function()
+            expect(values_of{
+                "allow_weapon_loss", "allow_artifact_loss", "allow_outfit_loss",
+                "allow_headgear_loss", "allow_toolkit_loss",
+            }).toEqual{
+                allow_weapon_loss   = true,
+                allow_artifact_loss = true,
+                allow_outfit_loss   = true,
+                allow_headgear_loss = true,
+                allow_toolkit_loss  = true,
+            }
+        end)
+
+        it("defaults every per-type loss chance to certain", function()
+            expect(values_of{
+                "get_outfit_loss_chance", "get_weapon_loss_chance",
+                "get_artefact_loss_chance", "get_headgear_loss_chance",
+                "get_toolkit_loss_chance", "get_other_loss_chance",
+            }).toEqual{
+                get_outfit_loss_chance   = 1.0,
+                get_weapon_loss_chance   = 1.0,
+                get_artefact_loss_chance = 1.0,
+                get_headgear_loss_chance = 1.0,
+                get_toolkit_loss_chance  = 1.0,
+                get_other_loss_chance    = 1.0,
+            }
+        end)
+
+        it("defaults every per-type condition loss chance to certain", function()
+            expect(values_of{
+                "get_outfit_condition_loss_chance",
+                "get_weapon_condition_loss_chance",
+                "get_artefact_condition_loss_chance",
+                "get_headgear_condition_loss_chance",
+            }).toEqual{
+                get_outfit_condition_loss_chance   = 1.0,
+                get_weapon_condition_loss_chance   = 1.0,
+                get_artefact_condition_loss_chance = 1.0,
+                get_headgear_condition_loss_chance = 1.0,
+            }
+        end)
+
+        it("defaults the character penalties", function()
+            expect(values_of{
+                "get_health_loss_percent", "rank_loss_percent",
+                "rep_loss_percent", "allow_nighttime_respawn",
+                "allow_rank_loss", "allow_rep_loss",
+            }).toEqual{
+                get_health_loss_percent = 0.75,
+                rank_loss_percent = 0.02,
+                rep_loss_percent = 0.05,
+                allow_nighttime_respawn = true,
+                allow_rank_loss = true,
+                allow_rep_loss = true,
+            }
+        end)
+
+        it("defaults the money penalties", function()
+            expect(values_of{
+                "allow_money_loss", "get_money_loss_chance",
+                "get_money_loss_max_percent",
+            }).toEqual{
+                allow_money_loss = true,
+                get_money_loss_chance = 0.5,
+                get_money_loss_max_percent = 0.10,
+            }
+        end)
+
+        it("defaults the ambush chances to a quarter", function()
+            expect(values_of{
+                "mutant_ambush_chance", "stalker_ambush_chance",
+            }).toEqual{
+                mutant_ambush_chance = 0.25,
+                stalker_ambush_chance = 0.25,
+            }
+        end)
+
+        it("permits every ambush type", function()
+            expect(values_of{
+                "allow_boar_ambush", "allow_flesh_ambush", "allow_dogs_ambush",
+                "allow_cats_ambush", "allow_snorks_ambush",
+                "allow_bloodsucker_ambush", "allow_burer_ambush",
+                "allow_chimera_ambush", "allow_controller_ambush",
+                "allow_stalker_novice_ambush", "allow_stalker_advanced_ambush",
+                "allow_stalker_veteran_ambush", "allow_stalker_sniper_ambush",
+            }).toEqual{
+                allow_boar_ambush = true, allow_flesh_ambush = true,
+                allow_dogs_ambush = true, allow_cats_ambush = true,
+                allow_snorks_ambush = true, allow_bloodsucker_ambush = true,
+                allow_burer_ambush = true, allow_chimera_ambush = true,
+                allow_controller_ambush = true,
+                allow_stalker_novice_ambush = true,
+                allow_stalker_advanced_ambush = true,
+                allow_stalker_veteran_ambush = true,
+                allow_stalker_sniper_ambush = true,
+            }
+        end)
+
+        it("defaults the scenario options", function()
+            expect(values_of{
+                "are_looter_npcs_marked", "nearby_dead_stalker_scenario_weight",
+            }).toEqual{
+                are_looter_npcs_marked = false,
+                nearby_dead_stalker_scenario_weight = 0.10,
+            }
+        end)
+
+        it("defaults every debug flag off", function()
+            expect(values_of{
+                "is_debug_enabled", "show_debug_tips", "debug_hidden_stashes",
+                "debug_squad_spawns", "debug_item_loss",
+                "debug_remove_default_scenario", "debug_the_tarkov_looter",
+                "debug_always_spawn_ambush",
+            }).toEqual{
+                is_debug_enabled = false, show_debug_tips = false,
+                debug_hidden_stashes = false, debug_squad_spawns = false,
+                debug_item_loss = false, debug_remove_default_scenario = false,
+                debug_the_tarkov_looter = false, debug_always_spawn_ambush = false,
+            }
+        end)
+
+        it("protects every named item by default", function()
+            expect(soulslike_mcm.is_ignored("ignore_bolt")).toBe(true)
+            expect(soulslike_mcm.is_ignored("ignore_medkit")).toBe(true)
+        end)
+
+        it("defaults the free-text ignore list to empty", function()
+            expect(soulslike_mcm.get_ignored_other()).toBe("")
+        end)
+    end)
+
+    describe("given a configured value", function()
+
+        it("returns it instead of the default", function()
+            H.fakes.set_mcm("items/item_loss_scalar", 0.9)
+            expect(soulslike_mcm.get_item_loss_scalar()).toBeCloseTo(0.9)
+        end)
+
+        -- The check is `opt == nil`, not `not opt`. With `not opt`, every one
+        -- of the dozen true-by-default toggles would be impossible to turn off:
+        -- setting false would fall straight back to the default.
+        it("honours an explicit false over a true default", function()
+            H.fakes.set_mcm("items/allow_weapon_loss", false)
+            expect(soulslike_mcm.allow_weapon_loss()).toBe(false)
+        end)
+
+        it("honours an explicit zero over a non-zero default", function()
+            H.fakes.set_mcm("ambush/mutant_ambush_chance", 0)
+            expect(soulslike_mcm.mutant_ambush_chance()).toBe(0)
+        end)
+
+        it("honours an explicit false for every allow_ toggle", function()
+            local names = {
+                "allow_weapon_loss", "allow_artifact_loss", "allow_outfit_loss",
+                "allow_headgear_loss", "allow_nighttime_respawn",
+                "allow_rank_loss", "allow_rep_loss", "allow_money_loss",
+                "allow_boar_ambush", "allow_flesh_ambush", "allow_dogs_ambush",
+                "allow_cats_ambush", "allow_snorks_ambush",
+                "allow_bloodsucker_ambush", "allow_burer_ambush",
+                "allow_chimera_ambush", "allow_controller_ambush",
+                "allow_stalker_novice_ambush", "allow_stalker_advanced_ambush",
+                "allow_stalker_veteran_ambush", "allow_stalker_sniper_ambush",
+            }
+            -- Keys are not derivable from the getter names (allow_toolkit_loss
+            -- reads items/allow_tool_loss), so set every plausible path and
+            -- assert the effect rather than the wiring.
+            for _, group in ipairs{ "items", "character", "ambush" } do
+                for _, name in ipairs(names) do
+                    H.fakes.set_mcm(group .. "/" .. name, false)
+                end
+            end
+
+            local still_true = {}
+            for _, name in ipairs(names) do
+                if soulslike_mcm[name]() ~= false then
+                    still_true[#still_true + 1] = name
+                end
+            end
+            expect(still_true).toEqual({})
+        end)
+
+        it("lets an item be un-protected", function()
+            H.fakes.set_mcm("ignored_items/ignore_bolt", false)
+            expect(soulslike_mcm.is_ignored("ignore_bolt")).toBe(false)
+        end)
+    end)
+
+    describe("the debug gate", function()
+        -- Every debug getter is `is_debug_enabled() and get_config(...)`, so
+        -- the master switch overrides each sub-flag rather than sitting
+        -- alongside it.
+        it("keeps sub-flags off while debug is disabled", function()
+            H.fakes.set_mcm("debug/debug_squad_spawns", true)
+            H.fakes.set_mcm("debug/debug_item_loss", true)
+            expect(soulslike_mcm.debug_squad_spawns()).toBe(false)
+            expect(soulslike_mcm.debug_item_loss()).toBe(false)
+        end)
+
+        it("lets them through once debug is enabled", function()
+            H.fakes.set_mcm("debug/is_enabled", true)
+            H.fakes.set_mcm("debug/debug_squad_spawns", true)
+            expect(soulslike_mcm.debug_squad_spawns()).toBe(true)
+        end)
+    end)
+
+    describe("DEAD CODE: the disabled scenario weights", function()
+        -- These three hard-return 0.0 with the real get_config call commented
+        -- out (:961-971), and the two debug scenario getters hard-return false
+        -- (:1138, :1142). The RF Detector and Hidden Stash scenarios are
+        -- therefore unreachable through create_new; they exist only for saves
+        -- that already selected them.
+        it("keeps the weights at zero whatever is configured", function()
+            H.fakes.set_mcm("scenarios/rf_detector_scenario_weight", 1.0)
+            H.fakes.set_mcm("scenarios/hidden_stash_scenario_weight", 1.0)
+            H.fakes.set_mcm("scenarios/scattered_stash_scenario_weight", 1.0)
+
+            expect(soulslike_mcm.rf_detector_scenario_weight()).toBe(0.0)
+            expect(soulslike_mcm.hidden_stash_scenario_weight()).toBe(0.0)
+            expect(soulslike_mcm.scattered_stash_scenario_weight()).toBe(0.0)
+        end)
+
+        it("keeps the debug scenario flags false even with debug on", function()
+            H.fakes.set_mcm("debug/is_enabled", true)
+            H.fakes.set_mcm("debug/debug_the_rf_scenario", true)
+            H.fakes.set_mcm("debug/debug_the_hidden_stash_scenario", true)
+
+            expect(soulslike_mcm.debug_the_rf_scenario()).toBe(false)
+            expect(soulslike_mcm.debug_the_hidden_stash_scenario()).toBe(false)
+        end)
+    end)
+
+    describe("given ui_mcm is not installed at all", function()
+        -- get_config guards with `ui_mcm and ...`, so a player without the MCM
+        -- framework gets every declared default rather than a nil-index crash.
+        beforeEach(function()
+            H.boot{ load = MOD_SCRIPTS }
+            H.fakes.set_random_min()
+            _G.ui_mcm = nil
+        end)
+
+        it("still returns the defaults", function()
+            expect(soulslike_mcm.get_item_loss_scalar()).toBeCloseTo(0.2)
+            expect(soulslike_mcm.allow_weapon_loss()).toBe(true)
+        end)
+
+        it("does not raise", function()
+            expect(function() soulslike_mcm.is_hardcore_save_enabled() end)
+                .never.toThrow()
+        end)
+    end)
+end)
+
+return true

--- a/tests/unit/mcm_localization.spec.lua
+++ b/tests/unit/mcm_localization.spec.lua
@@ -1,0 +1,359 @@
+-- MCM labels against the localisation tables, in both directions.
+--
+-- MCM resolves an option's on-screen label like this (ui_mcm.script):
+--
+--   explicit:  node.text
+--   derived:   "ui_mcm_" .. <full path with "/" replaced by "_">
+--
+-- so a node declared as
+--
+--   { id = "allow_weapon_loss", type = "check", val = 1, def = true }
+--
+-- inside group `items` under root `soulslike` needs the string id
+-- `ui_mcm_soulslike_items_allow_weapon_loss`. Nothing checks that at load time:
+-- game.translate_string returns the raw id on a miss, so a broken entry shows
+-- up in the menu as `ui_mcm_soulslike_items_allow_weapon_loss` and nowhere
+-- else. Renaming an option id silently breaks its label.
+--
+-- MCM also looks up an optional tooltip at "<label key>_desc". Absent is fine
+-- -- it just means no tooltip -- so those are only checked in the orphan
+-- direction, where a stray `_desc` means the option it described is gone.
+--
+-- BASELINE, not a wishlist. The tables below record what is broken TODAY so
+-- the suite stays green and a NEW break fails immediately. Shrinking a baseline
+-- table is the fix; growing one should be a deliberate decision.
+
+local H = require("harness.init")
+
+local MOD_SCRIPTS = { "soulslike_classes", "soulslike", "soulslike_mcm" }
+
+local ROOT = "soulslike"
+
+-- Nodes that render rather than store. They still carry a label, so they are
+-- checked the same way; only `line` has nothing to show.
+local NO_LABEL = { line = true, image = true }
+
+local eng, rus, tree
+
+local function boot()
+    H.boot{ load = MOD_SCRIPTS }
+    H.fakes.set_random_min()
+    tree = soulslike_mcm.on_mcm_load()
+    eng = H.loader.load_string_table("eng")
+    rus = H.loader.load_string_table("rus")
+end
+
+--- Every labelled node, with the string id MCM will actually look up.
+--- { path, key, explicit, group, id }
+local function labels()
+    local out = {}
+
+    local function walk(node, prefix)
+        for _, child in ipairs(node.gr or {}) do
+            local path = prefix .. "/" .. tostring(child.id)
+            if type(child.gr) == "table" then
+                walk(child, path)
+            elseif not NO_LABEL[child.type] then
+                out[#out + 1] = {
+                    path     = path,
+                    key      = child.text or ("ui_mcm_" .. path:gsub("/", "_")),
+                    explicit = child.text ~= nil,
+                    group    = prefix:match("([^/]+)$"),
+                    id       = child.id,
+                    type     = child.type,
+                }
+            end
+        end
+    end
+
+    walk(tree, ROOT)
+    return out
+end
+
+--- A `text` that is not a string id at all, but a literal English sentence.
+--- It renders, because translate_string passes unknown input through, but it
+--- can never be localised.
+local function is_literal(key)
+    return not key:match("^ui_") and not key:match("^st_")
+end
+
+local function sorted(set)
+    local out = {}
+    for v in pairs(set) do out[#out + 1] = v end
+    table.sort(out)
+    return out
+end
+
+-- ---------------------------------------------------------------- baselines
+
+-- Nodes whose label key is not in the English tables. These render as the raw
+-- id in the menu right now.
+local MISSING_ENG = {
+    ["ui_mcm_soulslike_ignored_items_other"] = true,
+    ["ui_mcm_soulslike_debug_debug_squad_spawns"] = true,
+    ["ui_mcm_soulslike_debug_debug_remove_default_scenario"] = true,
+    ["ui_mcm_soulslike_debug_debug_always_spawn_ambush"] = true,
+}
+
+-- Nodes carrying a hardcoded English sentence instead of a string id.
+-- Both of these already HAVE translations in the tables
+-- (ui_mcm_soulslike_hardcore_lose_all_items_on_death and its _desc), which is
+-- why they show up as orphans below -- deleting the literal would wire them up.
+local LITERAL_TEXT = {
+    ["soulslike/hardcore/lose_all_items_on_death"] = true,
+    ["soulslike/hardcore/lose_all_items_on_death_desc"] = true,
+}
+
+-- Translations with no node to attach to. Everything here belongs to an option
+-- that is commented out in the tree, so the string is dead until that option
+-- comes back.
+local ORPHAN_ENG = {
+    ["ui_mcm_soulslike_debug_debug_hidden_stashes"] = true,
+    ["ui_mcm_soulslike_debug_debug_the_hidden_stash_scenario"] = true,
+    ["ui_mcm_soulslike_debug_debug_the_rf_scenario"] = true,
+    ["ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight"] = true,
+    ["ui_mcm_soulslike_scenarios_rf_detector_scenario_weight"] = true,
+    ["ui_mcm_soulslike_scenarios_rf_detector_scenario_weight_desc"] = true,
+    -- Orphaned only because the node hardcodes the English literal above.
+    ["ui_mcm_soulslike_hardcore_lose_all_items_on_death"] = true,
+    ["ui_mcm_soulslike_hardcore_lose_all_items_on_death_desc"] = true,
+}
+
+-- Labels present in English but not Russian: a Russian player sees the raw id.
+local MISSING_RUS = {
+    ["ui_mcm_soulslike_ignored_items_device_pda_0"] = true,
+    ["ui_mcm_soulslike_ignored_items_device_pda_4"] = true,
+    ["ui_mcm_soulslike_ignored_items_device_pda_getac"] = true,
+    ["ui_mcm_soulslike_ignored_items_device_pda_kulon"] = true,
+    ["ui_mcm_soulslike_ignored_items_device_pda_milspec"] = true,
+    ["ui_mcm_soulslike_items_artifact_keep_chance"] = true,
+    ["ui_mcm_soulslike_items_headgear_keep_chance"] = true,
+    ["ui_mcm_soulslike_items_outfit_keep_chance"] = true,
+    ["ui_mcm_soulslike_items_weapon_keep_chance"] = true,
+    -- The `desc` nodes carrying these ids as their own explicit text.
+    ["ui_mcm_soulslike_ignored_items_other_desc"] = true,
+    ["ui_mcm_soulslike_items_artifact_keep_chance_desc"] = true,
+    ["ui_mcm_soulslike_items_headgear_keep_chance_desc"] = true,
+    ["ui_mcm_soulslike_items_outfit_keep_chance_desc"] = true,
+    ["ui_mcm_soulslike_items_weapon_keep_chance_desc"] = true,
+}
+
+describe("MCM localisation", function()
+
+    beforeEach(boot)
+
+    describe("the string tables", function()
+        it("loads the English table", function()
+            expect(eng["ui_mcm_menu_soulslike"]).toBe(true)
+        end)
+
+        it("loads the Russian table", function()
+            expect(rus["ui_mcm_menu_soulslike"]).toBe(true)
+        end)
+
+        -- The root has no `text`, so MCM derives ui_mcm_menu_<root_id> for the
+        -- entry in the mod list.
+        it("has a name for the mod's own menu entry", function()
+            expect(eng["ui_mcm_menu_" .. ROOT]).toBe(true)
+        end)
+
+        it("finds every group's label", function()
+            local missing = {}
+            for _, group in ipairs(tree.gr) do
+                local key = group.text or ("ui_mcm_menu_" .. tostring(group.id))
+                if not eng[key] then missing[#missing + 1] = group.id .. " -> " .. key end
+            end
+            expect(missing).toEqual({})
+        end)
+    end)
+
+    describe("every node's label exists in English", function()
+        -- The direction that matters most: this is what a player sees.
+        it("has no unlisted missing keys", function()
+            local broken = {}
+            for _, label in ipairs(labels()) do
+                if not is_literal(label.key)
+                   and not eng[label.key]
+                   and not MISSING_ENG[label.key] then
+                    broken[#broken + 1] = label.path .. "  ->  " .. label.key
+                end
+            end
+            table.sort(broken)
+            expect(broken).toEqual({})
+        end)
+
+        -- Guards the baseline itself. If one of these gains a translation the
+        -- entry should come off the list, so the next regression is caught.
+        it("keeps the known-missing list accurate", function()
+            local now_fixed = {}
+            for key in pairs(MISSING_ENG) do
+                if eng[key] then now_fixed[#now_fixed + 1] = key end
+            end
+            table.sort(now_fixed)
+            expect(now_fixed).toEqual({})
+        end)
+
+        it("keeps the known-missing list reachable", function()
+            -- A baseline entry naming a node that no longer exists is stale.
+            local live = {}
+            for _, label in ipairs(labels()) do live[label.key] = true end
+
+            local stale = {}
+            for key in pairs(MISSING_ENG) do
+                if not live[key] then stale[#stale + 1] = key end
+            end
+            table.sort(stale)
+            expect(stale).toEqual({})
+        end)
+    end)
+
+    describe("every node's label is a string id", function()
+        -- A literal renders, because translate_string passes unknown input
+        -- through unchanged, but it can never be translated.
+        it("has no unlisted hardcoded English", function()
+            local literals = {}
+            for _, label in ipairs(labels()) do
+                if label.explicit and is_literal(label.key)
+                   and not LITERAL_TEXT[label.path] then
+                    literals[#literals + 1] = label.path
+                end
+            end
+            table.sort(literals)
+            expect(literals).toEqual({})
+        end)
+
+        it("keeps the known-literal list accurate", function()
+            local live = {}
+            for _, label in ipairs(labels()) do
+                if label.explicit and is_literal(label.key) then live[label.path] = true end
+            end
+
+            local stale = {}
+            for path in pairs(LITERAL_TEXT) do
+                if not live[path] then stale[#stale + 1] = path end
+            end
+            table.sort(stale)
+            expect(stale).toEqual({})
+        end)
+    end)
+
+    describe("every translation has a node", function()
+        -- The other direction. An orphan is usually a rename: the option moved
+        -- and its old string stayed behind, so the new one shows a raw id
+        -- while the old translation sits unused.
+        --
+        -- `<key>_desc` is MCM's optional tooltip for `<key>`, not a node of its
+        -- own, so it counts as used when its owner exists.
+        local function used_keys()
+            local used = {}
+            used["ui_mcm_menu_" .. ROOT] = true
+            for _, group in ipairs(tree.gr) do
+                used[group.text or ("ui_mcm_menu_" .. tostring(group.id))] = true
+            end
+            for _, label in ipairs(labels()) do
+                used[label.key] = true
+                used[label.key .. "_desc"] = true
+            end
+            return used
+        end
+
+        it("has no unlisted orphans", function()
+            local used = used_keys()
+            local orphans = {}
+
+            for id in pairs(eng) do
+                if id:match("^ui_mcm_" .. ROOT .. "_")
+                   and not used[id] and not ORPHAN_ENG[id] then
+                    orphans[#orphans + 1] = id
+                end
+            end
+            table.sort(orphans)
+            expect(orphans).toEqual({})
+        end)
+
+        it("keeps the known-orphan list accurate", function()
+            local used = used_keys()
+            local reattached = {}
+            for id in pairs(ORPHAN_ENG) do
+                if used[id] then reattached[#reattached + 1] = id end
+            end
+            table.sort(reattached)
+            expect(reattached).toEqual({})
+        end)
+
+        it("keeps the known-orphan list present in the tables", function()
+            local gone = {}
+            for id in pairs(ORPHAN_ENG) do
+                if not eng[id] then gone[#gone + 1] = id end
+            end
+            table.sort(gone)
+            expect(gone).toEqual({})
+        end)
+    end)
+
+    describe("Russian parity", function()
+        -- Lower severity than a missing English key -- an English speaker never
+        -- sees it -- but a Russian player gets the raw id just the same.
+        it("has no unlisted untranslated labels", function()
+            local untranslated = {}
+            for _, label in ipairs(labels()) do
+                if not is_literal(label.key)
+                   and eng[label.key] and not rus[label.key]
+                   and not MISSING_RUS[label.key] then
+                    untranslated[#untranslated + 1] = label.path
+                end
+            end
+            table.sort(untranslated)
+            expect(untranslated).toEqual({})
+        end)
+
+        it("keeps the known-untranslated list accurate", function()
+            local now_translated = {}
+            for key in pairs(MISSING_RUS) do
+                if rus[key] then now_translated[#now_translated + 1] = key end
+            end
+            table.sort(now_translated)
+            expect(now_translated).toEqual({})
+        end)
+
+        it("translates every group heading", function()
+            local missing = {}
+            for _, group in ipairs(tree.gr) do
+                local key = group.text or ("ui_mcm_menu_" .. tostring(group.id))
+                if eng[key] and not rus[key] then missing[#missing + 1] = group.id end
+            end
+            expect(missing).toEqual({})
+        end)
+    end)
+
+    describe("the derivation rule itself", function()
+        -- Pins the concatenation, since every assertion above depends on it.
+        it("joins root, group and option with underscores", function()
+            local found
+            for _, label in ipairs(labels()) do
+                if label.id == "allow_weapon_loss" then found = label end
+            end
+            expect(found).toBeDefined()
+            expect(found.key).toBe("ui_mcm_soulslike_items_allow_weapon_loss")
+        end)
+
+        it("prefers an explicit text over the derived key", function()
+            local found
+            for _, label in ipairs(labels()) do
+                if label.id == "allow_rank_loss" then found = label end
+            end
+            expect(found.explicit).toBe(true)
+            expect(found.key).toBe("ui_mcm_soulslike_character_allow_rank_loss")
+        end)
+
+        -- Renaming an option id moves its label key, which is exactly how these
+        -- break in practice.
+        it("ties the key to the option id", function()
+            local by_key = {}
+            for _, label in ipairs(labels()) do by_key[label.key] = label.id end
+            expect(by_key["ui_mcm_soulslike_ambush_allow_boar_ambush"]).toBe("allow_boar_ambush")
+        end)
+    end)
+end)
+
+return true

--- a/tests/unit/mcm_localization.spec.lua
+++ b/tests/unit/mcm_localization.spec.lua
@@ -15,9 +15,17 @@
 -- translation AND the old translation is orphaned, so one mistake fails two
 -- assertions that point at each other.
 --
--- The derivation, the analysis and the baselines all live in
--- harness/mcm_labels.lua, shared with locals.lua so there is one copy. Run
--- `locals.bat` for the same findings as a readable report.
+-- The derivation and the analysis live in harness/mcm_labels.lua, shared with
+-- locals.lua so there is one copy. Run `locals.bat` for the same findings as a
+-- readable report.
+--
+-- Every assertion below expects an empty list, and there is no way to make one
+-- pass other than fixing the localisation. An earlier version of this file
+-- checked findings against four tables of "known broken" string ids in the
+-- harness, so adding an id turned a failure into a pass. That is backwards: a
+-- test that a caller can switch off by editing data is not testing anything.
+-- If a finding ever has to be tolerated, write the reason here, in prose, next
+-- to the assertion that tolerates it.
 
 local H = require("harness.init")
 local labels = require("harness.mcm_labels")
@@ -60,8 +68,8 @@ describe("MCM localisation", function()
 
     describe("every node's label exists in English", function()
         -- The direction that matters most: this is what a player sees.
-        it("has no new missing keys", function()
-            expect(result.missing_eng.new).toEqual({})
+        it("has no missing keys", function()
+            expect(result.missing_eng).toEqual({})
         end)
 
         it("translates every group heading", function()
@@ -72,8 +80,8 @@ describe("MCM localisation", function()
     describe("every node's label is a string id", function()
         -- A literal renders, since translate_string passes unknown input
         -- through unchanged, but it can never be translated.
-        it("has no new hardcoded English", function()
-            expect(result.literal.new).toEqual({})
+        it("has no hardcoded English", function()
+            expect(result.literal).toEqual({})
         end)
     end)
 
@@ -81,30 +89,36 @@ describe("MCM localisation", function()
         -- An orphan is usually a rename: the option moved and its old string
         -- stayed behind, so the new one shows a raw id while the old
         -- translation sits unused.
-        it("has no new orphans", function()
-            expect(result.orphan.new).toEqual({})
+        --
+        -- A string for an option that is commented out is an orphan too, and
+        -- it is deleted, not kept. Git holds the text if the option comes
+        -- back, and a string with nothing pointing at it cannot be told apart
+        -- from half a rename by reading the file.
+        it("has no orphans", function()
+            expect(result.orphan).toEqual({})
         end)
     end)
 
     describe("Russian parity", function()
         -- Lower severity than a missing English key -- an English speaker never
         -- sees it -- but a Russian player gets the raw id just the same.
-        it("has no newly untranslated labels", function()
-            expect(result.missing_rus.new).toEqual({})
+        it("has no untranslated labels", function()
+            expect(result.missing_rus).toEqual({})
         end)
 
-        -- The check above only sees ids the MCM tree asks for -- 112 of 218
+        -- The check above only sees ids the MCM tree asks for -- 112 of 220
         -- strings. Every message, item name and main-menu string was outside
         -- its reach, so a translation gap in soulslike_messages.xml was
         -- invisible to the whole suite while `locals.bat` printed it and no
         -- assertion read it. Compare the tables outright instead.
-        it("has no newly untranslated strings anywhere", function()
-            expect(result.parity.only_eng.new).toEqual({})
+        it("has no untranslated strings anywhere", function()
+            expect(result.parity.only_eng).toEqual({})
         end)
 
-        -- Not baselined, unlike the direction above: this is not outstanding
-        -- translation work but a rename applied to one table only, so the rus
-        -- entry is dead and its replacement is untranslated under a new id.
+        -- The opposite direction is not translation work at all: there is
+        -- nothing left to translate. It is a rename applied to one table only,
+        -- so the rus entry is dead and its replacement is untranslated under a
+        -- new id.
         it("has no Russian string without an English one", function()
             expect(result.parity.only_rus).toEqual({})
         end)
@@ -121,18 +135,48 @@ describe("MCM localisation", function()
         end)
     end)
 
-    describe("the baselines", function()
-        -- A baseline entry that no longer describes reality is worse than a
-        -- plain break: it masks the next regression in that slot. Deleting a
-        -- stale entry is the fix, never updating it to match.
-        it("all still describe reality", function()
-            expect(result.stale).toEqual({})
+    describe("the analysis itself", function()
+        -- Every assertion above expects an empty list, so all of them would
+        -- pass just as well if analyse() had stopped looking at anything.
+        -- Feed it a tree whose label is missing from both tables and confirm
+        -- each category still reports.
+        local BROKEN = { gr = {
+            { id = "nowhere", gr = {
+                { id = "no_such_option", type = "check", val = 1, def = false },
+                { id = "hardcoded", type = "check", val = 1, def = false,
+                  text = "A literal sentence" },
+            }},
+        }}
+
+        it("reports a label with no English string", function()
+            local r = labels.analyse(BROKEN, {}, {})
+            expect(#r.missing_eng).toBe(1)
         end)
 
-        it("account for everything currently broken", function()
-            local known = #result.missing_eng.known + #result.literal.known
-                        + #result.orphan.known + #result.missing_rus.known
-            expect(known).toBeGreaterThan(0)
+        it("reports a hardcoded sentence", function()
+            local r = labels.analyse(BROKEN, {}, {})
+            expect(r.literal).toEqual({ "soulslike/nowhere/hardcoded" })
+        end)
+
+        it("reports a string with no node", function()
+            local r = labels.analyse(BROKEN, { ui_mcm_soulslike_gone = true }, {})
+            expect(r.orphan).toEqual({ "ui_mcm_soulslike_gone" })
+        end)
+
+        it("reports a string in eng with no rus", function()
+            local r = labels.analyse(BROKEN, { st_thing = true }, {})
+            expect(r.parity.only_eng).toEqual({ "st_thing" })
+        end)
+
+        it("reports a string in rus with no eng", function()
+            local r = labels.analyse(BROKEN, {}, { st_thing = true })
+            expect(r.parity.only_rus).toEqual({ "st_thing" })
+        end)
+
+        it("reports a repeated string id", function()
+            local r = labels.analyse(BROKEN, {}, {},
+                { eng = { { id = "st_dup", file = "a.xml", count = 2 } } })
+            expect(#r.duplicates).toBe(1)
         end)
     end)
 

--- a/tests/unit/mcm_localization.spec.lua
+++ b/tests/unit/mcm_localization.spec.lua
@@ -92,6 +92,33 @@ describe("MCM localisation", function()
         it("has no newly untranslated labels", function()
             expect(result.missing_rus.new).toEqual({})
         end)
+
+        -- The check above only sees ids the MCM tree asks for -- 112 of 218
+        -- strings. Every message, item name and main-menu string was outside
+        -- its reach, so a translation gap in soulslike_messages.xml was
+        -- invisible to the whole suite while `locals.bat` printed it and no
+        -- assertion read it. Compare the tables outright instead.
+        it("has no newly untranslated strings anywhere", function()
+            expect(result.parity.only_eng.new).toEqual({})
+        end)
+
+        -- Not baselined, unlike the direction above: this is not outstanding
+        -- translation work but a rename applied to one table only, so the rus
+        -- entry is dead and its replacement is untranslated under a new id.
+        it("has no Russian string without an English one", function()
+            expect(result.parity.only_rus).toEqual({})
+        end)
+    end)
+
+    describe("the string tables themselves", function()
+        -- The engine keeps one <text> per id and drops the rest, so a
+        -- copy-pasted block that was never renamed quietly replaces the string
+        -- it was meant to become. Every other check here reads a set, where
+        -- the repeat has already collapsed and the id still resolves -- so
+        -- this is the only thing that can see it.
+        it("declares each string id once", function()
+            expect(result.duplicates).toEqual({})
+        end)
     end)
 
     describe("the baselines", function()

--- a/tests/unit/mcm_localization.spec.lua
+++ b/tests/unit/mcm_localization.spec.lua
@@ -1,142 +1,38 @@
 -- MCM labels against the localisation tables, in both directions.
 --
--- MCM resolves an option's on-screen label like this (ui_mcm.script):
---
---   explicit:  node.text
---   derived:   "ui_mcm_" .. <full path with "/" replaced by "_">
---
--- so a node declared as
+-- MCM derives an option's on-screen label from its path when the node has no
+-- explicit `text`: "ui_mcm_" plus the path with "/" replaced by "_". So
 --
 --   { id = "allow_weapon_loss", type = "check", val = 1, def = true }
 --
--- inside group `items` under root `soulslike` needs the string id
--- `ui_mcm_soulslike_items_allow_weapon_loss`. Nothing checks that at load time:
--- game.translate_string returns the raw id on a miss, so a broken entry shows
--- up in the menu as `ui_mcm_soulslike_items_allow_weapon_loss` and nowhere
--- else. Renaming an option id silently breaks its label.
+-- in group `items` under root `soulslike` needs the string id
+-- `ui_mcm_soulslike_items_allow_weapon_loss`. Nothing validates that at load
+-- time: game.translate_string returns the raw id on a miss, so a broken entry
+-- shows in the menu as the literal string id and nowhere else. Renaming an
+-- option id silently breaks its label.
 --
--- MCM also looks up an optional tooltip at "<label key>_desc". Absent is fine
--- -- it just means no tooltip -- so those are only checked in the orphan
--- direction, where a stray `_desc` means the option it described is gone.
+-- Checking both directions is what makes a rename obvious -- the new id has no
+-- translation AND the old translation is orphaned, so one mistake fails two
+-- assertions that point at each other.
 --
--- BASELINE, not a wishlist. The tables below record what is broken TODAY so
--- the suite stays green and a NEW break fails immediately. Shrinking a baseline
--- table is the fix; growing one should be a deliberate decision.
+-- The derivation, the analysis and the baselines all live in
+-- harness/mcm_labels.lua, shared with locals.lua so there is one copy. Run
+-- `locals.bat` for the same findings as a readable report.
 
 local H = require("harness.init")
+local labels = require("harness.mcm_labels")
 
 local MOD_SCRIPTS = { "soulslike_classes", "soulslike", "soulslike_mcm" }
 
-local ROOT = "soulslike"
-
--- Nodes that render rather than store. They still carry a label, so they are
--- checked the same way; only `line` has nothing to show.
-local NO_LABEL = { line = true, image = true }
-
-local eng, rus, tree
+local result, tree, eng, rus
 
 local function boot()
     H.boot{ load = MOD_SCRIPTS }
     H.fakes.set_random_min()
-    tree = soulslike_mcm.on_mcm_load()
     eng = H.loader.load_string_table("eng")
     rus = H.loader.load_string_table("rus")
+    result, tree = labels.inspect()
 end
-
---- Every labelled node, with the string id MCM will actually look up.
---- { path, key, explicit, group, id }
-local function labels()
-    local out = {}
-
-    local function walk(node, prefix)
-        for _, child in ipairs(node.gr or {}) do
-            local path = prefix .. "/" .. tostring(child.id)
-            if type(child.gr) == "table" then
-                walk(child, path)
-            elseif not NO_LABEL[child.type] then
-                out[#out + 1] = {
-                    path     = path,
-                    key      = child.text or ("ui_mcm_" .. path:gsub("/", "_")),
-                    explicit = child.text ~= nil,
-                    group    = prefix:match("([^/]+)$"),
-                    id       = child.id,
-                    type     = child.type,
-                }
-            end
-        end
-    end
-
-    walk(tree, ROOT)
-    return out
-end
-
---- A `text` that is not a string id at all, but a literal English sentence.
---- It renders, because translate_string passes unknown input through, but it
---- can never be localised.
-local function is_literal(key)
-    return not key:match("^ui_") and not key:match("^st_")
-end
-
-local function sorted(set)
-    local out = {}
-    for v in pairs(set) do out[#out + 1] = v end
-    table.sort(out)
-    return out
-end
-
--- ---------------------------------------------------------------- baselines
-
--- Nodes whose label key is not in the English tables. These render as the raw
--- id in the menu right now.
-local MISSING_ENG = {
-    ["ui_mcm_soulslike_ignored_items_other"] = true,
-    ["ui_mcm_soulslike_debug_debug_squad_spawns"] = true,
-    ["ui_mcm_soulslike_debug_debug_remove_default_scenario"] = true,
-    ["ui_mcm_soulslike_debug_debug_always_spawn_ambush"] = true,
-}
-
--- Nodes carrying a hardcoded English sentence instead of a string id.
--- Both of these already HAVE translations in the tables
--- (ui_mcm_soulslike_hardcore_lose_all_items_on_death and its _desc), which is
--- why they show up as orphans below -- deleting the literal would wire them up.
-local LITERAL_TEXT = {
-    ["soulslike/hardcore/lose_all_items_on_death"] = true,
-    ["soulslike/hardcore/lose_all_items_on_death_desc"] = true,
-}
-
--- Translations with no node to attach to. Everything here belongs to an option
--- that is commented out in the tree, so the string is dead until that option
--- comes back.
-local ORPHAN_ENG = {
-    ["ui_mcm_soulslike_debug_debug_hidden_stashes"] = true,
-    ["ui_mcm_soulslike_debug_debug_the_hidden_stash_scenario"] = true,
-    ["ui_mcm_soulslike_debug_debug_the_rf_scenario"] = true,
-    ["ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight"] = true,
-    ["ui_mcm_soulslike_scenarios_rf_detector_scenario_weight"] = true,
-    ["ui_mcm_soulslike_scenarios_rf_detector_scenario_weight_desc"] = true,
-    -- Orphaned only because the node hardcodes the English literal above.
-    ["ui_mcm_soulslike_hardcore_lose_all_items_on_death"] = true,
-    ["ui_mcm_soulslike_hardcore_lose_all_items_on_death_desc"] = true,
-}
-
--- Labels present in English but not Russian: a Russian player sees the raw id.
-local MISSING_RUS = {
-    ["ui_mcm_soulslike_ignored_items_device_pda_0"] = true,
-    ["ui_mcm_soulslike_ignored_items_device_pda_4"] = true,
-    ["ui_mcm_soulslike_ignored_items_device_pda_getac"] = true,
-    ["ui_mcm_soulslike_ignored_items_device_pda_kulon"] = true,
-    ["ui_mcm_soulslike_ignored_items_device_pda_milspec"] = true,
-    ["ui_mcm_soulslike_items_artifact_keep_chance"] = true,
-    ["ui_mcm_soulslike_items_headgear_keep_chance"] = true,
-    ["ui_mcm_soulslike_items_outfit_keep_chance"] = true,
-    ["ui_mcm_soulslike_items_weapon_keep_chance"] = true,
-    -- The `desc` nodes carrying these ids as their own explicit text.
-    ["ui_mcm_soulslike_ignored_items_other_desc"] = true,
-    ["ui_mcm_soulslike_items_artifact_keep_chance_desc"] = true,
-    ["ui_mcm_soulslike_items_headgear_keep_chance_desc"] = true,
-    ["ui_mcm_soulslike_items_outfit_keep_chance_desc"] = true,
-    ["ui_mcm_soulslike_items_weapon_keep_chance_desc"] = true,
-}
 
 describe("MCM localisation", function()
 
@@ -151,197 +47,83 @@ describe("MCM localisation", function()
             expect(rus["ui_mcm_menu_soulslike"]).toBe(true)
         end)
 
-        -- The root has no `text`, so MCM derives ui_mcm_menu_<root_id> for the
-        -- entry in the mod list.
-        it("has a name for the mod's own menu entry", function()
-            expect(eng["ui_mcm_menu_" .. ROOT]).toBe(true)
+        -- The root carries no `text`, so MCM derives ui_mcm_menu_<root id> for
+        -- the mod's entry in the settings list.
+        it("names the mod's own menu entry", function()
+            expect(eng["ui_mcm_menu_" .. labels.ROOT]).toBe(true)
         end)
 
-        it("finds every group's label", function()
-            local missing = {}
-            for _, group in ipairs(tree.gr) do
-                local key = group.text or ("ui_mcm_menu_" .. tostring(group.id))
-                if not eng[key] then missing[#missing + 1] = group.id .. " -> " .. key end
-            end
-            expect(missing).toEqual({})
+        it("finds every option in the tree", function()
+            expect(#labels.labels(tree)).toBeGreaterThan(0)
         end)
     end)
 
     describe("every node's label exists in English", function()
         -- The direction that matters most: this is what a player sees.
-        it("has no unlisted missing keys", function()
-            local broken = {}
-            for _, label in ipairs(labels()) do
-                if not is_literal(label.key)
-                   and not eng[label.key]
-                   and not MISSING_ENG[label.key] then
-                    broken[#broken + 1] = label.path .. "  ->  " .. label.key
-                end
-            end
-            table.sort(broken)
-            expect(broken).toEqual({})
+        it("has no new missing keys", function()
+            expect(result.missing_eng.new).toEqual({})
         end)
 
-        -- Guards the baseline itself. If one of these gains a translation the
-        -- entry should come off the list, so the next regression is caught.
-        it("keeps the known-missing list accurate", function()
-            local now_fixed = {}
-            for key in pairs(MISSING_ENG) do
-                if eng[key] then now_fixed[#now_fixed + 1] = key end
-            end
-            table.sort(now_fixed)
-            expect(now_fixed).toEqual({})
-        end)
-
-        it("keeps the known-missing list reachable", function()
-            -- A baseline entry naming a node that no longer exists is stale.
-            local live = {}
-            for _, label in ipairs(labels()) do live[label.key] = true end
-
-            local stale = {}
-            for key in pairs(MISSING_ENG) do
-                if not live[key] then stale[#stale + 1] = key end
-            end
-            table.sort(stale)
-            expect(stale).toEqual({})
+        it("translates every group heading", function()
+            expect(result.groups).toEqual({})
         end)
     end)
 
     describe("every node's label is a string id", function()
-        -- A literal renders, because translate_string passes unknown input
+        -- A literal renders, since translate_string passes unknown input
         -- through unchanged, but it can never be translated.
-        it("has no unlisted hardcoded English", function()
-            local literals = {}
-            for _, label in ipairs(labels()) do
-                if label.explicit and is_literal(label.key)
-                   and not LITERAL_TEXT[label.path] then
-                    literals[#literals + 1] = label.path
-                end
-            end
-            table.sort(literals)
-            expect(literals).toEqual({})
-        end)
-
-        it("keeps the known-literal list accurate", function()
-            local live = {}
-            for _, label in ipairs(labels()) do
-                if label.explicit and is_literal(label.key) then live[label.path] = true end
-            end
-
-            local stale = {}
-            for path in pairs(LITERAL_TEXT) do
-                if not live[path] then stale[#stale + 1] = path end
-            end
-            table.sort(stale)
-            expect(stale).toEqual({})
+        it("has no new hardcoded English", function()
+            expect(result.literal.new).toEqual({})
         end)
     end)
 
     describe("every translation has a node", function()
-        -- The other direction. An orphan is usually a rename: the option moved
-        -- and its old string stayed behind, so the new one shows a raw id
-        -- while the old translation sits unused.
-        --
-        -- `<key>_desc` is MCM's optional tooltip for `<key>`, not a node of its
-        -- own, so it counts as used when its owner exists.
-        local function used_keys()
-            local used = {}
-            used["ui_mcm_menu_" .. ROOT] = true
-            for _, group in ipairs(tree.gr) do
-                used[group.text or ("ui_mcm_menu_" .. tostring(group.id))] = true
-            end
-            for _, label in ipairs(labels()) do
-                used[label.key] = true
-                used[label.key .. "_desc"] = true
-            end
-            return used
-        end
-
-        it("has no unlisted orphans", function()
-            local used = used_keys()
-            local orphans = {}
-
-            for id in pairs(eng) do
-                if id:match("^ui_mcm_" .. ROOT .. "_")
-                   and not used[id] and not ORPHAN_ENG[id] then
-                    orphans[#orphans + 1] = id
-                end
-            end
-            table.sort(orphans)
-            expect(orphans).toEqual({})
-        end)
-
-        it("keeps the known-orphan list accurate", function()
-            local used = used_keys()
-            local reattached = {}
-            for id in pairs(ORPHAN_ENG) do
-                if used[id] then reattached[#reattached + 1] = id end
-            end
-            table.sort(reattached)
-            expect(reattached).toEqual({})
-        end)
-
-        it("keeps the known-orphan list present in the tables", function()
-            local gone = {}
-            for id in pairs(ORPHAN_ENG) do
-                if not eng[id] then gone[#gone + 1] = id end
-            end
-            table.sort(gone)
-            expect(gone).toEqual({})
+        -- An orphan is usually a rename: the option moved and its old string
+        -- stayed behind, so the new one shows a raw id while the old
+        -- translation sits unused.
+        it("has no new orphans", function()
+            expect(result.orphan.new).toEqual({})
         end)
     end)
 
     describe("Russian parity", function()
         -- Lower severity than a missing English key -- an English speaker never
         -- sees it -- but a Russian player gets the raw id just the same.
-        it("has no unlisted untranslated labels", function()
-            local untranslated = {}
-            for _, label in ipairs(labels()) do
-                if not is_literal(label.key)
-                   and eng[label.key] and not rus[label.key]
-                   and not MISSING_RUS[label.key] then
-                    untranslated[#untranslated + 1] = label.path
-                end
-            end
-            table.sort(untranslated)
-            expect(untranslated).toEqual({})
+        it("has no newly untranslated labels", function()
+            expect(result.missing_rus.new).toEqual({})
+        end)
+    end)
+
+    describe("the baselines", function()
+        -- A baseline entry that no longer describes reality is worse than a
+        -- plain break: it masks the next regression in that slot. Deleting a
+        -- stale entry is the fix, never updating it to match.
+        it("all still describe reality", function()
+            expect(result.stale).toEqual({})
         end)
 
-        it("keeps the known-untranslated list accurate", function()
-            local now_translated = {}
-            for key in pairs(MISSING_RUS) do
-                if rus[key] then now_translated[#now_translated + 1] = key end
-            end
-            table.sort(now_translated)
-            expect(now_translated).toEqual({})
-        end)
-
-        it("translates every group heading", function()
-            local missing = {}
-            for _, group in ipairs(tree.gr) do
-                local key = group.text or ("ui_mcm_menu_" .. tostring(group.id))
-                if eng[key] and not rus[key] then missing[#missing + 1] = group.id end
-            end
-            expect(missing).toEqual({})
+        it("account for everything currently broken", function()
+            local known = #result.missing_eng.known + #result.literal.known
+                        + #result.orphan.known + #result.missing_rus.known
+            expect(known).toBeGreaterThan(0)
         end)
     end)
 
     describe("the derivation rule itself", function()
         -- Pins the concatenation, since every assertion above depends on it.
-        it("joins root, group and option with underscores", function()
-            local found
-            for _, label in ipairs(labels()) do
-                if label.id == "allow_weapon_loss" then found = label end
+        local function label_for(id)
+            for _, label in ipairs(labels.labels(tree)) do
+                if label.id == id then return label end
             end
-            expect(found).toBeDefined()
-            expect(found.key).toBe("ui_mcm_soulslike_items_allow_weapon_loss")
+        end
+
+        it("joins root, group and option with underscores", function()
+            expect(label_for("allow_weapon_loss").key)
+                .toBe("ui_mcm_soulslike_items_allow_weapon_loss")
         end)
 
         it("prefers an explicit text over the derived key", function()
-            local found
-            for _, label in ipairs(labels()) do
-                if label.id == "allow_rank_loss" then found = label end
-            end
+            local found = label_for("allow_rank_loss")
             expect(found.explicit).toBe(true)
             expect(found.key).toBe("ui_mcm_soulslike_character_allow_rank_loss")
         end)
@@ -349,9 +131,21 @@ describe("MCM localisation", function()
         -- Renaming an option id moves its label key, which is exactly how these
         -- break in practice.
         it("ties the key to the option id", function()
-            local by_key = {}
-            for _, label in ipairs(labels()) do by_key[label.key] = label.id end
-            expect(by_key["ui_mcm_soulslike_ambush_allow_boar_ambush"]).toBe("allow_boar_ambush")
+            expect(label_for("allow_boar_ambush").key)
+                .toBe("ui_mcm_soulslike_ambush_allow_boar_ambush")
+        end)
+
+        -- A tooltip is looked up at "<label key>_desc" and is optional, so it
+        -- must not be reported as an orphan when its owner exists.
+        it("treats a _desc as belonging to its option", function()
+            local used = labels.used_keys(tree)
+            expect(used["ui_mcm_soulslike_items_allow_weapon_loss_desc"]).toBe(true)
+        end)
+
+        it("counts a rendering-only node as having no label", function()
+            for _, label in ipairs(labels.labels(tree)) do
+                expect(label.type).never.toBe("line")
+            end
         end)
     end)
 end)

--- a/tests/unit/mcm_options.spec.lua
+++ b/tests/unit/mcm_options.spec.lua
@@ -1,0 +1,478 @@
+-- Structural walk of on_mcm_load's option tree (soulslike_mcm.script:8-937).
+--
+-- The tree is a 930-line nested literal that MCM reads at runtime. A malformed
+-- node -- a track with no `def`, a group missing `gr`, a typo'd id -- breaks
+-- the settings page in-game with no compile-time signal at all, and the getters
+-- silently fall back to their defaults so the mod keeps "working" while nothing
+-- the player configures takes effect.
+--
+-- The highest-value check here is the last one: every option's "<group>/<id>"
+-- path is cross-referenced against the paths the getters actually read. That
+-- catches an orphaned option or a mistyped path, which is the failure mode a
+-- literal this size grows over time.
+
+local H = require("harness.init")
+
+local MOD_SCRIPTS = { "soulslike_classes", "soulslike", "soulslike_mcm" }
+
+-- Nodes that render something rather than storing a value. They take no `val`
+-- and never appear in a storage path.
+local PRESENTATION = {
+    slide = true, desc = true, line = true, image = true, title = true,
+}
+
+-- MCM's `val` is a REQUIRED type code for the stored value, not a display
+-- hint: 0 = string, 1 = boolean, 2 = float. A mismatch does not fail loudly --
+-- the option reads and writes through the wrong type, so a track declared
+-- val = 1 silently stores a boolean and the slider never persists.
+local VAL_STRING, VAL_BOOL, VAL_FLOAT = 0, 1, 2
+
+local REQUIRED_VAL = {
+    check    = VAL_BOOL,
+    track    = VAL_FLOAT,
+    key_bind = VAL_FLOAT,
+}
+
+local tree
+
+local function boot()
+    H.boot{ load = MOD_SCRIPTS }
+    H.fakes.set_random_min()
+    tree = soulslike_mcm.on_mcm_load()
+end
+
+--- Every group directly under the root.
+local function groups()
+    return tree.gr or {}
+end
+
+--- A node is a group if it carries its own `gr` list.
+local function is_group(node)
+    return type(node.gr) == "table"
+end
+
+--- Walk the whole tree, yielding { path, node, group } for every leaf option.
+--- Recursive because MCM allows groups to nest arbitrarily deep and the storage
+--- path traces every ancestor id -- a flat walk would mis-key anything nested.
+local function options()
+    local out = {}
+
+    local function walk(node, prefix, group)
+        for _, child in ipairs(node.gr or {}) do
+            if is_group(child) then
+                walk(child, prefix .. "/" .. tostring(child.id), child)
+            else
+                out[#out + 1] = {
+                    node = child,
+                    group = group,
+                    path = prefix .. "/" .. tostring(child.id),
+                }
+            end
+        end
+    end
+
+    -- The root id is the storage prefix the getters strip, so paths here start
+    -- below it: "character/rank_loss_percent", matching get_config's key.
+    for _, group in ipairs(groups()) do
+        walk(group, tostring(group.id), group)
+    end
+
+    return out
+end
+
+--- "<group>/<id>" for every value-carrying option in the tree.
+local function option_paths()
+    local out = {}
+    for _, entry in ipairs(options()) do
+        if not PRESENTATION[entry.node.type] then
+            out[entry.path] = entry.node.type
+        end
+    end
+    return out
+end
+
+--- The keys the getters actually read, discovered by driving each getter with
+--- a recording ui_mcm rather than by restating them here -- a hand-written list
+--- would drift from the module it is meant to check.
+local function getter_paths()
+    local seen = {}
+    local real_get = _G.ui_mcm.get
+    _G.ui_mcm.get = function(path)
+        seen[path:gsub("^soulslike/", "")] = true
+        return real_get(path)
+    end
+
+    -- Debug getters short-circuit on is_debug_enabled, so their inner
+    -- get_config never runs unless debug is on.
+    H.fakes.set_mcm("debug/is_enabled", true)
+
+    for name, fn in pairs(soulslike_mcm) do
+        if type(fn) == "function" and name ~= "on_mcm_load" then
+            pcall(fn, "ignore_bolt")
+        end
+    end
+
+    _G.ui_mcm.get = real_get
+    return seen
+end
+
+describe("soulslike_mcm.on_mcm_load()", function()
+
+    beforeEach(boot)
+
+    describe("the root", function()
+        it("is identified as soulslike", function()
+            expect(tree.id).toBe("soulslike")
+        end)
+
+        it("carries groups", function()
+            expect(#groups()).toBeGreaterThan(0)
+        end)
+    end)
+
+    describe("every group", function()
+        it("has an id", function()
+            local bad = {}
+            for i, group in ipairs(groups()) do
+                if type(group.id) ~= "string" or group.id == "" then
+                    bad[#bad + 1] = i
+                end
+            end
+            expect(bad).toEqual({})
+        end)
+
+        it("has a display text", function()
+            local bad = {}
+            for _, group in ipairs(groups()) do
+                if type(group.text) ~= "string" then bad[#bad + 1] = group.id end
+            end
+            expect(bad).toEqual({})
+        end)
+
+        it("has its own option list", function()
+            local bad = {}
+            for _, group in ipairs(groups()) do
+                if type(group.gr) ~= "table" then bad[#bad + 1] = group.id end
+            end
+            expect(bad).toEqual({})
+        end)
+
+        it("has a unique id", function()
+            local seen, dupes = {}, {}
+            for _, group in ipairs(groups()) do
+                if seen[group.id] then dupes[#dupes + 1] = group.id end
+                seen[group.id] = true
+            end
+            expect(dupes).toEqual({})
+        end)
+    end)
+
+    describe("every option", function()
+        it("has an id", function()
+            local bad = {}
+            for _, entry in ipairs(options()) do
+                if type(entry.node.id) ~= "string" or entry.node.id == "" then
+                    bad[#bad + 1] = entry.group.id
+                end
+            end
+            expect(bad).toEqual({})
+        end)
+
+        it("has a type", function()
+            local bad = {}
+            for _, entry in ipairs(options()) do
+                if type(entry.node.type) ~= "string" then
+                    bad[#bad + 1] = entry.path
+                end
+            end
+            expect(bad).toEqual({})
+        end)
+
+        -- `val` is the stored-value type code and it is required on every
+        -- interactive option. Without it the read/write path has no type to
+        -- work through and the setting does not persist.
+        it("declares a val type code", function()
+            local bad = {}
+            for _, entry in ipairs(options()) do
+                if not PRESENTATION[entry.node.type]
+                   and type(entry.node.val) ~= "number" then
+                    bad[#bad + 1] = entry.path
+                end
+            end
+            expect(bad).toEqual({})
+        end)
+
+        -- FIXES: D13. The free-text ignore list declared val = '' -- reading
+        -- `val` as an initial value rather than a type code. Not a recognised
+        -- code, so the box could not round-trip through axr_options.ltx and
+        -- get_ignored_other() always saw its '' default: whatever the player
+        -- typed there protected nothing.
+        it("declares a val the framework recognises", function()
+            local bad = {}
+            for _, entry in ipairs(options()) do
+                local val = entry.node.val
+                if not PRESENTATION[entry.node.type]
+                   and val ~= VAL_STRING and val ~= VAL_BOOL and val ~= VAL_FLOAT then
+                    bad[#bad + 1] = entry.path .. " (val " .. tostring(val) .. ")"
+                end
+            end
+            expect(bad).toEqual({})
+        end)
+
+        -- The high-value one. A mismatch is silent: a track with val = 1
+        -- stores a boolean, so the slider reads back as true/false and the
+        -- configured number never reaches the getter.
+        it("declares a val matching its type", function()
+            local bad = {}
+            for _, entry in ipairs(options()) do
+                local want = REQUIRED_VAL[entry.node.type]
+                if want and entry.node.val ~= want then
+                    bad[#bad + 1] = string.format("%s (%s wants val %d, got %s)",
+                        entry.path, entry.node.type, want, tostring(entry.node.val))
+                end
+            end
+            expect(bad).toEqual({})
+        end)
+
+        it("declares a default, since none of them use cmd", function()
+            local bad = {}
+            for _, entry in ipairs(options()) do
+                if not PRESENTATION[entry.node.type]
+                   and entry.node.def == nil and entry.node.cmd == nil then
+                    bad[#bad + 1] = entry.path
+                end
+            end
+            expect(bad).toEqual({})
+        end)
+
+        it("uses only types this tree is built from", function()
+            local KNOWN = {
+                check = true, track = true, input = true,
+                slide = true, desc = true,
+            }
+            local unexpected = {}
+            for _, entry in ipairs(options()) do
+                if not KNOWN[entry.node.type] then
+                    unexpected[#unexpected + 1] = entry.path ..
+                        " (" .. tostring(entry.node.type) .. ")"
+                end
+            end
+            -- Not a prohibition on new types -- a new one just needs its own
+            -- required-field assertions adding below before it lands.
+            expect(unexpected).toEqual({})
+        end)
+
+        -- Paths are the storage keys, so a collision means two controls writing
+        -- over each other in axr_options.ltx.
+        it("has a unique storage path", function()
+            local seen, dupes = {}, {}
+            for _, entry in ipairs(options()) do
+                if seen[entry.path] then dupes[#dupes + 1] = entry.path end
+                seen[entry.path] = true
+            end
+            expect(dupes).toEqual({})
+        end)
+    end)
+
+    describe("every slide and image option", function()
+        it("declares the texture to link", function()
+            local bad = {}
+            for _, entry in ipairs(options()) do
+                local t = entry.node.type
+                if (t == "slide" or t == "image") and type(entry.node.link) ~= "string" then
+                    bad[#bad + 1] = entry.path
+                end
+            end
+            expect(bad).toEqual({})
+        end)
+    end)
+
+    describe("every desc and title option", function()
+        it("declares the string id to display", function()
+            local bad = {}
+            for _, entry in ipairs(options()) do
+                local t = entry.node.type
+                if (t == "desc" or t == "title") and type(entry.node.text) ~= "string" then
+                    bad[#bad + 1] = entry.path
+                end
+            end
+            expect(bad).toEqual({})
+        end)
+    end)
+
+    describe("every track option", function()
+        local function tracks()
+            local out = {}
+            for _, entry in ipairs(options()) do
+                if entry.node.type == "track" then
+                    out[#out + 1] = { path = entry.path, node = entry.node }
+                end
+            end
+            return out
+        end
+
+        it("declares min, max, step and def", function()
+            local bad = {}
+            for _, t in ipairs(tracks()) do
+                for _, key in ipairs{ "min", "max", "step", "def" } do
+                    if type(t.node[key]) ~= "number" then
+                        bad[#bad + 1] = t.path .. "." .. key
+                    end
+                end
+            end
+            expect(bad).toEqual({})
+        end)
+
+        -- A default outside its own slider cannot be restored by "reset to
+        -- default", and the slider snaps somewhere else the moment it is moved.
+        it("keeps its default inside its range", function()
+            local bad = {}
+            for _, t in ipairs(tracks()) do
+                local n = t.node
+                if n.def < n.min or n.def > n.max then
+                    bad[#bad + 1] = string.format("%s (def %s not in [%s, %s])",
+                        t.path, tostring(n.def), tostring(n.min), tostring(n.max))
+                end
+            end
+            expect(bad).toEqual({})
+        end)
+
+        it("declares a range with room in it", function()
+            local bad = {}
+            for _, t in ipairs(tracks()) do
+                if t.node.min >= t.node.max then bad[#bad + 1] = t.path end
+            end
+            expect(bad).toEqual({})
+        end)
+
+        it("declares a positive step", function()
+            local bad = {}
+            for _, t in ipairs(tracks()) do
+                if t.node.step <= 0 then bad[#bad + 1] = t.path end
+            end
+            expect(bad).toEqual({})
+        end)
+    end)
+
+    describe("every check option", function()
+        it("declares a boolean default", function()
+            local bad = {}
+            for _, entry in ipairs(options()) do
+                if entry.node.type == "check" and type(entry.node.def) ~= "boolean" then
+                    bad[#bad + 1] = entry.path
+                end
+            end
+            expect(bad).toEqual({})
+        end)
+    end)
+
+    describe("every list and radio option", function()
+        -- radio_h and radio_v are the framework's names; a bare "radio" would
+        -- never render.
+        it("declares its content", function()
+            local bad = {}
+            for _, entry in ipairs(options()) do
+                local t = entry.node.type
+                if (t == "list" or t == "radio_h" or t == "radio_v")
+                   and type(entry.node.content) ~= "table" then
+                    bad[#bad + 1] = entry.path
+                end
+            end
+            expect(bad).toEqual({})
+        end)
+
+        it("does not use the non-existent bare 'radio' type", function()
+            local bad = {}
+            for _, entry in ipairs(options()) do
+                if entry.node.type == "radio" then bad[#bad + 1] = entry.path end
+            end
+            expect(bad).toEqual({})
+        end)
+    end)
+
+    describe("the tree against the getters", function()
+        -- The cross-check. An option present in the tree but read by nobody is
+        -- a control that does nothing; a key read by a getter but absent from
+        -- the tree is a setting the player cannot reach.
+
+        -- DEAD CODE. Two getters read keys that the tree does not declare, so
+        -- neither can ever be anything but its default. Both belong to the
+        -- disabled scenario cluster and are listed rather than ignored, so
+        -- re-enabling that cluster surfaces them as part of the work.
+        --
+        --   debug/debug_hidden_stashes
+        --     Tree entry commented out at soulslike_mcm.script:872. Its only
+        --     consumer is RFDetectorSoulslikeScenarioLogic
+        --     :ApplyTransferItemsPostConditions (soulslike_scenarios.script
+        --     :1473), and that scenario is unreachable through create_new --
+        --     its weight and debug flag both hard-return zero/false.
+        --
+        --   scenarios/nearby_dead_stalker_scenario_weight
+        --     Getter defined at soulslike_mcm.script:973 and called by nothing
+        --     at all: a scenario that was never built.
+        local KNOWN_UNREACHABLE = {
+            ["debug/debug_hidden_stashes"] = true,
+            ["scenarios/nearby_dead_stalker_scenario_weight"] = true,
+        }
+
+        it("declares an option for every key the getters read", function()
+            local declared = option_paths()
+            local missing = {}
+
+            for path in pairs(getter_paths()) do
+                -- The free-text ignore list and the per-item ignore toggles are
+                -- built dynamically from the item table, not declared inline.
+                local is_ignored_entry = path:match("^ignored_items/")
+                if not declared[path] and not is_ignored_entry
+                   and not KNOWN_UNREACHABLE[path] then
+                    missing[#missing + 1] = path
+                end
+            end
+
+            table.sort(missing)
+            expect(missing).toEqual({})
+        end)
+
+        it("keeps the known-unreachable options unreachable", function()
+            -- If one of these gains a tree entry, it is no longer an exception
+            -- and should come off the list above.
+            local declared = option_paths()
+            local now_reachable = {}
+            for path in pairs(KNOWN_UNREACHABLE) do
+                if declared[path] then now_reachable[#now_reachable + 1] = path end
+            end
+            expect(now_reachable).toEqual({})
+        end)
+
+        it("reads every option it declares", function()
+            local read = getter_paths()
+            local orphans = {}
+
+            for path in pairs(option_paths()) do
+                if not read[path] and not path:match("^ignored_items/") then
+                    orphans[#orphans + 1] = path
+                end
+            end
+
+            table.sort(orphans)
+            expect(orphans).toEqual({})
+        end)
+    end)
+
+    describe("re-entrancy", function()
+        -- MCM calls this again whenever the settings page is reopened.
+        it("returns an equivalent tree on a second call", function()
+            local first = soulslike_mcm.on_mcm_load()
+            local second = soulslike_mcm.on_mcm_load()
+            expect(#second.gr).toBe(#first.gr)
+        end)
+
+        it("does not accumulate groups", function()
+            local before = #tree.gr
+            soulslike_mcm.on_mcm_load()
+            expect(#soulslike_mcm.on_mcm_load().gr).toBe(before)
+        end)
+    end)
+end)
+
+return true

--- a/tests/unit/message_factory.spec.lua
+++ b/tests/unit/message_factory.spec.lua
@@ -1,0 +1,263 @@
+-- soulslike_message_factory.create (soulslike_message_factory.script:133).
+--
+-- Builds the rescuer's wake-up note by concatenating optional clauses. Fully
+-- exported and near-pure: with game.translate_string as identity and
+-- math.random pinned, the output is exactly the sequence of string ids, so
+-- clause presence and ordering are directly assertable.
+
+local H = require("harness.init")
+local fakes = H.fakes
+
+describe("soulslike_message_factory.create()", function()
+
+    beforeEach(function()
+        H.boot{ load = { "soulslike_classes", "soulslike",
+                         "soulslike_message_factory" } }
+        fakes.set_random_const(1)   -- always the first variant of each set
+    end)
+
+    local RESCUER = true            -- only truthiness is checked
+
+    local function create(rescuer, params)
+        return soulslike_message_factory.create(rescuer, params or {})
+    end
+
+    describe("given a rescuer", function()
+
+        describe("and no optional flags", function()
+            it("opens with the initial message", function()
+                expect(create(RESCUER, {})).toContain("st_soulslike_rescuer_initial_1")
+            end)
+
+            it("closes with the stay-safe message", function()
+                expect(create(RESCUER, {})).toContain("st_soulslike_rescuer_stay_safe_1")
+            end)
+        end)
+
+        describe("and every optional flag set", function()
+            local function full()
+                return create(RESCUER, {
+                    gave_food_or_water   = true,
+                    enemy                = { name = "V", community = "bandit" },
+                    has_pda_marker       = true,
+                    has_stash_pda_marker = true,
+                    radio_freq           = "121.5",
+                    items_were_lost      = true,
+                    looter_type          = soulslike.entity_type.Stalker,
+                })
+            end
+
+            it("emits the clauses in the documented order", function()
+                local expected = {
+                    "st_soulslike_rescuer_initial_1",
+                    "st_soulslike_rescuer_food_1",
+                    "st_soulslike_rescuer_enemy_looter_1",
+                    "st_soulslike_rescuer_pda_1",
+                    "st_soulslike_hidden_stash_1",
+                    "st_soulslike_rescuer_radio_freq_1",
+                    "st_soulslike_rescuer_used_items_1",
+                    "st_soulslike_rescuer_stay_safe_1",
+                }
+                local msg, pos = full(), 0
+                for _, frag in ipairs(expected) do
+                    local at = msg:find(frag, pos + 1, true)
+                    expect(at).toBeDefined()
+                    pos = at
+                end
+            end)
+
+            it("always terminates with stay-safe", function()
+                local msg = full()
+                local closer = "st_soulslike_rescuer_stay_safe_1"
+                expect(msg:sub(-#closer)).toBe(closer)
+            end)
+        end)
+
+        describe("and the death happened indoors", function()
+            it("uses the indoor opener", function()
+                local msg = create(RESCUER, { player_died_indoor = true,
+                                              level_name = "labx8" })
+                expect(msg).toContain("st_soulslike_rescuer_indoor_1")
+            end)
+
+            it("omits the standard opener", function()
+                local msg = create(RESCUER, { player_died_indoor = true,
+                                              level_name = "labx8" })
+                expect(msg).never.toContain("st_soulslike_rescuer_initial_1")
+            end)
+        end)
+
+        describe("and gave_food_or_water is set", function()
+            it("includes the food clause", function()
+                expect(create(RESCUER, { gave_food_or_water = true }))
+                    .toContain("st_soulslike_rescuer_food_1")
+            end)
+        end)
+
+        describe("and gave_food_or_water is unset", function()
+            it("omits the food clause", function()
+                expect(create(RESCUER, {})).never.toContain("st_soulslike_rescuer_food_1")
+            end)
+        end)
+
+        describe("and has_pda_marker is set", function()
+            it("includes the pda clause", function()
+                expect(create(RESCUER, { has_pda_marker = true }))
+                    .toContain("st_soulslike_rescuer_pda_1")
+            end)
+        end)
+
+        describe("and has_stash_pda_marker is set", function()
+            it("includes the hidden-stash clause", function()
+                expect(create(RESCUER, { has_stash_pda_marker = true }))
+                    .toContain("st_soulslike_hidden_stash_1")
+            end)
+        end)
+
+        describe("and radio_freq is set", function()
+            it("includes the radio clause", function()
+                expect(create(RESCUER, { radio_freq = "121.5" }))
+                    .toContain("st_soulslike_rescuer_radio_freq_1")
+            end)
+        end)
+
+        describe("and a plain looter took the items", function()
+            it("uses the enemy-looter clause", function()
+                expect(create(RESCUER, { enemy = { name = "Vasya", community = "bandit" } }))
+                    .toContain("st_soulslike_rescuer_enemy_looter_1")
+            end)
+        end)
+
+        describe("and the looter has tarkov_experience", function()
+            local params = { enemy = { name = "Vasya", community = "bandit",
+                                       tarkov_experience = true } }
+
+            it("uses the tarkov clause", function()
+                expect(create(RESCUER, params))
+                    .toContain("st_soulslike_rescuer_enemy_tarkov_looter_1")
+            end)
+
+            it("omits the plain enemy-looter clause", function()
+                expect(create(RESCUER, params))
+                    .never.toContain("st_soulslike_rescuer_enemy_looter_1")
+            end)
+        end)
+
+        describe("and items were lost to a monster", function()
+            local params = { items_were_lost = true,
+                             looter_type = 2 }   -- entity_type.Monster
+
+            it("uses the monster-looter clause", function()
+                expect(create(RESCUER, params))
+                    .toContain("st_soulslike_rescuer_monster_looter_1")
+            end)
+
+            it("omits the used-items clause", function()
+                expect(create(RESCUER, params))
+                    .never.toContain("st_soulslike_rescuer_used_items_1")
+            end)
+        end)
+
+        describe("and items were lost to a stalker", function()
+            it("uses the used-items clause", function()
+                expect(create(RESCUER, { items_were_lost = true,
+                                         looter_type = 1 }))   -- Stalker
+                    .toContain("st_soulslike_rescuer_used_items_1")
+            end)
+        end)
+
+        describe("and items were lost with no looter_type", function()
+            it("falls back to the used-items clause", function()
+                -- The branch tests `looter_type == Monster`, so nil takes the
+                -- else arm.
+                expect(create(RESCUER, { items_were_lost = true }))
+                    .toContain("st_soulslike_rescuer_used_items_1")
+            end)
+        end)
+
+        describe("clause joining", function()
+            it("separates clauses with a single space", function()
+                expect(create(RESCUER, { gave_food_or_water = true })).toContain(
+                    "st_soulslike_rescuer_initial_1 st_soulslike_rescuer_food_1")
+            end)
+        end)
+
+        describe("variant selection", function()
+            it("picks the variant math.random returns", function()
+                fakes.set_random_const(3)
+                local msg = create(RESCUER, {})
+                expect(msg).toContain("st_soulslike_rescuer_initial_3")
+                expect(msg).toContain("st_soulslike_rescuer_stay_safe_3")
+            end)
+
+            it("offers five variants per message set", function()
+                for i = 1, 5 do
+                    fakes.set_random_const(i)
+                    expect(create(RESCUER, {}))
+                        .toContain("st_soulslike_rescuer_initial_" .. i)
+                end
+            end)
+        end)
+    end)
+
+    describe("given no rescuer", function()
+
+        describe("and no optional flags", function()
+            it("returns just the generic opener", function()
+                expect(create(nil, {})).toBe("st_soulslike_rescuer_initial_generic")
+            end)
+        end)
+
+        describe("and gave_food_or_water is set", function()
+            it("includes the generic food clause", function()
+                expect(create(nil, { gave_food_or_water = true }))
+                    .toContain("st_soulslike_rescuer_food_generic")
+            end)
+
+            it("still has no stay-safe closer", function()
+                -- Deliberate asymmetry with the rescuer branch.
+                expect(create(nil, { gave_food_or_water = true }))
+                    .never.toContain("stay_safe")
+            end)
+        end)
+
+        describe("and any of the three pda flags is set", function()
+            it("includes the generic pda clause", function()
+                for _, flag in ipairs({ "has_pda_marker", "has_stash_pda_marker",
+                                        "has_multi_stash_pda_marker" }) do
+                    expect(create(nil, { [flag] = true }))
+                        .toContain("st_soulslike_rescuer_pda_generic")
+                end
+            end)
+        end)
+
+        describe("and all three pda flags are set", function()
+            it("emits the pda clause exactly once", function()
+                local msg = create(nil, {
+                    has_pda_marker = true, has_stash_pda_marker = true,
+                    has_multi_stash_pda_marker = true,
+                })
+                local _, count = msg:gsub("st_soulslike_rescuer_pda_generic", "")
+                expect(count).toBe(1)
+            end)
+        end)
+
+        describe("and radio_freq is set", function()
+            it("includes the generic radio clause", function()
+                expect(create(nil, { radio_freq = "121.5" }))
+                    .toContain("st_soulslike_rescuer_radio_generic")
+            end)
+        end)
+
+        describe("and looter or items_were_lost are set", function()
+            it("ignores them, since those clauses are rescuer-only", function()
+                expect(create(nil, {
+                    enemy = { name = "V", community = "bandit" },
+                    items_were_lost = true,
+                })).toBe("st_soulslike_rescuer_initial_generic")
+            end)
+        end)
+    end)
+end)
+
+return true

--- a/tests/unit/save_load.spec.lua
+++ b/tests/unit/save_load.spec.lua
@@ -1,0 +1,340 @@
+-- save_state / load_state (soulslike.script:777-795 and :760-775).
+--
+-- Both are file-locals registered as callbacks, reached here as upvalues of
+-- on_game_start, which closes over all thirteen handlers.
+--
+-- This pair carries the scenario across a ChangeLevel: the engine unloads and
+-- re-executes every script, so the live scenario object cannot survive -- only
+-- what save_state put into the save table does. The mod's own comment at :790
+-- calls the path fragile, and it is the only route by which a death in progress
+-- outlives the level transition it triggers.
+
+local H = require("harness.init")
+local B = H.builders
+
+local MOD_SCRIPTS = {
+    "soulslike_classes", "soulslike", "soulslike_mcm",
+    "soulslike_message_factory", "soulslike_scenarios",
+    "soulslike_scenario_logic_factory",
+}
+
+local save_state, load_state
+
+local function bind_handlers()
+    save_state = H.loader.upvalue(soulslike.on_game_start, "save_state")
+    load_state = H.loader.upvalue(soulslike.on_game_start, "load_state")
+end
+
+local function boot(opts)
+    opts = opts or {}
+    H.boot{
+        load = MOD_SCRIPTS,
+        soulslike_mode = opts.soulslike_mode ~= false,
+        state = opts.state,
+    }
+    H.fakes.set_random_min()
+    H.set_spawn{ level = "zaton" }
+    -- create_new consults these, and unstubbed they scan 65534 alife slots.
+    B.stub_finders{ friendly_stalker = B.make_stalker{} }
+    bind_handlers()
+    soulslike.on_game_start()
+end
+
+--- Drive a real death so soulslike.script ends up holding a scenario, rather
+--- than reaching into its file-locals to plant one. The handler takes
+--- (who, flags) and writes ret_value onto flags (soulslike.script:497, :516).
+local function die()
+    SendScriptCallback("actor_on_before_death", nil, {})
+end
+
+--- The scenario soulslike.script is currently holding, read out of the same
+--- file-local the handlers assign to.
+local function live_scenario()
+    return H.loader.upvalue(soulslike.wakeup_callback, "scenario_logic")
+end
+
+describe("save_state()", function()
+
+    beforeEach(function() boot() end)
+
+    it("is reachable as an upvalue of on_game_start", function()
+        expect(save_state).toBeType("function")
+    end)
+
+    describe("given soulslike mode is off", function()
+        it("writes nothing to the save", function()
+            boot{ soulslike_mode = false }
+            soulslike.get_soulslike_state().spawn_location.level = nil
+            save_state({})
+            expect(soulslike.get_soulslike_state().spawn_location.level).toBeNil()
+        end)
+    end)
+
+    describe("given no spawn point has been recorded", function()
+        it("records one", function()
+            soulslike.get_soulslike_state().spawn_location.level = nil
+            save_state({})
+            expect(soulslike.get_soulslike_state().spawn_location.level).toBe("zaton")
+        end)
+
+        it("captures the actor's position", function()
+            H.set_actor{ position = { x = 7, y = 8, z = 9 } }
+            soulslike.get_soulslike_state().spawn_location.level = nil
+            save_state({})
+            local pos = soulslike.get_soulslike_state().spawn_location.position
+            expect(pos.x).toBe(7)
+            expect(pos.z).toBe(9)
+        end)
+
+        -- fake_start is the character-creation level; recording a spawn there
+        -- would peg every future death to the intro area.
+        it("does not record one on fake_start", function()
+            H.fakes.set_level("fake_start")
+            soulslike.get_soulslike_state().spawn_location.level = nil
+            save_state({})
+            expect(soulslike.get_soulslike_state().spawn_location.level).toBeNil()
+        end)
+    end)
+
+    describe("given a spawn point is already recorded", function()
+        it("leaves it alone", function()
+            H.fakes.set_level("jupiter")
+            save_state({})
+            expect(soulslike.get_soulslike_state().spawn_location.level).toBe("zaton")
+        end)
+    end)
+
+    describe("given no scenario is running", function()
+        it("leaves logic_state absent", function()
+            save_state({})
+            expect(soulslike.get_soulslike_state().logic_state).toBeNil()
+        end)
+    end)
+
+    describe("given a scenario is running", function()
+        local scenario
+
+        beforeEach(function()
+            die()
+            scenario = live_scenario()
+            scenario.logic_state.stash_id = 4242
+        end)
+
+        it("persists the running scenario's state", function()
+            save_state({})
+            expect(soulslike.get_soulslike_state().logic_state).toBeDefined()
+        end)
+
+        it("stores the scenario id", function()
+            save_state({})
+            expect(soulslike.get_soulslike_state().logic_state.scenario_id).toBeDefined()
+        end)
+
+        -- CHARACTERIZATION: assigned by reference, with no serialization step
+        -- (:793). Safe only because logic_state holds plain data; anything with
+        -- a metatable or an engine object in it would not survive a real save.
+        it("CHARACTERIZATION: stores the live table, not a copy", function()
+            save_state({})
+            local saved = soulslike.get_soulslike_state().logic_state
+            expect(saved).toBe(live_scenario().logic_state)
+        end)
+
+        it("CHARACTERIZATION: later scenario mutations reach the save", function()
+            save_state({})
+            live_scenario().logic_state.stash_id = 9999
+            expect(soulslike.get_soulslike_state().logic_state.stash_id).toBe(9999)
+        end)
+    end)
+
+    -- CHARACTERIZATION: both handlers shadow their `data` parameter with
+    -- get_soulslike_state() on the very next line (:765, :782), so the payload
+    -- the callback dispatches is ignored entirely.
+    describe("CHARACTERIZATION: the callback payload", function()
+        it("is ignored", function()
+            local payload = { sentinel = true }
+            save_state(payload)
+            expect(payload).toEqual({ sentinel = true })
+        end)
+    end)
+end)
+
+describe("load_state()", function()
+
+    beforeEach(function() boot() end)
+
+    it("is reachable as an upvalue of on_game_start", function()
+        expect(load_state).toBeType("function")
+    end)
+
+    describe("given soulslike mode is off", function()
+        it("restores nothing", function()
+            boot{
+                soulslike_mode = false,
+                state = { logic_state = B.make_logic_state{ scenario_id = 1 } },
+            }
+            load_state({})
+            expect(live_scenario()).toBeNil()
+        end)
+    end)
+
+    describe("given the save has no logic_state", function()
+        it("restores nothing", function()
+            load_state({})
+            expect(live_scenario()).toBeNil()
+        end)
+
+        it("does not raise", function()
+            expect(function() load_state({}) end).never.toThrow()
+        end)
+    end)
+
+    describe("given a logic_state with no scenario id", function()
+        -- A save written mid-death by an older build. The scenario cannot be
+        -- reconstructed, so the mod warns and leaves nothing running rather
+        -- than guessing.
+        beforeEach(function()
+            boot{ state = { logic_state = B.make_logic_state{} } }
+        end)
+
+        it("restores nothing", function()
+            load_state({})
+            expect(live_scenario()).toBeNil()
+        end)
+
+        it("does not raise", function()
+            expect(function() load_state({}) end).never.toThrow()
+        end)
+    end)
+
+    describe("given a complete logic_state", function()
+        local saved
+
+        beforeEach(function()
+            saved = B.make_logic_state{ rank = 4242 }
+            saved.scenario_id = _G.soulslike.SCENARIOS.NoLoss
+            saved.stash_id = 777
+            boot{ state = { logic_state = saved } }
+            load_state({})
+        end)
+
+        it("restores a scenario", function()
+            expect(live_scenario()).toBeDefined()
+        end)
+
+        it("restores the right subclass", function()
+            expect(H.class.is_instance(live_scenario(),
+                                       _G.NoLossSoulslikeScenarioLogic)).toBe(true)
+        end)
+
+        it("adopts the saved table by reference", function()
+            expect(live_scenario().logic_state).toBe(
+                soulslike.get_soulslike_state().logic_state)
+        end)
+
+        it("preserves the scenario's own fields", function()
+            expect(live_scenario().logic_state.stash_id).toBe(777)
+            expect(live_scenario().logic_state.rank).toBe(4242)
+        end)
+
+        -- __init takes the restore branch when handed a state
+        -- (soulslike_scenarios.script:227), so no MCM is re-read. A player who
+        -- changed settings mid-death keeps the terms they died under.
+        it("does not re-read MCM over the restored state", function()
+            H.fakes.set_mcm("items/item_loss_scalar", 0.99)
+            load_state({})
+            expect(live_scenario().logic_state.item_loss_scalar)
+                .toBeCloseTo(saved.item_loss_scalar)
+        end)
+    end)
+end)
+
+describe("the save/load round trip", function()
+
+    -- H.reboot models a ChangeLevel: every script re-executes and every module
+    -- table is discarded, but alife_storage_manager's state survives. That is
+    -- the transition the mod's own comment at :790 flags as fragile.
+    local function change_level()
+        H.reboot{ load = MOD_SCRIPTS, soulslike_mode = true }
+        H.fakes.set_random_min()
+        bind_handlers()
+        soulslike.on_game_start()
+    end
+
+    beforeEach(function() boot() end)
+
+    describe("given a scenario was running when the level changed", function()
+        local before
+
+        beforeEach(function()
+            die()
+            before = live_scenario().logic_state
+            before.stash_id = 4242
+            before.story.items_were_lost = true
+
+            save_state({})
+            change_level()
+            load_state({})
+        end)
+
+        it("restores a scenario on the far side", function()
+            expect(live_scenario()).toBeDefined()
+        end)
+
+        it("restores the same scenario id", function()
+            expect(live_scenario().logic_state.scenario_id).toBe(before.scenario_id)
+        end)
+
+        it("carries the stash id across", function()
+            expect(live_scenario().logic_state.stash_id).toBe(4242)
+        end)
+
+        it("carries the story across", function()
+            expect(live_scenario().logic_state.story.items_were_lost).toBe(true)
+        end)
+
+        it("carries the death location across", function()
+            expect(live_scenario().logic_state.death_location)
+                .toEqual(before.death_location)
+        end)
+
+        -- The module table really was replaced -- otherwise the round trip
+        -- would be trivially "passing" against a scenario that never died.
+        it("really did discard the old module state", function()
+            expect(live_scenario()).never.toBe(before)
+        end)
+    end)
+
+    describe("given no scenario was running", function()
+        it("restores nothing across the level change", function()
+            save_state({})
+            change_level()
+            load_state({})
+            expect(live_scenario()).toBeNil()
+        end)
+
+        it("still carries the spawn point across", function()
+            save_state({})
+            change_level()
+            expect(soulslike.get_soulslike_state().spawn_location.level).toBe("zaton")
+        end)
+    end)
+
+    describe("given the save is reloaded twice", function()
+        it("restores the same state each time", function()
+            die()
+            live_scenario().logic_state.stash_id = 4242
+            save_state({})
+
+            change_level()
+            load_state({})
+            expect(live_scenario().logic_state.stash_id).toBe(4242)
+
+            save_state({})
+            change_level()
+            load_state({})
+            expect(live_scenario().logic_state.stash_id).toBe(4242)
+        end)
+    end)
+end)
+
+return true

--- a/tests/unit/spawn_ambush.spec.lua
+++ b/tests/unit/spawn_ambush.spec.lua
@@ -1,0 +1,904 @@
+-- SoulslikeScenarioLogic:SpawnAmbush (soulslike_scenarios.script:667-832)
+-- and TrackAmbusher (:652-665).
+--
+-- Two rolls per invocation: a gate roll deciding whether an ambush happens at
+-- all, then a weighted pick over the eligible spawn table. Both had defects.
+--
+-- The spawn tables are module-scope locals reached as upvalues, which is also
+-- how the leak spec checks that SpawnAmbush no longer writes bucket bounds
+-- onto them.
+
+local H = require("harness.init")
+local B = H.builders
+
+local MOD_SCRIPTS = {
+    "soulslike_classes", "soulslike", "soulslike_mcm",
+    "soulslike_message_factory", "soulslike_scenarios",
+}
+
+local mutant_spawns, stalker_spawns
+
+-- Sections are looked up in system.ltx for their class, which maps to a spawn
+-- group; only "Squads" takes the squad path (:781).
+local MUTANT_CLASS = "SM_BOARW"      -- -> "NPC (Mutant)", non-squad
+local SQUAD_CLASS  = "ON_OFF_S"      -- -> "Squads"
+
+local function boot()
+    H.boot{ load = MOD_SCRIPTS }
+
+    local fn = _G.SoulslikeScenarioLogic.SpawnAmbush
+    mutant_spawns  = H.loader.upvalue(fn, "mutant_spawns")
+    stalker_spawns = H.loader.upvalue(fn, "stalker_spawns")
+
+    -- Every mutant section resolves to a non-squad mutant class by default.
+    for _, spawn in ipairs(mutant_spawns) do
+        H.fakes.set_ltx(spawn.section, { class = MUTANT_CLASS })
+    end
+    for _, spawn in ipairs(stalker_spawns) do
+        H.fakes.set_ltx(spawn.section, { class = SQUAD_CLASS })
+    end
+end
+
+local DEATH_LOCATION = {
+    position = { x = 10, y = 0, z = 20 },
+    level_vertex_id = 55,
+    game_vertex_id = 66,
+}
+
+-- `false` means "no location recorded" and must survive into make_scenario as
+-- false; `or` would quietly restore the default.
+local function with_death_location(state)
+    if state.death_location == nil then
+        state.death_location = DEATH_LOCATION
+    end
+    return state
+end
+
+--- A scenario primed for a mutant ambush: monster killer, bait carried, and a
+--- recorded death location so the spawn is not skipped by the position guard.
+local function mutant_scenario(state)
+    state = with_death_location(state or {})
+    state.killer_type = soulslike.entity_type.Monster
+    if state.has_mutant_bait == nil then state.has_mutant_bait = true end
+    return B.make_scenario{ state = state }
+end
+
+local function stalker_scenario(state)
+    state = with_death_location(state or {})
+    state.killer_type = soulslike.entity_type.Stalker
+    return B.make_scenario{ state = state }
+end
+
+-- The bucket roll is `math.random() * weight_sum`, so specs drive it with a
+-- fraction of the total weight rather than a slot out of 100.
+local ROLL_STEPS = 100
+
+--- Section spawned for a bucket roll at `fraction` of the total weight, or nil
+--- if nothing was selected. The gate roll is pinned to 0 so only the bucket
+--- roll varies.
+local function section_for_roll(scenario_fn, fraction, state)
+    boot()
+    local s = scenario_fn(state)
+    H.fakes.set_random_sequence{ 0, fraction }
+    s:SpawnAmbush()
+    return H.world.created[1] and H.world.created[1].section
+end
+
+describe("SoulslikeScenarioLogic:SpawnAmbush()", function()
+
+    beforeEach(boot)
+
+    describe("the gate roll", function()
+
+        describe("given a monster killer carrying bait and a passing roll", function()
+            it("spawns something", function()
+                local s = mutant_scenario()
+                H.fakes.set_random_sequence{ 0.1, 0.5 }
+                s:SpawnAmbush()
+                expect(H.world.created).toHaveLength(1)
+            end)
+        end)
+
+        describe("given the roll fails", function()
+            it("spawns nothing", function()
+                local s = mutant_scenario()
+                H.fakes.set_random_sequence{ 0.99 }
+                s:SpawnAmbush()
+                expect(H.world.created).toHaveLength(0)
+            end)
+
+            it("spends only the gate roll", function()
+                local s = mutant_scenario()
+                H.fakes.set_random_sequence{ 0.99 }
+                local before = H.fakes.random_count()
+                s:SpawnAmbush()
+                expect(H.fakes.random_count() - before).toBe(1)
+            end)
+        end)
+
+        -- FIXES: D4. The gate used math.random(0, 100) -- 101 discrete outcomes
+        -- -- compared against chance*100, so the configured 0.25 actually meant
+        -- 25/101. Every other chance roll in the file is a float compared
+        -- directly against the chance, and this now matches.
+        describe("given the roll lands exactly on the configured chance", function()
+            it("does not ambush, because the comparison is `<`", function()
+                local s = mutant_scenario{ mutant_ambush_chance = 0.25 }
+                H.fakes.set_random_sequence{ 0.25 }
+                s:SpawnAmbush()
+                expect(H.world.created).toHaveLength(0)
+            end)
+
+            it("ambushes just below the chance", function()
+                local s = mutant_scenario{ mutant_ambush_chance = 0.25 }
+                H.fakes.set_random_sequence{ 0.2499, 0.5 }
+                s:SpawnAmbush()
+                expect(H.world.created).toHaveLength(1)
+            end)
+        end)
+
+        describe("given a chance of zero", function()
+            it("never ambushes, even on the lowest roll", function()
+                local s = mutant_scenario{ mutant_ambush_chance = 0 }
+                H.fakes.set_random_sequence{ 0 }
+                s:SpawnAmbush()
+                expect(H.world.created).toHaveLength(0)
+            end)
+        end)
+
+        describe("given a chance of one", function()
+            it("always ambushes, even on the highest roll", function()
+                local s = mutant_scenario{ mutant_ambush_chance = 1.0 }
+                H.fakes.set_random_sequence{ 0.9999, 0.5 }
+                s:SpawnAmbush()
+                expect(H.world.created).toHaveLength(1)
+            end)
+        end)
+
+        describe("given a monster killer but no bait", function()
+            it("spawns nothing", function()
+                local s = mutant_scenario{ has_mutant_bait = false }
+                H.fakes.set_random_sequence{ 0 }
+                s:SpawnAmbush()
+                expect(H.world.created).toHaveLength(0)
+            end)
+        end)
+
+        describe("given debug_always_spawn_ambush", function()
+            it("forces the ambush regardless of the roll", function()
+                H.fakes.set_mcm("debug/is_enabled", true)
+                H.fakes.set_mcm("debug/debug_always_spawn_ambush", true)
+                local s = mutant_scenario()
+                H.fakes.set_random_sequence{ 0.99, 0.5 }
+                s:SpawnAmbush()
+                expect(H.world.created).toHaveLength(1)
+            end)
+        end)
+
+        describe("given a stalker killer that cannot be resolved", function()
+            it("spawns nothing", function()
+                local s = stalker_scenario{ killer_id = 4242 }
+                H.fakes.set_random_sequence{ 0 }
+                s:SpawnAmbush()
+                expect(H.world.created).toHaveLength(0)
+            end)
+        end)
+
+        describe("given no killer type at all", function()
+            it("spawns nothing", function()
+                local s = B.make_scenario{}
+                H.fakes.set_random_sequence{ 0 }
+                s:SpawnAmbush()
+                expect(H.world.created).toHaveLength(0)
+            end)
+        end)
+    end)
+
+    describe("bucket selection", function()
+
+        -- FIXES: D1. The buckets were built by accumulating a FLOORED running
+        -- max, so truncation compounded and the last bucket ended below 100 --
+        -- at the defaults it ended at 96, leaving rolls 97-100 matching nothing
+        -- and SpawnAmbush returning silently with no ambush and no debug tip.
+        describe("given the full default mutant table", function()
+            it("selects a section across the whole roll range", function()
+                local missed = {}
+                for i = 0, ROLL_STEPS - 1 do
+                    local fraction = i / ROLL_STEPS
+                    if not section_for_roll(mutant_scenario, fraction) then
+                        missed[#missed + 1] = fraction
+                    end
+                end
+                expect(missed).toEqual({})
+            end)
+
+            -- math.random() is [0,1), so the highest reachable roll sits just
+            -- below the total weight. That is exactly where the old floored
+            -- buckets left a dead zone.
+            it("selects a section just below the top of the range", function()
+                expect(section_for_roll(mutant_scenario, 0.99999)).toBeDefined()
+            end)
+
+            it("selects a section on a roll of zero", function()
+                expect(section_for_roll(mutant_scenario, 0)).toBeDefined()
+            end)
+        end)
+
+        -- FIXES: D2. Once a bucket's share fell below 1 after flooring, its min
+        -- exceeded its max and it became permanently unreachable. At the
+        -- defaults that was every rare mutant -- bloodsucker, burer, chimera,
+        -- controller and the two weak variants all had min=97 > max=96, so
+        -- their configured weights were decorative.
+        describe("given the rare mutants are enabled", function()
+            -- Probing each entry at the midpoint of its OWN bucket rather than
+            -- sampling a fixed grid: the rarest entry is 0.01 of a 4.98 total,
+            -- roughly 0.2% of the range, which a 1/100 grid steps straight over.
+            -- Every entry must be selectable at the middle of its own share.
+            local function bucket_midpoints()
+                local total = 0
+                for _, spawn in ipairs(mutant_spawns) do
+                    total = total + spawn.weight
+                end
+
+                local out, lower = {}, 0
+                for _, spawn in ipairs(mutant_spawns) do
+                    out[#out + 1] = {
+                        section  = spawn.section,
+                        fraction = (lower + spawn.weight / 2) / total,
+                    }
+                    lower = lower + spawn.weight
+                end
+                return out
+            end
+
+            it("can select each rare mutant", function()
+                local rare = {
+                    simulation_bloodsucker = true, simulation_burer1 = true,
+                    simulation_chimera = true, simulation_bloodsucker_2weak = true,
+                    simulation_chimera_2weak = true, simulation_controller = true,
+                }
+
+                local unreachable = {}
+                for _, probe in ipairs(bucket_midpoints()) do
+                    if rare[probe.section] then
+                        if section_for_roll(mutant_scenario, probe.fraction)
+                           ~= probe.section then
+                            unreachable[#unreachable + 1] = probe.section
+                        end
+                    end
+                end
+                expect(unreachable).toEqual({})
+            end)
+
+            it("can select every entry in the table", function()
+                local unreachable = {}
+                for _, probe in ipairs(bucket_midpoints()) do
+                    if section_for_roll(mutant_scenario, probe.fraction)
+                       ~= probe.section then
+                        unreachable[#unreachable + 1] = probe.section
+                    end
+                end
+                expect(unreachable).toEqual({})
+            end)
+
+            -- Weights should now be proportional rather than decorative: a
+            -- bucket's width must track its declared weight.
+            it("gives each entry a share proportional to its weight", function()
+                local probes = bucket_midpoints()
+                local boar = probes[1]          -- weight 1.00
+                local controller = probes[#probes]
+
+                expect(section_for_roll(mutant_scenario, boar.fraction))
+                    .toBe(boar.section)
+                expect(section_for_roll(mutant_scenario, controller.fraction))
+                    .toBe(controller.section)
+            end)
+        end)
+
+        describe("given only one mutant type is enabled", function()
+            local ONLY_SNORK = {
+                allow_boar_ambush = false, allow_flesh_ambush = false,
+                allow_dogs_ambush = false, allow_cats_ambush = false,
+                allow_bloodsucker_ambush = false, allow_burer_ambush = false,
+                allow_chimera_ambush = false, allow_controller_ambush = false,
+            }
+
+            it("selects it on the lowest roll", function()
+                expect(section_for_roll(mutant_scenario, 0, ONLY_SNORK))
+                    .toBe("simulation_snork")
+            end)
+
+            it("selects it just below the top of the range", function()
+                expect(section_for_roll(mutant_scenario, 0.99999, ONLY_SNORK))
+                    .toBe("simulation_snork")
+            end)
+        end)
+
+        describe("given a disabled mutant type", function()
+            it("is never selected at any roll", function()
+                local seen = {}
+                for i = 0, ROLL_STEPS - 1 do
+                    local sec = section_for_roll(mutant_scenario, i / ROLL_STEPS,
+                                                 { allow_snorks_ambush = false })
+                    if sec then seen[sec] = true end
+                end
+                expect(seen["simulation_snork"]).toBeNil()
+            end)
+        end)
+
+        describe("given every mutant type is disabled", function()
+            it("spawns nothing", function()
+                local s = mutant_scenario{
+                    allow_boar_ambush = false, allow_flesh_ambush = false,
+                    allow_dogs_ambush = false, allow_cats_ambush = false,
+                    allow_snorks_ambush = false, allow_bloodsucker_ambush = false,
+                    allow_burer_ambush = false, allow_chimera_ambush = false,
+                    allow_controller_ambush = false,
+                }
+                H.fakes.set_random_sequence{ 0 }
+                s:SpawnAmbush()
+                expect(H.world.created).toHaveLength(0)
+            end)
+
+            it("does not spend the bucket roll", function()
+                local s = mutant_scenario{
+                    allow_boar_ambush = false, allow_flesh_ambush = false,
+                    allow_dogs_ambush = false, allow_cats_ambush = false,
+                    allow_snorks_ambush = false, allow_bloodsucker_ambush = false,
+                    allow_burer_ambush = false, allow_chimera_ambush = false,
+                    allow_controller_ambush = false,
+                }
+                H.fakes.set_random_sequence{ 0 }
+                local before = H.fakes.random_count()
+                s:SpawnAmbush()
+                expect(H.fakes.random_count() - before).toBe(1)
+            end)
+        end)
+
+        it("spends exactly two rolls on a successful ambush", function()
+            local s = mutant_scenario()
+            H.fakes.set_random_sequence{ 0, 0.5 }
+            local before = H.fakes.random_count()
+            s:SpawnAmbush()
+            expect(H.fakes.random_count() - before).toBe(2)
+        end)
+
+        -- FIXES: D3. table.insert put REFERENCES to the module-scope spawn
+        -- descriptors into the working list, so writing value.min/value.max
+        -- mutated the shared tables permanently. Harmless only by luck -- the
+        -- bounds were always recomputed before use -- but it made a supposedly
+        -- constant table carry per-call state.
+        describe("the module-scope spawn tables", function()
+            it("are not mutated by a spawn", function()
+                local s = mutant_scenario()
+                H.fakes.set_random_sequence{ 0, 0.5 }
+                s:SpawnAmbush()
+
+                local polluted = {}
+                for _, spawn in ipairs(mutant_spawns) do
+                    if spawn.min ~= nil or spawn.max ~= nil then
+                        polluted[#polluted + 1] = spawn.section
+                    end
+                end
+                expect(polluted).toEqual({})
+            end)
+
+            it("keep only their declared keys", function()
+                local s = mutant_scenario()
+                H.fakes.set_random_sequence{ 0, 0.5 }
+                s:SpawnAmbush()
+
+                local keys = {}
+                for k in pairs(mutant_spawns[1]) do keys[#keys + 1] = k end
+                table.sort(keys)
+                expect(keys).toEqual({ "section", "type", "weight" })
+            end)
+
+            it("give the same selection across repeated calls", function()
+                local first = section_for_roll(mutant_scenario, 50)
+
+                boot()
+                local s = mutant_scenario{ allow_snorks_ambush = false }
+                H.fakes.set_random_sequence{ 0, 0.5 }
+                s:SpawnAmbush()
+
+                -- A narrower table on the second call must not leave stale
+                -- bounds that change what the first configuration selects.
+                expect(section_for_roll(mutant_scenario, 50)).toBe(first)
+            end)
+        end)
+    end)
+
+    describe("stalker ambushes", function()
+
+        local function with_killer(community, state)
+            boot()
+            local killer = H.world.spawn_se_npc{ kind = "stalker", community = community }
+            state = state or {}
+            state.killer_id = killer.id
+            return stalker_scenario(state), killer
+        end
+
+        describe("given a killer of a given community", function()
+            it("only selects squads of that community", function()
+                local seen = {}
+                for i = 0, ROLL_STEPS - 1 do
+                    boot()
+                    local killer = H.world.spawn_se_npc{ kind = "stalker", community = "bandit" }
+                    local s = stalker_scenario{ killer_id = killer.id }
+                    H.fakes.set_random_sequence{ 0, i / ROLL_STEPS }
+                    s:SpawnAmbush()
+                    local made = H.world.created[1]
+                    if made then seen[made.section] = true end
+                end
+
+                for section in pairs(seen) do
+                    expect(section).toContain("bandit")
+                end
+            end)
+        end)
+
+        -- FIXES: D10. Advanced, Veteran and Sniper all had the value 2 in
+        -- stalker_spawn_type, and the filter tested `== Advanced` first, so
+        -- enabling any one of the three admitted all of them. The veteran and
+        -- sniper MCM toggles could never gate anything independently.
+        describe("given only the novice toggle is on", function()
+            local NOVICE_ONLY = {
+                allow_stalker_advanced_ambush = false,
+                allow_stalker_veteran_ambush  = false,
+                allow_stalker_sniper_ambush   = false,
+            }
+
+            it("never selects an advanced squad", function()
+                local seen = {}
+                for i = 0, ROLL_STEPS - 1 do
+                    boot()
+                    local killer = H.world.spawn_se_npc{ kind = "stalker", community = "stalker" }
+                    local s = stalker_scenario{
+                        killer_id = killer.id,
+                        allow_stalker_advanced_ambush = false,
+                        allow_stalker_veteran_ambush  = false,
+                        allow_stalker_sniper_ambush   = false,
+                    }
+                    H.fakes.set_random_sequence{ 0, i / ROLL_STEPS }
+                    s:SpawnAmbush()
+                    if H.world.created[1] then seen[H.world.created[1].section] = true end
+                end
+                expect(seen["stalker_sim_squad_advanced"]).toBeNil()
+                expect(seen["stalker_sim_squad_veteran"]).toBeNil()
+            end)
+        end)
+
+        describe("given only the veteran toggle is on", function()
+            it("never selects an advanced squad", function()
+                local seen = {}
+                for i = 0, ROLL_STEPS - 1 do
+                    boot()
+                    local killer = H.world.spawn_se_npc{ kind = "stalker", community = "stalker" }
+                    local s = stalker_scenario{
+                        killer_id = killer.id,
+                        allow_stalker_novice_ambush   = false,
+                        allow_stalker_advanced_ambush = false,
+                        allow_stalker_sniper_ambush   = false,
+                    }
+                    H.fakes.set_random_sequence{ 0, i / ROLL_STEPS }
+                    s:SpawnAmbush()
+                    if H.world.created[1] then seen[H.world.created[1].section] = true end
+                end
+                expect(seen["stalker_sim_squad_advanced"]).toBeNil()
+                expect(seen["stalker_sim_squad_veteran"]).toBe(true)
+            end)
+        end)
+
+        describe("given only the sniper toggle is on", function()
+            it("selects only the sniper squad", function()
+                local seen = {}
+                for i = 0, ROLL_STEPS - 1 do
+                    boot()
+                    local killer = H.world.spawn_se_npc{ kind = "stalker", community = "army" }
+                    local s = stalker_scenario{
+                        killer_id = killer.id,
+                        allow_stalker_novice_ambush   = false,
+                        allow_stalker_advanced_ambush = false,
+                        allow_stalker_veteran_ambush  = false,
+                    }
+                    H.fakes.set_random_sequence{ 0, i / ROLL_STEPS }
+                    s:SpawnAmbush()
+                    if H.world.created[1] then seen[H.world.created[1].section] = true end
+                end
+                expect(seen).toEqual({ army_sim_squad_sniper = true })
+            end)
+        end)
+
+        describe("given a community with no matching squads", function()
+            it("spawns nothing", function()
+                local s = with_killer("zombied")
+                H.fakes.set_random_sequence{ 0 }
+                s:SpawnAmbush()
+                expect(H.world.created).toHaveLength(0)
+            end)
+        end)
+    end)
+
+    describe("spawning", function()
+
+        describe("given a non-squad section", function()
+            it("creates the object at the death location", function()
+                local s = mutant_scenario()
+                H.fakes.set_random_sequence{ 0, 0.5 }
+                s:SpawnAmbush()
+                expect(H.world.created).toHaveLength(1)
+            end)
+
+            it("tracks the ambusher with both vertex ids", function()
+                local s = mutant_scenario()
+                H.fakes.set_random_sequence{ 0, 0.5 }
+                s:SpawnAmbush()
+
+                local id = H.world.created[1].id
+                local tracked = s.game_state.tracked_ambushers[id]
+                expect(tracked.level_vertex_id).toBe(55)
+                expect(tracked.game_vertex_id).toBe(66)
+            end)
+
+            it("records the stance constants", function()
+                local s = mutant_scenario()
+                H.fakes.set_random_sequence{ 0, 0.5 }
+                s:SpawnAmbush()
+
+                local tracked = s.game_state.tracked_ambushers[H.world.created[1].id]
+                expect(tracked.mental_state).toBe(anim.look_around)
+                expect(tracked.body_state).toBe(move.standing)
+                expect(tracked.movement_type).toBe(move.stand)
+                expect(tracked.sight_type).toBe(look.search)
+            end)
+        end)
+
+        describe("given a squad section", function()
+            beforeEach(function()
+                H.world.squads["stalker_sim_squad_novice"] = {
+                    { kind = "stalker", section = "sim_default_stalker_1" },
+                    { kind = "stalker", section = "sim_default_stalker_2" },
+                }
+            end)
+
+            local function spawn_squad()
+                local killer = H.world.spawn_se_npc{ kind = "stalker", community = "stalker" }
+                local s = stalker_scenario{
+                    killer_id = killer.id,
+                    allow_stalker_advanced_ambush = false,
+                    allow_stalker_veteran_ambush  = false,
+                    allow_stalker_sniper_ambush   = false,
+                }
+                H.fakes.set_random_sequence{ 0, 0.5 }
+                s:SpawnAmbush()
+                return s
+            end
+
+            it("creates the npcs", function()
+                spawn_squad()
+                expect(H.fakes.call_count("se.create_npc")).toBe(1)
+            end)
+
+            it("sets up each member with the simulation board", function()
+                spawn_squad()
+                expect(H.fakes.call_count("setup_squad_and_group")).toBe(2)
+            end)
+
+            it("announces each member's creation", function()
+                spawn_squad()
+                expect(H.dispatch.sends_of("squad_on_npc_creation")).toHaveLength(2)
+            end)
+
+            it("tracks every member", function()
+                local s = spawn_squad()
+                local n = 0
+                for _ in pairs(s.game_state.tracked_ambushers) do n = n + 1 end
+                expect(n).toBe(2)
+            end)
+
+            -- CHARACTERIZATION: the squad call passes 6 args where the
+            -- non-squad call passes 8 (:796-802 vs :811-819), so squad members
+            -- are tracked with nil vertex ids. Left as-is: the consumer places
+            -- them by desired_position, which is supplied, and the squad's own
+            -- placement comes from the simulation board.
+            it("CHARACTERIZATION: leaves member vertex ids nil", function()
+                local s = spawn_squad()
+                for _, tracked in pairs(s.game_state.tracked_ambushers) do
+                    expect(tracked.level_vertex_id).toBeNil()
+                    expect(tracked.game_vertex_id).toBeNil()
+                end
+            end)
+        end)
+
+        describe("given no death location was recorded", function()
+            -- The position guard at :770 saves this call from building a vector
+            -- out of nils, which the engine would hard-crash on.
+            it("spawns nothing", function()
+                local s = mutant_scenario{ death_location = false }
+                H.fakes.set_random_sequence{ 0, 0.5 }
+                s:SpawnAmbush()
+                expect(H.world.created).toHaveLength(0)
+            end)
+
+            it("does not raise", function()
+                local s = mutant_scenario{ death_location = false }
+                H.fakes.set_random_sequence{ 0, 0.5 }
+                expect(function() s:SpawnAmbush() end).never.toThrow()
+            end)
+
+            it("still spends both rolls", function()
+                local s = mutant_scenario{ death_location = false }
+                H.fakes.set_random_sequence{ 0, 0.5 }
+                local before = H.fakes.random_count()
+                s:SpawnAmbush()
+                expect(H.fakes.random_count() - before).toBe(2)
+            end)
+        end)
+
+        describe("given an unknown spawn class", function()
+            it("still spawns, on the non-squad path", function()
+                for _, spawn in ipairs(mutant_spawns) do
+                    H.fakes.set_ltx(spawn.section, { class = "NOT_A_CLASS" })
+                end
+                local s = mutant_scenario()
+                H.fakes.set_random_sequence{ 0, 0.5 }
+                s:SpawnAmbush()
+                expect(H.world.created).toHaveLength(1)
+            end)
+        end)
+
+        describe("given debug_squad_spawns", function()
+            it("adds a map spot for the spawn", function()
+                H.fakes.set_mcm("debug/is_enabled", true)
+                H.fakes.set_mcm("debug/debug_squad_spawns", true)
+                local s = mutant_scenario()
+                H.fakes.set_random_sequence{ 0, 0.5 }
+                s:SpawnAmbush()
+                expect(H.fakes.call_count("level.map_add_object_spot_ser")).toBe(1)
+            end)
+        end)
+    end)
+end)
+
+describe("SoulslikeScenarioLogic:TrackAmbusher()", function()
+
+    beforeEach(boot)
+
+    it("creates the collection on first use", function()
+        local s = B.make_scenario{}
+        s.game_state.tracked_ambushers = nil
+        s:TrackAmbusher(1, "a", "b", "c", "d", { x = 1, y = 2, z = 3 }, 4, 5)
+        expect(s.game_state.tracked_ambushers).toBeDefined()
+    end)
+
+    it("records every field", function()
+        local s = B.make_scenario{}
+        s:TrackAmbusher(7, "mental", "body", "move", "sight", { x = 1, y = 2, z = 3 }, 4, 5)
+        expect(s.game_state.tracked_ambushers[7]).toEqual{
+            mental_state = "mental", body_state = "body",
+            movement_type = "move", sight_type = "sight",
+            position = { x = 1, y = 2, z = 3 },
+            level_vertex_id = 4, game_vertex_id = 5,
+        }
+    end)
+
+    it("overwrites an existing entry for the same id", function()
+        local s = B.make_scenario{}
+        s:TrackAmbusher(7, "first", nil, nil, nil, {}, nil, nil)
+        s:TrackAmbusher(7, "second", nil, nil, nil, {}, nil, nil)
+        expect(s.game_state.tracked_ambushers[7].mental_state).toBe("second")
+    end)
+
+    it("keeps separate entries per id", function()
+        local s = B.make_scenario{}
+        s:TrackAmbusher(1, "a", nil, nil, nil, {}, nil, nil)
+        s:TrackAmbusher(2, "b", nil, nil, nil, {}, nil, nil)
+        expect(s.game_state.tracked_ambushers[1].mental_state).toBe("a")
+        expect(s.game_state.tracked_ambushers[2].mental_state).toBe("b")
+    end)
+end)
+
+-- FIXES: D12. npc_on_net_spawn is the only consumer of tracked_ambushers, and
+-- its registration was commented out (soulslike.script:964) while nothing else
+-- referenced it. So no ambusher ever took its stance, and the table grew in
+-- every save forever -- it was not even in the migration schema, so old saves
+-- never had it repaired.
+describe("ambusher stance handover", function()
+
+    local function boot_with_mode()
+        H.boot{ load = MOD_SCRIPTS, soulslike_mode = true }
+        H.fakes.set_random_min()
+        soulslike.on_game_start()
+    end
+
+    beforeEach(boot_with_mode)
+
+    describe("the callback registration", function()
+        it("is registered on game start", function()
+            expect(H.dispatch.handler_count("npc_on_net_spawn")).toBe(1)
+        end)
+    end)
+
+    describe("given a tracked stalker net-spawns", function()
+        local npc
+
+        beforeEach(function()
+            npc = B.make_stalker{ id = 5150 }
+            soulslike.get_soulslike_state().tracked_ambushers = {
+                [5150] = {
+                    mental_state = anim.look_around,
+                    body_state = move.standing,
+                    movement_type = move.stand,
+                    sight_type = look.search,
+                    position = { x = 1, y = 2, z = 3 },
+                    level_vertex_id = 4,
+                    game_vertex_id = 5,
+                },
+            }
+            SendScriptCallback("npc_on_net_spawn", npc, nil)
+        end)
+
+        it("applies the recorded stance", function()
+            expect(npc.applied.mental_state).toBe(anim.look_around)
+            expect(npc.applied.body_state).toBe(move.standing)
+            expect(npc.applied.movement_type).toBe(move.stand)
+            expect(npc.applied.sight_type).toBe(look.search)
+        end)
+
+        it("points it at the recorded position", function()
+            -- A vector object, not a plain table: the handler rebuilds one via
+            -- vector():set (soulslike.script:927).
+            local pos = npc.applied.desired_position
+            expect(pos.x).toBe(1)
+            expect(pos.y).toBe(2)
+            expect(pos.z).toBe(3)
+            expect(npc.applied.desired_direction).toBe(true)
+        end)
+
+        -- The whole point of consuming the entry: without this the table is
+        -- append-only and every death adds to it permanently.
+        it("clears the entry", function()
+            expect(soulslike.get_soulslike_state().tracked_ambushers[5150]).toBeNil()
+        end)
+    end)
+
+    describe("given a tracked squad member with no position", function()
+        -- Squad members are tracked with only 6 of the 8 fields
+        -- (soulslike_scenarios.script:796-802), so position is an empty table
+        -- and the vertex ids are nil. Posing them would build a vector out of
+        -- nils, which the engine hard-crashes on.
+        local npc
+
+        beforeEach(function()
+            npc = B.make_stalker{ id = 5151 }
+            soulslike.get_soulslike_state().tracked_ambushers = {
+                [5151] = {
+                    mental_state = anim.look_around,
+                    body_state = move.standing,
+                    movement_type = move.stand,
+                    sight_type = look.search,
+                    position = {},
+                },
+            }
+        end)
+
+        it("does not raise", function()
+            expect(function()
+                SendScriptCallback("npc_on_net_spawn", npc, nil)
+            end).never.toThrow()
+        end)
+
+        it("still applies the stance", function()
+            SendScriptCallback("npc_on_net_spawn", npc, nil)
+            expect(npc.applied.mental_state).toBe(anim.look_around)
+        end)
+
+        it("does not set a desired position", function()
+            SendScriptCallback("npc_on_net_spawn", npc, nil)
+            expect(npc.applied.desired_position).toBeNil()
+        end)
+
+        it("still clears the entry", function()
+            SendScriptCallback("npc_on_net_spawn", npc, nil)
+            expect(soulslike.get_soulslike_state().tracked_ambushers[5151]).toBeNil()
+        end)
+    end)
+
+    describe("given a tracked mutant net-spawns", function()
+        -- The stance setters are stalker-only, but SpawnAmbush tracks mutants
+        -- too. The entry must still be consumed or mutants leak forever.
+        local mutant
+
+        beforeEach(function()
+            mutant = B.make_monster{ id = 5152 }
+            soulslike.get_soulslike_state().tracked_ambushers = {
+                [5152] = { position = { x = 1, y = 2, z = 3 } },
+            }
+            SendScriptCallback("npc_on_net_spawn", mutant, nil)
+        end)
+
+        it("clears the entry", function()
+            expect(soulslike.get_soulslike_state().tracked_ambushers[5152]).toBeNil()
+        end)
+
+        it("does not apply stalker-only stance setters to it", function()
+            expect(mutant.applied.mental_state).toBeNil()
+        end)
+    end)
+
+    describe("given an untracked npc net-spawns", function()
+        it("leaves other entries alone", function()
+            soulslike.get_soulslike_state().tracked_ambushers = { [1] = { position = {} } }
+            SendScriptCallback("npc_on_net_spawn", B.make_stalker{ id = 999 }, nil)
+            expect(soulslike.get_soulslike_state().tracked_ambushers[1]).toBeDefined()
+        end)
+
+        it("does not raise", function()
+            expect(function()
+                SendScriptCallback("npc_on_net_spawn", B.make_stalker{ id = 999 }, nil)
+            end).never.toThrow()
+        end)
+    end)
+
+    describe("given soulslike mode is off", function()
+        it("ignores the spawn entirely", function()
+            H.boot{ load = MOD_SCRIPTS }
+            H.fakes.set_random_min()
+            soulslike.on_game_start()
+
+            local npc = B.make_stalker{ id = 5153 }
+            soulslike.get_soulslike_state().tracked_ambushers = {
+                [5153] = { position = { x = 1, y = 2, z = 3 } },
+            }
+            SendScriptCallback("npc_on_net_spawn", npc, nil)
+            expect(soulslike.get_soulslike_state().tracked_ambushers[5153]).toBeDefined()
+        end)
+    end)
+
+    describe("the save schema", function()
+        -- Added to get_soulslike_state so a save written before the consumer
+        -- existed gets the collection repaired on load, rather than the
+        -- handler having to nil-guard it forever.
+        it("creates tracked_ambushers on a fresh save", function()
+            expect(soulslike.get_soulslike_state().tracked_ambushers).toEqual({})
+        end)
+
+        it("repairs a save that predates it", function()
+            H.boot{
+                load = MOD_SCRIPTS,
+                soulslike_mode = true,
+                state = { created_stashes = {}, hidden_stashes = {} },
+            }
+            expect(soulslike.get_soulslike_state().tracked_ambushers).toEqual({})
+        end)
+
+        it("does not clobber an existing collection", function()
+            H.boot{
+                load = MOD_SCRIPTS,
+                soulslike_mode = true,
+                state = { tracked_ambushers = { [7] = { position = {} } } },
+            }
+            expect(soulslike.get_soulslike_state().tracked_ambushers[7]).toBeDefined()
+        end)
+    end)
+
+    describe("across repeated ambushes", function()
+        it("does not accumulate entries once each is consumed", function()
+            local state = soulslike.get_soulslike_state()
+            for i = 1, 5 do
+                local npc = B.make_stalker{ id = 6000 + i }
+                state.tracked_ambushers[6000 + i] = {
+                    mental_state = anim.look_around,
+                    position = { x = 1, y = 2, z = 3 },
+                }
+                SendScriptCallback("npc_on_net_spawn", npc, nil)
+            end
+
+            local remaining = 0
+            for _ in pairs(state.tracked_ambushers) do remaining = remaining + 1 end
+            expect(remaining).toBe(0)
+        end)
+    end)
+end)
+
+return true

--- a/tests/unit/state_shape.spec.lua
+++ b/tests/unit/state_shape.spec.lua
@@ -1,0 +1,165 @@
+-- soulslike.get_soulslike_state() (soulslike.script:207-265).
+--
+-- Real save-migration logic. It runs against whatever shape an older save left
+-- behind, and every guard exists because some past version shipped without
+-- that field. Cheap to pin, expensive to get wrong: a missed guard is a
+-- nil-index crash on load for players upgrading.
+
+local H = require("harness.init")
+local fakes = H.fakes
+
+describe("soulslike.get_soulslike_state()", function()
+
+    beforeEach(function()
+        H.boot{ load = { "soulslike_classes", "soulslike" } }
+    end)
+
+    local function state() return soulslike.get_soulslike_state() end
+
+    describe("given a save with no soulslike data at all", function()
+
+        beforeEach(function() fakes.game_state = {} end)
+
+        it("creates every top-level collection", function()
+            local s = state()
+            expect(s.created_stashes).toBeDefined()
+            expect(s.hidden_stashes).toBeDefined()
+            expect(s.note_message_data).toBeDefined()
+        end)
+
+        it("creates spawn_location with its position and angle sub-tables", function()
+            local s = state()
+            expect(s.spawn_location).toBeDefined()
+            expect(s.spawn_location.position).toBeDefined()
+            expect(s.spawn_location.angle).toBeDefined()
+        end)
+
+        it("leaves spawn coordinates nil rather than zeroed", function()
+            -- create_new() branches on `spawn_loc.level` being set
+            -- (soulslike_scenario_logic_factory.script:164). Defaulting these
+            -- to 0 would make an unset spawn look like a valid origin.
+            local s = state()
+            expect(s.spawn_location.level).toBeNil()
+            expect(s.spawn_location.position.x).toBeNil()
+            expect(s.spawn_location.game_vertex_id).toBeNil()
+            expect(s.spawn_location.level_vertex_id).toBeNil()
+        end)
+
+        it("persists the state onto the save table", function()
+            -- Build first: expect()'s argument is evaluated before the matcher
+            -- call, so inlining state() here would capture the pre-call nil.
+            local s = state()
+            expect(fakes.game_state.soulslike).toBe(s)
+        end)
+
+        it("returns the same table on subsequent calls", function()
+            local first = state()
+            first.marker = "mine"
+            expect(state().marker).toBe("mine")
+        end)
+    end)
+
+    describe("given a save from a version missing one field", function()
+
+        it("repairs a missing note_message_data", function()
+            fakes.game_state = { soulslike = {
+                created_stashes = {}, hidden_stashes = {}, spawn_location = {} } }
+            expect(state().note_message_data).toBeDefined()
+        end)
+
+        it("repairs a missing hidden_stashes", function()
+            fakes.game_state = { soulslike = {
+                created_stashes = {}, note_message_data = {}, spawn_location = {} } }
+            expect(state().hidden_stashes).toBeDefined()
+        end)
+
+        it("repairs a missing created_stashes", function()
+            fakes.game_state = { soulslike = {
+                hidden_stashes = {}, note_message_data = {}, spawn_location = {} } }
+            expect(state().created_stashes).toBeDefined()
+        end)
+
+        it("repairs a missing spawn_location with its full sub-shape", function()
+            fakes.game_state = { soulslike = {
+                created_stashes = {}, hidden_stashes = {}, note_message_data = {} } }
+            local s = state()
+            expect(s.spawn_location).toBeDefined()
+            expect(s.spawn_location.position).toBeDefined()
+            expect(s.spawn_location.angle).toBeDefined()
+        end)
+    end)
+
+    describe("given a save with data worth preserving", function()
+
+        beforeEach(function()
+            fakes.game_state = {
+                soulslike = {
+                    created_stashes = { [42] = { lost_items = { "wpn_ak74" } } },
+                    -- hidden_stashes, note_message_data, spawn_location absent
+                },
+            }
+        end)
+
+        it("keeps the existing entries", function()
+            local s = state()
+            expect(s.created_stashes[42]).toBeDefined()
+            expect(s.created_stashes[42].lost_items[1]).toBe("wpn_ak74")
+        end)
+
+        it("still adds the missing siblings", function()
+            local s = state()
+            expect(s.hidden_stashes).toBeDefined()
+            expect(s.note_message_data).toBeDefined()
+            expect(s.spawn_location).toBeDefined()
+        end)
+    end)
+
+    describe("given a fully populated spawn_location", function()
+
+        beforeEach(function()
+            fakes.game_state = { soulslike = {
+                created_stashes = {}, hidden_stashes = {}, note_message_data = {},
+                spawn_location = {
+                    level = "zaton",
+                    position = { x = 1, y = 2, z = 3 },
+                    angle = { x = 0, y = 0, z = 0 },
+                    level_vertex_id = 111,
+                    game_vertex_id = 222,
+                },
+            } }
+        end)
+
+        it("leaves it untouched", function()
+            local s = state()
+            expect(s.spawn_location.level).toBe("zaton")
+            expect(s.spawn_location.position.x).toBe(1)
+            expect(s.spawn_location.game_vertex_id).toBe(222)
+        end)
+    end)
+
+    describe("given a bare soulslike table from an early version", function()
+        -- Worst case: a save that wrote soulslike = {} and nothing else. All
+        -- four repairs must run in a single pass.
+        beforeEach(function() fakes.game_state = { soulslike = {} } end)
+
+        it("runs every guard at once", function()
+            local s = state()
+            expect(s.created_stashes).toBeDefined()
+            expect(s.hidden_stashes).toBeDefined()
+            expect(s.note_message_data).toBeDefined()
+            expect(s.spawn_location).toBeDefined()
+            expect(s.spawn_location.position).toBeDefined()
+            expect(s.spawn_location.angle).toBeDefined()
+        end)
+    end)
+
+    describe("given another mod's data in the same save", function()
+        it("does not disturb it", function()
+            fakes.game_state = { some_other_mod = { keep = true } }
+            state()
+            expect(fakes.game_state.some_other_mod.keep).toBe(true)
+        end)
+    end)
+end)
+
+return true

--- a/tests/unit/text_encoding.spec.lua
+++ b/tests/unit/text_encoding.spec.lua
@@ -1,0 +1,174 @@
+-- The localisation XML is stored as windows-1251, one byte per Cyrillic
+-- letter, and must stay that way.
+--
+-- A regression guard for damage that already happened. Across ten revisions
+-- (f177d70, d8af180, af26ed0, 42aca5e, d3347ee, 6594b15, ac8a81c, 718d1ca,
+-- f3306f4, 94535ac) the rus tables were committed as UTF-8; e5494dc put them
+-- back. Each round trip is an editor, not a person: VS Code guesses an encoding
+-- when it opens a cp1251 file, guesses wrong, and rewrites every Cyrillic byte
+-- on save. The tree is correct now, so this spec is green as written -- it was
+-- confirmed to fail by re-encoding rus/ui_st_mcm_soulslite.xml to UTF-8, and
+-- again for the BOM and declaration cases.
+--
+-- Nothing else here catches it. The engine's XML reader is not encoding-aware
+-- in any useful sense -- it takes the bytes as they are and hands them to
+-- cp1251 font tables -- so a UTF-8 file still parses, every <string id> still
+-- resolves, and `mcm_localization.spec.lua` stays green while every Russian
+-- label in the menu renders as mojibake. The declaration is no help either: it
+-- keeps saying windows-1251 through the whole thing, so the diff looks
+-- innocent. It has to be checked at the byte level or not at all.
+--
+-- Reference for a correct file: any stock Anomaly/GAMMA translation, e.g.
+-- "HD Glowsticks" rus/st_items_glowstick.xml -- declaration windows-1251,
+-- single-byte Cyrillic in 0xC0..0xFF, no BOM.
+--
+-- Line endings are deliberately NOT asserted. Stock files use LF and ours use
+-- CRLF; the engine reads both, and core.autocrlf rewrites them on checkout
+-- anyway, so pinning them would fail for a reason nobody should care about.
+
+local H   = require("harness.init")
+local enc = require("harness.encoding")
+
+local reports = {}      -- flat list, every language
+local by_lang = {}
+
+local function scan()
+    H.boot{}
+    reports, by_lang = {}, {}
+
+    local text_dir = H.loader.text_dir()
+    for _, lang in ipairs(enc.languages(text_dir)) do
+        by_lang[lang] = {}
+        for _, name in ipairs(H.loader.string_table_files(lang)) do
+            local report = enc.inspect(text_dir .. "/" .. lang .. "/" .. name)
+            if report then
+                report.lang, report.name = lang, name
+                reports[#reports + 1] = report
+                by_lang[lang][#by_lang[lang] + 1] = report
+            end
+        end
+    end
+end
+
+--- Reports failing `pred`, described one per line. An assertion against this
+--- names the offending file and offset instead of just "expected true".
+local function offenders(pred)
+    local out = {}
+    for _, report in ipairs(reports) do
+        if pred(report) then out[#out + 1] = enc.describe(report) end
+    end
+    return out
+end
+
+describe("localisation file encoding", function()
+
+    beforeEach(scan)
+
+    describe("the scan itself", function()
+        -- A check that silently covers nothing is the failure mode here: a
+        -- typo'd directory, a `dir` that returns nothing, and every assertion
+        -- below passes vacuously forever.
+        it("finds the text directory", function()
+            expect(H.loader.text_dir()).toContain("configs/text")
+        end)
+
+        it("finds both shipped languages", function()
+            expect(by_lang.eng).toBeDefined()
+            expect(by_lang.rus).toBeDefined()
+        end)
+
+        it("reads every string table", function()
+            expect(#reports).toBeGreaterThan(0)
+            expect(#by_lang.rus).toBeGreaterThan(0)
+        end)
+
+        -- Without this, an all-ASCII rus directory -- which is what a wholesale
+        -- deletion or a bad checkout looks like -- would pass every encoding
+        -- assertion below.
+        it("sees Cyrillic in the Russian tables", function()
+            local high = 0
+            for _, report in ipairs(by_lang.rus) do high = high + report.high end
+            expect(high).toBeGreaterThan(1000)
+        end)
+    end)
+
+    describe("no file has been re-encoded as UTF-8", function()
+        -- The load-bearing assertion. A cp1251 sentence is essentially never
+        -- valid UTF-8 -- Cyrillic sits in 0xC0..0xFF, so every letter reads as
+        -- a lead byte demanding continuations the next letter does not supply.
+        -- Decoding cleanly as UTF-8 therefore means it was rewritten, and no
+        -- amount of luck produces that by accident.
+        it("has no file that decodes as UTF-8", function()
+            expect(offenders(function(r) return r.utf8 end)).toEqual({})
+        end)
+
+        -- Same damage, caught a second way, because the first check is a
+        -- statistical argument and this one is not: UTF-8 Cyrillic emits
+        -- continuation bytes in 0x80..0xBF, which are undefined or nonsensical
+        -- in cp1251. Two independent signals on the one failure that matters.
+        it("uses only bytes that exist in cp1251", function()
+            expect(offenders(function(r) return #r.illegal > 0 end)).toEqual({})
+        end)
+
+        -- An editor that adds a BOM has already decided the file is Unicode.
+        -- The engine has no BOM handling, so the marker itself lands in the
+        -- first string.
+        it("has no byte-order mark", function()
+            expect(offenders(function(r) return r.bom ~= nil end)).toEqual({})
+        end)
+    end)
+
+    describe("the declaration matches the bytes", function()
+        it("declares windows-1251 wherever it declares anything", function()
+            expect(offenders(function(r)
+                return r.declared ~= nil and r.declared ~= "windows-1251"
+            end)).toEqual({})
+        end)
+
+        -- eng/ui_st_mcm_soulslite.xml has never carried a declaration and is
+        -- pure ASCII, where the encoding cannot be got wrong. The requirement
+        -- is scoped to files that actually contain high bytes rather than
+        -- baselined, so adding one Cyrillic character to that file fails here
+        -- instead of shipping ambiguous.
+        it("declares an encoding on every file with high bytes", function()
+            expect(offenders(function(r)
+                return r.high > 0 and not r.has_declaration
+            end)).toEqual({})
+        end)
+    end)
+
+    describe("the detector itself", function()
+        -- The assertions above are all negative -- they pass on an empty list,
+        -- including a list that is empty because the detector is broken. These
+        -- prove it still fires.
+        it("recognises UTF-8 Cyrillic as UTF-8", function()
+            -- "Режим" in UTF-8: D0 A0 D0 B5 D0 B6 D0 B8 D0 BC
+            local utf8_ru = "\208\160\208\181\208\182\208\184\208\188"
+            expect(enc.is_valid_utf8(utf8_ru)).toBe(true)
+        end)
+
+        it("rejects the same word in cp1251", function()
+            -- "Режим" in cp1251: D0 E5 E6 E8 EC
+            local cp1251_ru = "\208\229\230\232\236"
+            expect(enc.is_valid_utf8(cp1251_ru)).toBe(false)
+        end)
+
+        it("treats pure ASCII as valid UTF-8", function()
+            expect(enc.is_valid_utf8("<string_table>")).toBe(true)
+        end)
+
+        -- 0xB5 and 0xB6 are UTF-8 continuation bytes with no meaning of their
+        -- own in cp1251 -- exactly what a re-encoded file is full of.
+        it("counts UTF-8 continuation bytes as illegal in cp1251", function()
+            expect(enc.CP1251_HIGH[0xB5]).toBeFalsy()
+            expect(enc.CP1251_HIGH[0xB6]).toBeFalsy()
+        end)
+
+        it("accepts the Cyrillic block", function()
+            expect(enc.CP1251_HIGH[0xD0]).toBe(true)     -- Р
+            expect(enc.CP1251_HIGH[0xFF]).toBe(true)     -- я
+        end)
+    end)
+end)
+
+return true

--- a/tests/unit/timed_queue.spec.lua
+++ b/tests/unit/timed_queue.spec.lua
@@ -1,0 +1,238 @@
+-- soulslike_classes.TimedQueue (soulslike_classes.script).
+--
+-- Backs the rolling hit window that feeds death-cause attribution:
+-- soulslike.script:58 creates it with MAX_HIT_POOL_COUNT / MAX_HIT_TIME, and
+-- actor_on_before_hit enqueues into it on every hit taken.
+
+local H = require("harness.init")
+local fakes = H.fakes
+
+describe("TimedQueue", function()
+
+    local TimedQueue
+
+    beforeEach(function()
+        H.boot{ load = { "soulslike_classes" } }
+        TimedQueue = soulslike_classes.TimedQueue
+        fakes.set_time(0)
+    end)
+
+    local function queue(max_count, expiry)
+        return TimedQueue(max_count or 30, expiry or 1000)
+    end
+
+    describe("a newly constructed queue", function()
+        it("has nothing to peek at", function()
+            expect(queue():Peek()).toBeNil()
+        end)
+
+        it("dequeues nil", function()
+            expect(queue():Dequeue()).toBeNil()
+        end)
+
+        it("has no values", function()
+            expect(queue():Values()).toHaveLength(0)
+        end)
+    end)
+
+    describe("Enqueue()", function()
+        describe("given an entry", function()
+            it("stamps it with the current time_global", function()
+                local q = queue()
+                fakes.set_time(4321)
+                q:Enqueue({ id = 1 })
+                expect(q:Peek().__cached_time).toBe(4321)
+            end)
+        end)
+
+        describe("given an entry that already carries __cached_time", function()
+            it("overwrites it, so callers cannot backdate an entry", function()
+                local q = queue()
+                fakes.set_time(777)
+                q:Enqueue({ id = 1, __cached_time = 1 })
+                expect(q:Peek().__cached_time).toBe(777)
+            end)
+        end)
+    end)
+
+    describe("Dequeue()", function()
+        describe("given several entries", function()
+            it("returns them in FIFO order", function()
+                local q = queue()
+                q:Enqueue({ id = 1 }); q:Enqueue({ id = 2 }); q:Enqueue({ id = 3 })
+                expect(q:Dequeue().id).toBe(1)
+                expect(q:Dequeue().id).toBe(2)
+                expect(q:Dequeue().id).toBe(3)
+            end)
+
+            it("returns nil once drained", function()
+                local q = queue()
+                q:Enqueue({ id = 1 })
+                q:Dequeue()
+                expect(q:Dequeue()).toBeNil()
+            end)
+        end)
+    end)
+
+    describe("Peek()", function()
+        describe("given a non-empty queue", function()
+            it("returns the head", function()
+                local q = queue()
+                q:Enqueue({ id = 1 })
+                expect(q:Peek().id).toBe(1)
+            end)
+
+            it("does not consume it", function()
+                local q = queue()
+                q:Enqueue({ id = 1 })
+                q:Peek()
+                expect(q:Peek().id).toBe(1)
+                expect(q:Dequeue().id).toBe(1)
+            end)
+        end)
+    end)
+
+    describe("Values()", function()
+        describe("given several entries", function()
+            it("returns all of them", function()
+                local q = queue()
+                q:Enqueue({ id = 1 }); q:Enqueue({ id = 2 })
+                expect(q:Values()).toHaveLength(2)
+            end)
+        end)
+
+        describe("given a partial dequeue", function()
+            -- The internal first/last index pair leaves a hole at the front,
+            -- and Values() walks with pairs(). This is the shape most at risk.
+            it("omits the dequeued entry", function()
+                local q = queue()
+                q:Enqueue({ id = 1 }); q:Enqueue({ id = 2 }); q:Enqueue({ id = 3 })
+                q:Dequeue()
+
+                local vals = q:Values()
+                expect(vals).toHaveLength(2)
+                for _, v in ipairs(vals) do
+                    expect(v.id).never.toBe(1)
+                end
+            end)
+        end)
+    end)
+
+    describe("Clear()", function()
+        describe("given a populated queue", function()
+            it("empties it", function()
+                local q = queue()
+                q:Enqueue({ id = 1 }); q:Enqueue({ id = 2 })
+                q:Clear()
+                expect(q:Peek()).toBeNil()
+                expect(q:Values()).toHaveLength(0)
+            end)
+
+            it("resets the indices so the queue is reusable", function()
+                local q = queue()
+                q:Enqueue({ id = 1 }); q:Enqueue({ id = 2 })
+                q:Clear()
+                q:Enqueue({ id = 9 })
+                expect(q:Peek().id).toBe(9)
+                expect(q:Values()).toHaveLength(1)
+            end)
+        end)
+    end)
+
+    describe("Invalidate()", function()
+
+        describe("given an entry older than the expiry window", function()
+            it("drops it", function()
+                local q = queue(30, 1000)
+                fakes.set_time(0)
+                q:Enqueue({ id = "old" })
+                fakes.set_time(2000)
+                q:Invalidate()
+                expect(q:Peek()).toBeNil()
+            end)
+        end)
+
+        describe("given an entry inside the window", function()
+            it("keeps it", function()
+                local q = queue(30, 1000)
+                fakes.set_time(0)
+                q:Enqueue({ id = "fresh" })
+                fakes.set_time(500)
+                q:Invalidate()
+                expect(q:Peek().id).toBe("fresh")
+            end)
+        end)
+
+        describe("given an entry exactly on the window boundary", function()
+            it("keeps it, because the comparison is strict", function()
+                -- Condition is `cached + expiry < now`, so equality survives.
+                local q = queue(30, 1000)
+                fakes.set_time(0)
+                q:Enqueue({ id = "edge" })
+                fakes.set_time(1000)
+                q:Invalidate()
+                expect(q:Peek().id).toBe("edge")
+            end)
+        end)
+
+        describe("given expired entries followed by a live one", function()
+            it("stops at the first live entry", function()
+                -- It breaks rather than scanning on, which is correct only
+                -- because entries are enqueued in time order.
+                local q = queue(30, 1000)
+                fakes.set_time(0);    q:Enqueue({ id = "old1" })
+                fakes.set_time(100);  q:Enqueue({ id = "old2" })
+                fakes.set_time(5000); q:Enqueue({ id = "fresh" })
+
+                fakes.set_time(5100)
+                q:Invalidate()
+
+                local vals = q:Values()
+                expect(vals).toHaveLength(1)
+                expect(vals[1].id).toBe("fresh")
+            end)
+        end)
+
+        describe("given every entry has expired", function()
+            it("empties the queue", function()
+                local q = queue(30, 100)
+                fakes.set_time(0)
+                q:Enqueue({ id = 1 }); q:Enqueue({ id = 2 })
+                fakes.set_time(10000)
+                q:Invalidate()
+                expect(q:Values()).toHaveLength(0)
+            end)
+        end)
+
+        describe("given an empty queue", function()
+            it("does not raise", function()
+                local q = queue()
+                expect(function() q:Invalidate() end).never.toThrow()
+            end)
+        end)
+    end)
+
+    describe("max_count", function()
+        -- CHARACTERIZATION, NOT ENDORSEMENT. __init takes max_count and the
+        -- caller passes MAX_HIT_POOL_COUNT = 30 (soulslike.script:56), but no
+        -- method ever reads it -- Enqueue does not evict. In-game the queue is
+        -- bounded only by the 30s expiry window and by Clear() on death, so a
+        -- sustained hit stream grows it without limit.
+        --
+        -- If bounding is later added, these should flip to asserting eviction.
+        describe("given more entries than max_count", function()
+            it("does not evict anything", function()
+                local q = queue(3, 100000)
+                for i = 1, 10 do q:Enqueue({ id = i }) end
+                expect(q:Values()).toHaveLength(10)
+            end)
+
+            it("still records the unused limit", function()
+                local q = queue(3, 100000)
+                expect(q.max_count).toBe(3)
+            end)
+        end)
+    end)
+end)
+
+return true

--- a/tests/unit/transfer_guards.spec.lua
+++ b/tests/unit/transfer_guards.spec.lua
@@ -1,0 +1,194 @@
+-- The two file-local guards TransferItem consults before moving an item:
+-- ignore_list (soulslike_scenarios.script:30-49) and is_equipped (:208-218).
+--
+-- Neither is exported. Both are reached as upvalues of TransferItem, which is
+-- their only caller (:1102, :1109).
+
+local H = require("harness.init")
+local B = H.builders
+
+local MOD_SCRIPTS = {
+    "soulslike_classes", "soulslike", "soulslike_mcm",
+    "soulslike_message_factory", "soulslike_scenarios",
+}
+
+local ignore_list, is_equipped
+
+local function boot()
+    H.boot{ load = MOD_SCRIPTS }
+    H.fakes.set_random_min()
+
+    local transfer = _G.SoulslikeScenarioLogic.TransferItem
+    ignore_list = H.loader.upvalue(transfer, "ignore_list")
+    is_equipped = H.loader.upvalue(transfer, "is_equipped")
+end
+
+describe("ignore_list()", function()
+
+    beforeEach(boot)
+
+    it("is reachable as an upvalue of TransferItem", function()
+        expect(ignore_list).toBeType("function")
+    end)
+
+    describe("given a section in the known ignore table", function()
+        -- Each known section maps to an MCM key whose default is true
+        -- (soulslike_mcm.script:1189), so these are protected out of the box.
+        it("is ignored by default", function()
+            expect(ignore_list("bolt")).toBe(true)
+            expect(ignore_list("device_pda")).toBe(true)
+            expect(ignore_list("itm_actor_backpack")).toBe(true)
+        end)
+
+        it("stops being ignored when its MCM toggle is off", function()
+            H.fakes.set_mcm("ignored_items/ignore_bolt", false)
+            expect(ignore_list("bolt")).toBe(false)
+        end)
+
+        it("does not consult the free-text list for a known section", function()
+            H.fakes.set_mcm("ignored_items/ignore_bolt", false)
+            H.fakes.set_mcm("ignored_items/other", "bolt")
+            -- The table lookup returns early, so the free-text entry never runs.
+            expect(ignore_list("bolt")).toBe(false)
+        end)
+    end)
+
+    describe("given a section only in the free-text 'other' list", function()
+        it("matches a single entry", function()
+            H.fakes.set_mcm("ignored_items/other", "vodka")
+            expect(ignore_list("vodka")).toBe(true)
+        end)
+
+        it("matches an entry in a comma-separated list", function()
+            H.fakes.set_mcm("ignored_items/other", "bread,vodka,kolbasa")
+            expect(ignore_list("vodka")).toBe(true)
+        end)
+
+        it("trims surrounding whitespace", function()
+            H.fakes.set_mcm("ignored_items/other", "bread ,  vodka  , kolbasa")
+            expect(ignore_list("vodka")).toBe(true)
+        end)
+
+        it("skips empty entries from a double comma", function()
+            H.fakes.set_mcm("ignored_items/other", "bread,,vodka")
+            expect(ignore_list("vodka")).toBe(true)
+        end)
+
+        it("tolerates a trailing comma", function()
+            H.fakes.set_mcm("ignored_items/other", "vodka,")
+            expect(ignore_list("vodka")).toBe(true)
+        end)
+
+        -- Whole-string equality, not a substring or prefix test.
+        it("does not match a prefix of an entry", function()
+            H.fakes.set_mcm("ignored_items/other", "vodka")
+            expect(ignore_list("vod")).toBe(false)
+        end)
+
+        it("does not match a section that merely contains an entry", function()
+            H.fakes.set_mcm("ignored_items/other", "medkit")
+            expect(ignore_list("medkit_army")).toBe(false)
+        end)
+    end)
+
+    describe("given an unlisted section", function()
+        it("is not ignored", function()
+            expect(ignore_list("wpn_ak74")).toBe(false)
+        end)
+
+        it("is not ignored when the free-text list is empty", function()
+            H.fakes.set_mcm("ignored_items/other", "")
+            expect(ignore_list("wpn_ak74")).toBe(false)
+        end)
+    end)
+
+    describe("CHARACTERIZATION: the known-section list uses bare section names", function()
+        -- `bandage` and `medkit` are listed bare, but Anomaly ships variants
+        -- (medkit_army, medkit_scientic, bandage_army...). Those take the
+        -- free-text path instead, so the shipped toggle does not cover them.
+        -- Flagged as a config question rather than fixed here: widening the
+        -- table changes which items players keep, which is a balance decision.
+        it("protects the bare section", function()
+            expect(ignore_list("medkit")).toBe(true)
+        end)
+
+        it("does not protect the army variant", function()
+            expect(ignore_list("medkit_army")).toBe(false)
+        end)
+    end)
+end)
+
+describe("is_equipped()", function()
+
+    beforeEach(boot)
+
+    it("is reachable as an upvalue of TransferItem", function()
+        expect(is_equipped).toBeType("function")
+    end)
+
+    describe("given the item occupies a slot", function()
+        it("finds it in the first slot", function()
+            local knife = B.make_item{ section = "wpn_knife" }
+            H.set_actor{ slots = { [1] = knife } }
+            expect(is_equipped(knife:id())).toBe(true)
+        end)
+
+        it("finds it in the helmet slot", function()
+            local helm = B.make_item{ section = "helm_respirator" }
+            H.set_actor{ slots = { [12] = helm } }
+            expect(is_equipped(helm:id())).toBe(true)
+        end)
+
+        -- FIXES: D7. LAST_SLOT is CUSTOM_SLOT_5 = 18 in this build, because
+        -- MORE_INVENTORY_SLOTS is defined (build_config_defines.h:15,
+        -- inventory_space.h:40). A loop stopping at 12 leaves BACKPACK(13) and
+        -- CUSTOM_1..5(14-18) looking unequipped, so those items are wrongly
+        -- eligible for loss when keep_equipped_items_on_death is on.
+        it("finds it in the backpack slot", function()
+            local pack = B.make_item{ section = "itm_actor_backpack" }
+            H.set_actor{ slots = { [13] = pack } }
+            expect(is_equipped(pack:id())).toBe(true)
+        end)
+
+        it("finds it in the last custom slot", function()
+            local item = B.make_item{ section = "device_torch" }
+            H.set_actor{ slots = { [18] = item } }
+            expect(is_equipped(item:id())).toBe(true)
+        end)
+
+        it("finds it in every slot from 1 to 18", function()
+            for slot = 1, 18 do
+                boot()
+                local item = B.make_item{ section = "slot_probe" }
+                H.set_actor{ slots = { [slot] = item } }
+                expect(is_equipped(item:id())).toBe(true)
+            end
+        end)
+    end)
+
+    describe("given the item is not equipped", function()
+        it("returns false", function()
+            local loose = B.make_item{ section = "medkit" }
+            H.set_actor{ slots = { [1] = B.make_item{ section = "wpn_knife" } } }
+            expect(is_equipped(loose:id())).toBe(false)
+        end)
+
+        it("returns false when no slots are filled at all", function()
+            local loose = B.make_item{ section = "medkit" }
+            H.set_actor{ slots = {} }
+            expect(is_equipped(loose:id())).toBe(false)
+        end)
+    end)
+
+    describe("given slot 0", function()
+        -- Slot 0 is NO_ACTIVE_SLOT and the engine rejects it outright
+        -- (Inventory.cpp:658-664), so nothing there can count as equipped.
+        it("never reports the item as equipped", function()
+            local item = B.make_item{ section = "wpn_knife" }
+            H.set_actor{ slots = { [0] = item } }
+            expect(is_equipped(item:id())).toBe(false)
+        end)
+    end)
+end)
+
+return true


### PR DESCRIPTION
Brings the 0.47 and 0.48 gamedata fixes to `main` together with a full LuaJIT
test suite, and the further defects that writing it surfaced.
**21 defects fixed in total**; version `0.46-beta` → `0.49-beta`.

The suite runs the mod's Lua **unmodified** outside the game by reproducing the
X-Ray script loader, the luabind `class` binding, the callback dispatcher,
`CreateTimeEvent` and an alife/inventory world model. Engine behaviour was
verified against the `xray-monolith` source rather than assumed — every
load-bearing constant now carries a `file.cpp:line` citation.

**865 specs passing** (224 harness self-tests, 474 unit, 167 end-to-end);
reachability probe 72/0. The mod ships fully translated in English and Russian.

---

## Previously on this branch (0.47 / 0.48)

Carried in unchanged; listed here because they have not reached `main` yet.

**0.47 — six gamedata fixes**

- `soulslike.script` — the hidden-stash relocation loop referenced an undefined
  `id` and re-teleported the parent instead of its children.
- `soulslike_mcm.script` — `get_ignored_other()` queried
  `ignored_items/ignored_other`, a key that does not exist.
- `soulslike_mcm.script` — added the missing `debug_remove_default_scenario`
  option so its existing getter is reachable from the UI.
- `soulslike_message_factory.script` — `strformat` wrapped the translation *key*
  instead of the translated string in the generic radio-freq line.
- `soulslike_scenario_logic_factory.script` — the weighted scenario roll floored
  each range, leaking fractional weight and letting top-end rolls fall through
  to NoLoss. Replaced with continuous cumulative weights.
- `soulslike_scenario_logic_factory.script` — nil-guarded
  `hit.fatal_hit.draftsman` before `:general_goodwill()`.

**0.48 — cross-level spawn distance**

- Death-to-spawn distance now uses the game-graph global frame when the player
  died on a different level than their spawn. Level-local coordinates share a
  per-level origin, so the old `distance_to_sqr` produced bogus small distances
  across levels and mis-triggered the near-spawn NoLoss scenario.
- Simplified item loss in `TransferItem` to destroy anything that has already
  cleared every protection check, regardless of type.

---

## Defects found and fixed by the new suite

Each has a spec that **failed first**, then passed once the fix landed. Each now
has its own issue with the root cause and the fix. Ordered by what a player would
actually notice.

Fixes #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18.

### #8 — a quarter of the ambush table could never spawn

`SpawnAmbush`'s bucket walk accumulated a *floored* running max out of 100
slots, so truncation compounded and the final bucket ended at **96** while the
roll was `math.random(1,100)`. Rolls 97-100 matched nothing: the ambush silently
did not happen, roughly 4% of the time, with no debug tip.

The same truncation gave any bucket under one whole slot `min > max`. At shipped
defaults that was **every rare mutant** — bloodsucker, burer, chimera,
controller and both weak variants could never spawn, and their configured
weights were decorative.

Replaced with the continuous cumulative walk 0.47 already introduced for
scenario selection, so the two now match.

### #9 — the free-text ignore list has never worked

It declared `val = ''`, reading MCM's `val` as an initial value when it is the
stored-value **type code** (0 = string, 1 = boolean, 2 = float). Not a
recognised code, so the input could not round-trip through `axr_options.ltx` and
`get_ignored_other()` always saw its `''` default. Whatever a player typed there
protected nothing.

Note this survived the 0.47 fix to the same option's *key* — the box had two
independent bugs stacked.

### #10 — tracked ambushers were write-only, and grew forever

`npc_on_net_spawn`, the only consumer of `tracked_ambushers`, had its
registration commented out and was referenced nowhere. No ambusher ever took its
stance, and the table grew in **every save forever** — it was not in the
migration schema either, so old saves were never repaired.

Re-registered, added to the schema, entries consumed on spawn. Mutants are
consumed without being posed (the stance setters are stalker-only) and squad
members skip the pose rather than building a vector from nils.

### #11 — two crashes on the death path

Unguarded `vector():set(nil, nil, nil)` in `RespawnActor` and in `create_new`'s
distance fallback, reachable whenever a save has no recorded spawn point.

Per the engine source this is **not** a catchable Lua error: `NDEBUG` defines
`LUABIND_NO_ERROR_CHECKING`, compiling out the no-matching-overload guard
(`config.hpp:81-91`), so execution runs off the end of the overload table
(`class_rep.cpp:688`). An access violation.

Both now guarded. `create_new` degrades to "far from spawn" rather than silently
gifting a no-loss death on the strength of missing data.

### #12 — equipped items in slots 13-18 were lost anyway

`is_equipped` scanned slots 1-12, but `LAST_SLOT` is `CUSTOM_SLOT_5` = **18** in
this build, since `MORE_INVENTORY_SLOTS` is defined. Items in BACKPACK(13) and
CUSTOM_1..5(14-18) looked unequipped and were eligible for loss even with
`keep_equipped_items_on_death` enabled.

### #13 — negative rank and reputation fell without bound

`ApplyRankLoss` / `ApplyReputationLoss` used `math.abs`, making the deduction
positive regardless of sign, so a **negative** value was driven further negative
every death. Nothing in the engine clamps it back.

Rank now floors and clamps at 0. Reputation decays *toward* zero instead,
because it legitimately runs negative for a hated actor and clamping there would
wipe out earned standing in a single death.

### #14 — friendly-fire deaths lost their rescuer

The friendly-fire selection arm set `rescuer = hit.draftsman`, but
`compute_fatal_hit_info` builds each aggregate as
`{draftsman_type, power, fatal_hit}` and never puts `draftsman` on it. Always
nil, so a death at a neutral or friendly stalker's hands fell back to the wakeup
message's "it's a mystery" path even though the mod knew exactly who was
standing over the body.

### #15 — the veteran and sniper ambush toggles did nothing

`stalker_spawn_type` had `Advanced = Veteran = Sniper = 2`, and the filter tests
`== Advanced` first, so enabling any one of the three admitted all three.

### #16 — the indoor rescue message was unreachable

`SetIsInDoor` / `SetIsInWater` wrote only the top-level `logic_state` fields,
but `SendWakeupMessage` hands `story` to the message factory as its params, and
the factory keys the indoor rescue text off `params.player_died_indoor`. `story`
declared both keys and received neither.

### #17 — shared-state mutation and a skewed gate roll

`table.insert` put *references* to the module-scope spawn descriptors into the
working list, so writing `value.min`/`value.max` mutated tables meant to be
constant. Separately, the ambush gate roll was `math.random(0, 100)` — 101
discrete outcomes — compared against `chance * 100`, so a configured 0.25
actually meant 25/101.

### #18 — two hardcore options could never be translated

`lose_all_items_on_death` and its description carried English sentences in
`text` instead of string ids. MCM passes unknown input through
`game.translate_string` unchanged, so both rendered correctly in English and
stayed English in every other language.

Both already had English and Russian translations sitting unused in
`ui_st_mcm_soulslite.xml`, which is why the same two ids also reported as
orphaned strings. One mistake, counted twice. The checkbox now derives its key
from its path. The description names the string id, because `mcm_options.spec`
requires every `desc` and `title` node to declare a `text` and no citation says
MCM derives one.

---

## Localisation

**Russian is complete.** The 20 remaining untranslated strings are done: five
debug options, five PDA names, the free-text ignore list, and the four
keep-chance sliders with their tooltips. Terms match what the file already
used — броня, шлем, оружие, артефакт, КПК — and the slider tooltips quote the
Russian option labels they refer to.

This is a machine translation, not a native speaker's. It has not been reviewed
by a Russian player. `Армейский КПК` for "Milspec PDA" is the one call worth a
second opinion, since it translates the sense rather than transliterating.

**The Russian tables are windows-1251, and stay that way.** The engine hands
the bytes straight to cp1251 font tables, so a file re-saved as UTF-8 still
parses, every string id still resolves, and every label spec stays green while
every Russian string renders as mojibake. That already happened once here,
across ten commits, caused by an editor guessing the encoding on open.

So these files were never opened in an editor. They were edited through a
cp1251 encoder with `ExceptionFallback`, which raises on any character it
cannot map rather than writing a silent `?`. Checked afterwards on the bytes
git actually stores: not valid UTF-8, 8625 high bytes with none undefined in
cp1251, no BOM, declaration unchanged.

**Seven orphaned strings deleted.** Each belonged to an option that is
commented out with its getter stubbed to a constant. A string with nothing
pointing at it cannot be told apart from half a rename by reading the file, so
it goes; git holds the text if the options return. Restoring those options now
means restoring their labels in the same change.

---

## Test infrastructure

**Runner.** Spec files are discovered from `self/`, `unit/` and `e2e/`, so a new
spec needs no registration. Adds `--file <substr>` and `-t <substr>` filters
(both skip the self-test gate — they are the "run just this one thing" switches)
and a third `e2e` suite. A filter matching nothing reports `EMPTY` and exits
non-zero rather than reading as a green run of zero tests.

**Harness fidelity.** Four places where it modelled the engine wrongly were
corrected against source. Each would otherwise have produced permanently green
specs:

- `alife_create_item` returned a *client* object, so `note_message_data` came
  back keyed by a **function** — silently unlookupable.
- `iterate_inventory` stopped only on literal `true`; the engine tests with
  `lua_toboolean`, so any truthy value stops it. This is the *opposite* of
  `CreateTimeEvent`, which re-queues on anything but `true`.
- `set_character_rank` / `_reputation` now truncate toward zero and stay
  unclamped, matching `static_cast<int>`.
- `give_money` no longer clamps at zero — the engine underflows u32, and a
  clamping fake would have hidden that.

Also fixes a cross-spec leak: `class "X"` writes a true global that nothing
removed, so a spec which never loaded `soulslike_scenarios` could still find a
class an earlier spec left behind and pass for the wrong reason.

**No test may be switched off by editing data.** The localisation checks used
to filter their findings through four tables of "known broken" string ids in
`harness/mcm_labels.lua`. Adding an id to one of those tables turned a failing
assertion into a passing one, which inverts what a test is for. The tables then
needed their own staleness guard, so the mechanism grew a mechanism.

They also failed at the one job they had. Four MCM labels rendered as raw
string ids in the shipped settings menu while `run.bat` reported PASS, because
someone had baselined them.

All four tables are gone, along with the `new`/`known` split that fed them.
Every localisation assertion now expects an empty list, and the only way to
reach green is to fix the localisation. `CLAUDE.md`, `tests/CLAUDE.md` and
`tests/README.md` taught this pattern and told the next contributor to use it;
all three now say the opposite, with the reason.

Deleting the tables gave up the one useful thing they did: they proved the
analysis was still looking. With every list empty, all five assertions would
pass just as well if `analyse()` had quietly stopped working. So six new specs
feed a deliberately broken option tree through it and check each category still
reports.

**Coverage.** `IsItemLossAllowed` as a decision table with exact per-case RNG
budgets; the four economy deductions; `SpawnAmbush`'s bucket math; the 14-arm
selection tree (asserting *which* finder each arm consulted, since several arms
differ only by that); the save/load round trip across a simulated `ChangeLevel`;
six end-to-end journeys; and a structural walk of MCM's 930-line option tree
that cross-references it against the keys the getters actually read — which is
what found #9 and two dead getters.

---

## Verification

```
tests\run.bat                       # 865 specs, exit 0
tests\locals.bat                    # localisation, strict: nothing broken
tests\tools\luajit.exe probe.lua    # 72 reachable, 0 unreachable
```

**Not yet done: this has not been run in-game.** None of the above runs
Anomaly. A green suite is evidence about logic, not about the game.

Three things are worth checking before merge:

1. Die to a monster carrying bait, then to a stalker. Confirm ambushes appear.
   #8 changes the ambush spawn distribution.
2. Type a section into the free-text ignore list, then die. Confirm the item
   survives. #9 turns a setting that never worked into one that does.
3. Open the settings menu with the Russian localisation active. Confirm the
   labels read as Russian and not as raw string ids or mojibake.

Also worth loading a pre-change save to confirm `load_state` still restores.



