### PR TITLE
Re-enable RF Detector and Hidden Stash death scenarios (no-backpack only)

### DIFF
--- a/gamedata/configs/text/eng/ui_st_mcm_soulslite.xml
+++ b/gamedata/configs/text/eng/ui_st_mcm_soulslite.xml
@@ -132,6 +132,30 @@ You can tweak this scalar to reflect your desired level of item condition loss. 
     <string id="ui_mcm_soulslike_scenarios_description">
         <text>Soulslike scenarios are dynamic by nature.  Respawn events occur based on who killed you, how you were killed, where, how close to your spawn you are when you died, whether you are inside or outside, just to name a few.  These settings exist to allow you to customize the ways you want to try and recover your gear.  The default scenario's that always exist are that you may end up having all of your items on you on respawn (again, based on events), or you may find that your items are in a backpack on the ground where your body was found.  The options below are in addition to those and weight can be changed to make them more or less frequent.</text>
      </string>
+    <string id="ui_mcm_soulslike_scenarios_enable_rf_detector_scenario">
+        <text>Enable the RF Detector scenario</text>
+    </string>
+    <string id="ui_mcm_soulslike_scenarios_enable_rf_detector_scenario_desc">
+        <text>When you die without a backpack, your gear may be hidden in a stash instead of dropped where you died. You will be given a note with a radio frequency to help you find it. Only applies when you have no backpack equipped.</text>
+    </string>
+    <string id="ui_mcm_soulslike_scenarios_rf_detector_scenario_weight">
+        <text>RF Detector scenario weight</text>
+    </string>
+    <string id="ui_mcm_soulslike_scenarios_rf_detector_scenario_weight_desc">
+        <text>How often the RF Detector scenario is chosen relative to the other scenarios that can happen when you have no backpack.</text>
+    </string>
+    <string id="ui_mcm_soulslike_scenarios_enable_hidden_stash_scenario">
+        <text>Enable the Hidden Stash scenario</text>
+    </string>
+    <string id="ui_mcm_soulslike_scenarios_enable_hidden_stash_scenario_desc">
+        <text>When you die without a backpack, your gear may be hidden in a stash instead of dropped where you died. The stash location will be marked on your PDA. Only applies when you have no backpack equipped.</text>
+    </string>
+    <string id="ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight">
+        <text>Hidden Stash scenario weight</text>
+    </string>
+    <string id="ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight_desc">
+        <text>How often the Hidden Stash scenario is chosen relative to the other scenarios that can happen when you have no backpack.</text>
+    </string>
     <string id="ui_mcm_soulslike_scenarios_looter_npcs_marked">
         <text>Mark looting NPCs on the PDA</text>
     </string>
@@ -233,7 +257,13 @@ You can tweak this scalar to reflect your desired level of item condition loss. 
     </string>  
     <string id="ui_mcm_soulslike_debug_enable_tips">
         <text>Show PDA Messages</text>
-    </string>    
+    </string>
+    <string id="ui_mcm_soulslike_debug_debug_hidden_stashes">
+        <text>Debug Hidden Stashes</text>
+    </string>
+    <string id="ui_mcm_soulslike_debug_debug_hidden_stashes_desc">
+        <text>Marks every RF Detector/Hidden Stash location on the PDA, even ones you have not been told about yet.</text>
+    </string>
     <string id="ui_mcm_soulslike_debug_debug_item_loss">
         <text>Debug Item Loss</text>
     </string>
@@ -245,6 +275,12 @@ You can tweak this scalar to reflect your desired level of item condition loss. 
     </string>
     <string id="ui_mcm_soulslike_debug_debug_the_default_scenario">
         <text>Debug Default Loss Scenario</text>
+    </string>
+    <string id="ui_mcm_soulslike_debug_debug_the_rf_scenario">
+        <text>Debug RF Detector Scenario</text>
+    </string>
+    <string id="ui_mcm_soulslike_debug_debug_the_hidden_stash_scenario">
+        <text>Debug Hidden Stash Scenario</text>
     </string>
     <string id="ui_mcm_soulslike_debug_debug_squad_spawns">
         <text>Debug Squad Spawns</text>

--- a/gamedata/configs/text/rus/ui_st_mcm_soulslite.xml
+++ b/gamedata/configs/text/rus/ui_st_mcm_soulslite.xml
@@ -123,7 +123,30 @@
     <string id="ui_mcm_soulslike_scenarios_description">
         <text>Сценарии мода по своей натуре динамичны. Обстоятельства вашего возрождения зависят от того, кто вас убил, как вас убили, где и насколько далеко от вашего спавна вы погибли, были ли вы в тот момент во внутренней локации, и многих других факторов. Эти опции позволят вам настроить как вам придётся доставать ваши вещи. Сценарий по умолчанию оставляет все предметы с вами (в зависимости от обстоятельств), но может быть вам придётся идти к месту смерти, где будет рюкзак с вашим снаряжением. Опции ниже будут добавлены к этим двум, и их вероятность настраиваема.</text>
      </string>
-     <string id="ui_mcm_soulslike_scenarios_looter_npcs_marked">
+    <string id="ui_mcm_soulslike_scenarios_enable_rf_detector_scenario">
+        <text>Включить сценарий РЧ-детектора</text>
+    </string>
+    <string id="ui_mcm_soulslike_scenarios_enable_rf_detector_scenario_desc">
+        <text>Если вы умираете без рюкзака, ваше снаряжение может быть спрятано в тайнике вместо того, чтобы остаться на месте смерти. Вам дадут записку с радиочастотой, чтобы помочь его найти. Действует только когда у вас нет рюкзака.</text>
+    </string>
+    <string id="ui_mcm_soulslike_scenarios_rf_detector_scenario_weight">
+        <text>Вес сценария РЧ-детектора</text>
+    </string>
+    <string id="ui_mcm_soulslike_scenarios_rf_detector_scenario_weight_desc">
+        <text>Как часто выбирается сценарий РЧ-детектора относительно других сценариев, которые могут произойти, если у вас нет рюкзака.</text>
+    </string>
+    <string id="ui_mcm_soulslike_scenarios_enable_hidden_stash_scenario">
+        <text>Включить сценарий скрытого тайника</text>
+    </string>
+    <string id="ui_mcm_soulslike_scenarios_enable_hidden_stash_scenario_desc">
+        <text>Если вы умираете без рюкзака, ваше снаряжение может быть спрятано в тайнике вместо того, чтобы остаться на месте смерти. Место тайника будет отмечено на КПК. Действует только когда у вас нет рюкзака.</text>
+    </string>
+    <string id="ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight">
+        <text>Вес сценария скрытого тайника</text>
+    </string>
+    <string id="ui_mcm_soulslike_scenarios_hidden_stash_scenario_weight_desc">
+        <text>Как часто выбирается сценарий скрытого тайника относительно других сценариев, которые могут произойти, если у вас нет рюкзака.</text>
+    </string>     <string id="ui_mcm_soulslike_scenarios_looter_npcs_marked">
         <text>Помечать мародёров на КПК</text>
     </string>
     <string id="ui_mcm_soulslike_scenarios_looter_npcs_marked_desc">
@@ -224,7 +247,12 @@
     <string id="ui_mcm_soulslike_debug_enable_tips">
         <text>Показывать сообщения КПК</text>
     </string>    
-    <string id="ui_mcm_soulslike_debug_debug_item_loss">
+    <string id="ui_mcm_soulslike_debug_debug_hidden_stashes">
+        <text>Отладка скрытых тайников</text>
+    </string>
+    <string id="ui_mcm_soulslike_debug_debug_hidden_stashes_desc">
+        <text>Отмечает на КПК все места РЧ-детектора/скрытых тайников, даже те, о которых вам ещё не сообщили.</text>
+    </string>    <string id="ui_mcm_soulslike_debug_debug_item_loss">
         <text>Отладка потери предметов</text>
     </string>
     <string id="ui_mcm_soulslike_debug_debug_the_tarkov_looter">
@@ -236,7 +264,12 @@
     <string id="ui_mcm_soulslike_debug_debug_the_default_scenario">
         <text>Отладка сценария по умолчанию</text>
     </string>
-    <string id="ui_mcm_soulslike_items_outfit_loss_chance">
+    <string id="ui_mcm_soulslike_debug_debug_the_rf_scenario">
+        <text>Отладка сценария РЧ-детектора</text>
+    </string>
+    <string id="ui_mcm_soulslike_debug_debug_the_hidden_stash_scenario">
+        <text>Отладка сценария скрытого тайника</text>
+    </string>    <string id="ui_mcm_soulslike_items_outfit_loss_chance">
         <text>Шанс потери брони</text>
     </string>
     <string id="ui_mcm_soulslike_items_outfit_loss_chance_desc">

--- a/gamedata/scripts/soulslike.script
+++ b/gamedata/scripts/soulslike.script
@@ -828,11 +828,18 @@ local function on_game_load()
             elseif not se_box then 
                 debug("Unable to find box id "..tostring(box_id))
             else
+                -- This is a defensive fallback for saves made before
+                -- HiddenStashSoulslikeScenarioLogic:CreateStash started
+                -- spawning already-correct, already-online stashes; a freshly
+                -- created stash never needs it. Online the hidden stash
+                -- itself, not the linked box (se_box) -- the box is a
+                -- pre-existing treasure stash, not the item container the
+                -- player is trying to open.
                 debug("Moving hidden stash"..tostring(value.stash_id))
                 sim:teleport_object(value.stash_id, se_box.m_game_vertex_id, se_box.m_level_vertex_id, se_box.position)
                 debug("Setting hidden stash online")
-                if not se_box.online then
-                    se_box:switch_online()
+                if not se_hidden_stash.online then
+                    sim:set_switch_online(value.stash_id, true)
                 end
                 
                 for i=1,65534 do

--- a/gamedata/scripts/soulslike.script
+++ b/gamedata/scripts/soulslike.script
@@ -713,7 +713,6 @@ local function physic_object_on_use_callback(box, who)
     local id = box:id()
     local stash_data = data.hidden_stashes[id]
     local stash_id = stash_data.stash_id
-    local se_obj = alife_object(stash_id)
 	local stash = level.object_by_id(stash_id)
     
     if not stash then        
@@ -727,12 +726,12 @@ local function physic_object_on_use_callback(box, who)
 
     if not sim then return end
 
-    if se_obj and not se_obj.online then 
-        se_obj:switch_online()
-    end
-    
+    -- Do not call se_obj:switch_online() -- se_invbox (the hidden_box's own
+    -- class, se_item.script:382-402) has no such method, unlike se_item/
+    -- se_monster/se_stalker. alife():set_switch_online is the only
+    -- confirmed-safe API for this (alife_simulator_script.cpp:481-482).
     sim:set_switch_online(stash_id,true)
-    sim:set_switch_offline(stash_id,false)  
+    sim:set_switch_offline(stash_id,false)
     
     try_send_inventory_examined_message(stash_id)
 
@@ -828,13 +827,11 @@ local function on_game_load()
             elseif not se_box then 
                 debug("Unable to find box id "..tostring(box_id))
             else
-                -- This is a defensive fallback for saves made before
-                -- HiddenStashSoulslikeScenarioLogic:CreateStash started
-                -- spawning already-correct, already-online stashes; a freshly
-                -- created stash never needs it. Online the hidden stash
-                -- itself, not the linked box (se_box) -- the box is a
-                -- pre-existing treasure stash, not the item container the
-                -- player is trying to open.
+                -- Defensive fallback in case the stash isn't already at the
+                -- box's position and online. Online the hidden stash itself,
+                -- not the linked box (se_box) -- the box is a pre-existing
+                -- treasure stash, not the item container the player is
+                -- trying to open.
                 debug("Moving hidden stash"..tostring(value.stash_id))
                 sim:teleport_object(value.stash_id, se_box.m_game_vertex_id, se_box.m_level_vertex_id, se_box.position)
                 debug("Setting hidden stash online")
@@ -849,7 +846,7 @@ local function on_game_load()
                         sim:teleport_object(i, se_box.m_game_vertex_id, se_box.m_level_vertex_id, se_box.position)
                         if not se_obj.online then
                             debug("Setting "..se_obj.section.." online")
-                            se_obj:switch_online()
+                            sim:set_switch_online(i, true)
                         end
                     end
                 end

--- a/gamedata/scripts/soulslike_mcm.script
+++ b/gamedata/scripts/soulslike_mcm.script
@@ -651,24 +651,36 @@ function on_mcm_load()
                 text = "ui_mcm_soulslike_scenarios_description",
                 clr = {255, 255 ,255 ,255},
             },
-            -- {
-            --     id = "rf_detector_scenario_weight",
-            --     type = "track",
-            --     val = 2,
-            --     min = 0.0,
-            --     max = 1.0,
-            --     step = 0.01,
-            --     def = 0.10
-            -- },
-            -- {
-            --     id = "hidden_stash_scenario_weight",
-            --     type = "track",
-            --     val = 2,
-            --     min = 0.0,
-            --     max = 1.0,
-            --     step = 0.01,
-            --     def = 0.10
-            -- },
+            {
+                id = "enable_rf_detector_scenario",
+                type = "check",
+                val = 1,
+                def = true
+            },
+            {
+                id = "rf_detector_scenario_weight",
+                type = "track",
+                val = 2,
+                min = 0.0,
+                max = 1.0,
+                step = 0.01,
+                def = 0.10
+            },
+            {
+                id = "enable_hidden_stash_scenario",
+                type = "check",
+                val = 1,
+                def = true
+            },
+            {
+                id = "hidden_stash_scenario_weight",
+                type = "track",
+                val = 2,
+                min = 0.0,
+                max = 1.0,
+                step = 0.01,
+                def = 0.10
+            },
             {
                 id = "looter_npcs_marked",
                 type = "check",
@@ -873,12 +885,12 @@ function on_mcm_load()
                 val = 1,
                 def = false
             },
-            -- {
-            --     id = "debug_hidden_stashes",
-            --     type = "check",
-            --     val = 1,
-            --     def = false
-            -- },
+            {
+                id = "debug_hidden_stashes",
+                type = "check",
+                val = 1,
+                def = false
+            },
             {
                 id = "debug_squad_spawns",
                 type = "check",
@@ -915,18 +927,18 @@ function on_mcm_load()
                 val = 1,
                 def = false
             },
-            -- {
-            --     id = "debug_the_rf_scenario",
-            --     type = "check",
-            --     val = 1,
-            --     def = false
-            -- },
-            -- {
-            --     id = "debug_the_hidden_stash_scenario",
-            --     type = "check",
-            --     val = 1,
-            --     def = false
-            -- },
+            {
+                id = "debug_the_rf_scenario",
+                type = "check",
+                val = 1,
+                def = false
+            },
+            {
+                id = "debug_the_hidden_stash_scenario",
+                type = "check",
+                val = 1,
+                def = false
+            },
             {
                 id = "debug_always_spawn_ambush",
                 type = "check",
@@ -964,12 +976,18 @@ function are_looter_npcs_marked()
 end 
 
 function rf_detector_scenario_weight()
-    return  0.0 --get_config("scenarios/rf_detector_scenario_weight", 0.10)
-end 
+    if not get_config("scenarios/enable_rf_detector_scenario", true) then
+        return 0.0
+    end
+    return get_config("scenarios/rf_detector_scenario_weight", 0.10)
+end
 
 function hidden_stash_scenario_weight()
-    return 0.0 --get_config("scenarios/hidden_stash_scenario_weight", 0.10)
-end 
+    if not get_config("scenarios/enable_hidden_stash_scenario", true) then
+        return 0.0
+    end
+    return get_config("scenarios/hidden_stash_scenario_weight", 0.10)
+end
 
 function scattered_stash_scenario_weight()
     return  0.0 --get_config("scenarios/scattered_stash_scenario_weight", 0.02)
@@ -1141,12 +1159,12 @@ function debug_the_default_scenario()
 end 
 
 function debug_the_rf_scenario()
-    return false -- is_debug_enabled() and get_config("debug/debug_the_rf_scenario", false)
-end 
+    return is_debug_enabled() and get_config("debug/debug_the_rf_scenario", false)
+end
 
 function debug_the_hidden_stash_scenario()
-    return false -- is_debug_enabled() and get_config("debug/debug_the_hidden_stash_scenario", false)
-end 
+    return is_debug_enabled() and get_config("debug/debug_the_hidden_stash_scenario", false)
+end
 
 function debug_always_spawn_ambush()
     return is_debug_enabled() and get_config("debug/debug_always_spawn_ambush", false)

--- a/gamedata/scripts/soulslike_scenario_logic_factory.script
+++ b/gamedata/scripts/soulslike_scenario_logic_factory.script
@@ -250,10 +250,10 @@ function create_new(hits)
 
         if has_backpack then
             table.insert(available_scenarios, {id = soulslike.SCENARIOS.Default, min = 0, max = 0, weight = 1.0})
-        end 
-
-        -- table.insert(available_scenarios, {id = soulslike.SCENARIOS.RFDetectorStash, min = 0, max = 0, weight = soulslike_mcm.rf_detector_scenario_weight()})
-        -- table.insert(available_scenarios, {id = soulslike.SCENARIOS.HiddenStash, min = 0, max = 0, weight = soulslike_mcm.hidden_stash_scenario_weight()})
+        else
+            table.insert(available_scenarios, {id = soulslike.SCENARIOS.RFDetectorStash, min = 0, max = 0, weight = soulslike_mcm.rf_detector_scenario_weight()})
+            table.insert(available_scenarios, {id = soulslike.SCENARIOS.HiddenStash, min = 0, max = 0, weight = soulslike_mcm.hidden_stash_scenario_weight()})
+        end
     elseif hit and
            hit.draftsman_type == soulslike.entity_type.Stalker and
            hit.fatal_hit and
@@ -284,11 +284,11 @@ function create_new(hits)
 
         if has_backpack then
             table.insert(available_scenarios, {id = soulslike.SCENARIOS.Default, min = 0, max = 0, weight = 1.0})
+        else
+            table.insert(available_scenarios, {id = soulslike.SCENARIOS.RFDetectorStash, min = 0, max = 0, weight = soulslike_mcm.rf_detector_scenario_weight()})
+            table.insert(available_scenarios, {id = soulslike.SCENARIOS.HiddenStash, min = 0, max = 0, weight = soulslike_mcm.hidden_stash_scenario_weight()})
         end
-
-        -- table.insert(available_scenarios, {id = soulslike.SCENARIOS.RFDetectorStash, min = 0, max = 0, weight = soulslike_mcm.rf_detector_scenario_weight()})
-        -- table.insert(available_scenarios, {id = soulslike.SCENARIOS.HiddenStash, min = 0, max = 0, weight = soulslike_mcm.hidden_stash_scenario_weight()})
-    elseif hit and 
+    elseif hit and
            hit.draftsman_type == soulslike.entity_type.Monster then
         soulslike.debug("Mutant killed the player.")
 
@@ -300,11 +300,11 @@ function create_new(hits)
 
         if has_backpack then
             table.insert(available_scenarios, {id = soulslike.SCENARIOS.Default, min = 0, max = 0, weight = 1.0})
+        else
+            table.insert(available_scenarios, {id = soulslike.SCENARIOS.RFDetectorStash, min = 0, max = 0, weight = soulslike_mcm.rf_detector_scenario_weight()})
+            table.insert(available_scenarios, {id = soulslike.SCENARIOS.HiddenStash, min = 0, max = 0, weight = soulslike_mcm.hidden_stash_scenario_weight()})
         end
-
-        -- table.insert(available_scenarios, {id = soulslike.SCENARIOS.RFDetectorStash, min = 0, max = 0, weight = soulslike_mcm.rf_detector_scenario_weight()})
-        -- table.insert(available_scenarios, {id = soulslike.SCENARIOS.HiddenStash, min = 0, max = 0, weight = soulslike_mcm.hidden_stash_scenario_weight()})
-    elseif hit and 
+    elseif hit and
            hit.draftsman_type == soulslike.entity_type.Anomaly then
         soulslike.debug("Player died to an anomaly.")
 
@@ -317,10 +317,10 @@ function create_new(hits)
         if has_backpack then
             table.insert(available_scenarios, {id = soulslike.SCENARIOS.Default, min = 0, max = 0, weight = 1.0})
         else
-            -- table.insert(available_scenarios, {id = soulslike.SCENARIOS.RFDetectorStash, min = 0, max = 0, weight = soulslike_mcm.rf_detector_scenario_weight()})
-            -- table.insert(available_scenarios, {id = soulslike.SCENARIOS.HiddenStash, min = 0, max = 0, weight = soulslike_mcm.hidden_stash_scenario_weight()})
+            table.insert(available_scenarios, {id = soulslike.SCENARIOS.RFDetectorStash, min = 0, max = 0, weight = soulslike_mcm.rf_detector_scenario_weight()})
+            table.insert(available_scenarios, {id = soulslike.SCENARIOS.HiddenStash, min = 0, max = 0, weight = soulslike_mcm.hidden_stash_scenario_weight()})
         end
-    elseif hit and 
+    elseif hit and
            hit.draftsman_type == soulslike.entity_type.Other then
         soulslike.debug("Player died to damage over time of some sort.")
 
@@ -333,8 +333,8 @@ function create_new(hits)
         if has_backpack then
             table.insert(available_scenarios, {id = soulslike.SCENARIOS.Default, min = 0, max = 0, weight = 1.0})
         else
-            -- table.insert(available_scenarios, {id = soulslike.SCENARIOS.RFDetectorStash, min = 0, max = 0, weight = soulslike_mcm.rf_detector_scenario_weight()})
-            -- table.insert(available_scenarios, {id = soulslike.SCENARIOS.HiddenStash, min = 0, max = 0, weight = soulslike_mcm.hidden_stash_scenario_weight()})
+            table.insert(available_scenarios, {id = soulslike.SCENARIOS.RFDetectorStash, min = 0, max = 0, weight = soulslike_mcm.rf_detector_scenario_weight()})
+            table.insert(available_scenarios, {id = soulslike.SCENARIOS.HiddenStash, min = 0, max = 0, weight = soulslike_mcm.hidden_stash_scenario_weight()})
         end
     else
         soulslike.warn("I have no idea how the player died.")
@@ -348,8 +348,8 @@ function create_new(hits)
         if has_backpack then
             table.insert(available_scenarios, {id = soulslike.SCENARIOS.Default, min = 0, max = 0, weight = 1.0})
         else
-            -- table.insert(available_scenarios, {id = soulslike.SCENARIOS.RFDetectorStash, min = 0, max = 0, weight = soulslike_mcm.rf_detector_scenario_weight()})
-            -- table.insert(available_scenarios, {id = soulslike.SCENARIOS.HiddenStash, min = 0, max = 0, weight = soulslike_mcm.hidden_stash_scenario_weight()})
+            table.insert(available_scenarios, {id = soulslike.SCENARIOS.RFDetectorStash, min = 0, max = 0, weight = soulslike_mcm.rf_detector_scenario_weight()})
+            table.insert(available_scenarios, {id = soulslike.SCENARIOS.HiddenStash, min = 0, max = 0, weight = soulslike_mcm.hidden_stash_scenario_weight()})
         end
     end
 

--- a/gamedata/scripts/soulslike_scenarios.script
+++ b/gamedata/scripts/soulslike_scenarios.script
@@ -1510,27 +1510,42 @@ function HiddenStashSoulslikeScenarioLogic:CreateStash()
     -- If we could not grab a ransom stash, we need to return nil so we don't transfer anything
     if not id then return nil end
 
-    soulslike.debug("Random stash found: "..tostring(id))    
+    soulslike.debug("Random stash found: "..tostring(id))
 
-    local actor = db.actor
-    local se_stash = alife_create("hidden_box", actor:position(), actor:level_vertex_id(), actor:game_vertex_id())
+    local se_treasure = alife_object(id)
+
+    -- If we could not grab a ransom stash, we need to return nil so we don't transfer anything
+    if not se_treasure then return nil end
+
+    local se_stash = alife_create("hidden_box", se_treasure.position, se_treasure.m_level_vertex_id, se_treasure.m_game_vertex_id)
 
     if (se_stash) then
+        local sim = alife()
+
+        if sim then
+            -- force strictly online, same as RFDetectorSoulslikeScenarioLogic.
+            -- The PDA marker below points at the treasure location, so the
+            -- stash has to actually live there, online, or the marker sends
+            -- the player somewhere with no items to find.
+            sim:set_switch_online(se_stash.id,true)
+            sim:set_switch_offline(se_stash.id,false)
+        end
+
         self.game_state.created_stashes[se_stash.id] = {
             lost_items = {},
             examine = false
-        } 
+        }
 
         if not self.game_state.hidden_stashes then
             self.game_state.hidden_stashes = {}
         end
-    
+
         self.logic_state.hidden_stash_id = se_stash.id
         self.logic_state.treasure_stash_id = id
-    
+
         self.game_state.hidden_stashes[id] = {
             stash_id = se_stash.id,
-        } 
+        }
     end
 
     return se_stash

--- a/gamedata/scripts/soulslike_scenarios.script
+++ b/gamedata/scripts/soulslike_scenarios.script
@@ -1527,6 +1527,18 @@ function HiddenStashSoulslikeScenarioLogic:CreateStash()
             -- The PDA marker below points at the treasure location, so the
             -- stash has to actually live there, online, or the marker sends
             -- the player somewhere with no items to find.
+            --
+            -- set_switch_offline(id, false) is what actually pins this: it
+            -- makes can_switch_offline() false, so the engine's own distance
+            -- check never applies again -- the object force-onlines on the
+            -- next alife tick and is never switched back offline, regardless
+            -- of how far the player travels or how many levels change
+            -- (CSE_ALifeDynamicObject::try_switch_online/try_switch_offline,
+            -- alife_dynamic_object.cpp:130-181, xray-monolith). The pin
+            -- itself is a serialized flag on the object (m_flags,
+            -- xrServer_Objects_ALife.cpp:427-476) and survives every level
+            -- change; only its live client-object state resets, which the
+            -- next switch tick immediately restores.
             sim:set_switch_online(se_stash.id,true)
             sim:set_switch_offline(se_stash.id,false)
         end

--- a/tests/README.md
+++ b/tests/README.md
@@ -433,10 +433,13 @@ loot scalar at 1.0 where every other no-loss arm sets 0 · the ignore list
 matches bare `medkit`/`bandage` while Anomaly ships variants (a balance
 decision, not a code bug).
 
-Currently marked dead: the RF-detector and hidden-stash selection arms, whose
-MCM getters hard-return `false`/`0.0` · `debug/debug_hidden_stashes`, whose tree
-entry is commented out · `scenarios/nearby_dead_stalker_scenario_weight`, a
-getter nothing calls.
+Currently marked dead: `scenarios/nearby_dead_stalker_scenario_weight`, a
+getter nothing calls. The RF-detector and hidden-stash selection arms used to
+be listed here too — their weight getters hard-returned `false`/`0.0` and
+`debug/debug_hidden_stashes`'s tree entry was commented out. Both scenarios are
+reachable again: real `enable_rf_detector_scenario`/`enable_hidden_stash_scenario`
+checkboxes and weight sliders gate them in `soulslike_scenario_logic_factory
+.create_new`, restricted to deaths where the player has no backpack equipped.
 
 ## Localisation
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -434,12 +434,10 @@ matches bare `medkit`/`bandage` while Anomaly ships variants (a balance
 decision, not a code bug).
 
 Currently marked dead: `scenarios/nearby_dead_stalker_scenario_weight`, a
-getter nothing calls. The RF-detector and hidden-stash selection arms used to
-be listed here too — their weight getters hard-returned `false`/`0.0` and
-`debug/debug_hidden_stashes`'s tree entry was commented out. Both scenarios are
-reachable again: real `enable_rf_detector_scenario`/`enable_hidden_stash_scenario`
-checkboxes and weight sliders gate them in `soulslike_scenario_logic_factory
-.create_new`, restricted to deaths where the player has no backpack equipped.
+getter nothing calls. The RF-detector and hidden-stash scenarios are gated by
+real `enable_rf_detector_scenario`/`enable_hidden_stash_scenario` checkboxes
+and weight sliders in `soulslike_scenario_logic_factory.create_new`,
+restricted to deaths where the player has no backpack equipped.
 
 ## Localisation
 

--- a/tests/e2e/rf_hidden_stash_recovery.spec.lua
+++ b/tests/e2e/rf_hidden_stash_recovery.spec.lua
@@ -1,0 +1,151 @@
+-- End to end: the player finds and opens their RF Detector / Hidden Stash
+-- marker box (physic_object_on_use_callback), pulling their gear out of the
+-- real hidden stash and into the box they can see.
+
+local H = require("harness.init")
+local B = H.builders
+
+local MOD_SCRIPTS = {
+    "soulslike_classes", "soulslike", "soulslike_mcm",
+    "soulslike_message_factory", "soulslike_scenarios",
+    "soulslike_scenario_logic_factory",
+}
+
+local TREASURE_ID, STASH_ID = 8080, 8081
+
+--- A world where a hidden stash exists behind a linked marker box, optionally
+--- holding items, optionally registered for a radio frequency, and optionally
+--- still offline.
+local function boot(opts)
+    opts = opts or {}
+    H.boot{ load = MOD_SCRIPTS, soulslike_mode = true }
+    H.fakes.set_random_min()
+    H.set_spawn{ level = "zaton" }
+    soulslike.on_game_start()
+
+    local box = H.world.container("treasure_box", { id = TREASURE_ID })
+    H.world.container("hidden_stash", { id = STASH_ID })
+
+    for _, sec in ipairs(opts.contents or {}) do
+        H.world.give("hidden_stash", sec)
+    end
+
+    soulslike.get_soulslike_state().hidden_stashes[TREASURE_ID] = {
+        stash_id = STASH_ID,
+        radio_id = opts.radio_id,
+        radio_level = opts.radio_id and "zaton" or nil,
+    }
+
+    if opts.offline then H.world.hide(STASH_ID) end
+
+    return box
+end
+
+local function use_box(box)
+    SendScriptCallback("physic_object_on_use_callback", box, nil)
+end
+
+describe("e2e: RF Detector / Hidden Stash recovery", function()
+
+    describe("given the linked box is used and the hidden stash is online", function()
+        local box
+
+        beforeEach(function()
+            box = boot{ contents = { "wpn_ak74", "medkit" } }
+            use_box(box)
+            H.tick()
+        end)
+
+        it("transfers the items into the box the player can see", function()
+            expect(H.world.contents("treasure_box")).toEqual({ "wpn_ak74", "medkit" })
+        end)
+
+        it("empties the hidden stash", function()
+            expect(H.world.contents("hidden_stash")).toEqual({})
+        end)
+
+        it("removes the PDA marker for the box", function()
+            expect(H.fakes.call_count("level.map_remove_object_spot")).toBe(1)
+            expect(H.fakes.last_call("level.map_remove_object_spot")[1]).toBe(TREASURE_ID)
+        end)
+
+        it("releases the hidden stash object", function()
+            expect(H.world.object(STASH_ID)).toBeNil()
+        end)
+
+        it("clears the hidden stash entry from the save", function()
+            expect(soulslike.get_soulslike_state().hidden_stashes[TREASURE_ID]).toBeNil()
+        end)
+    end)
+
+    describe("given the stash was registered for a radio frequency", function()
+        it("clears the radio registration", function()
+            local box = boot{ radio_id = TREASURE_ID }
+            use_box(box)
+            expect(H.fakes.call_count("item_radio.clear_stash")).toBe(1)
+            local call = H.fakes.last_call("item_radio.clear_stash")
+            expect(call[1]).toBe("zaton")
+            expect(call[2]).toBe(TREASURE_ID)
+        end)
+    end)
+
+    describe("given the stash was not registered for a radio frequency", function()
+        -- HiddenStash marks the treasure on the PDA instead of handing out a
+        -- radio note, so its hidden_stashes entry carries no radio_id.
+        it("does not touch the radio at all", function()
+            local box = boot()
+            use_box(box)
+            expect(H.fakes.call_count("item_radio.clear_stash")).toBe(0)
+        end)
+    end)
+
+    -- Mirrors the warn-and-bail path in physic_object_on_use_callback: the
+    -- stash id is registered but level.object_by_id can't find it yet.
+    describe("given the hidden stash is still offline", function()
+        local box
+
+        beforeEach(function()
+            box = boot{ contents = { "wpn_ak74" }, offline = true }
+        end)
+
+        it("does not crash", function()
+            expect(function() use_box(box) end).never.toThrow()
+        end)
+
+        it("does not transfer anything", function()
+            use_box(box)
+            H.tick()
+            expect(H.world.contents("treasure_box")).toEqual({})
+        end)
+
+        it("removes the now-invalid PDA marker for the box", function()
+            use_box(box)
+            expect(H.fakes.call_count("level.map_remove_object_spot")).toBe(1)
+            expect(H.fakes.last_call("level.map_remove_object_spot")[1]).toBe(TREASURE_ID)
+        end)
+
+        it("leaves the hidden stash entry in the save for a future retry", function()
+            use_box(box)
+            expect(soulslike.get_soulslike_state().hidden_stashes[TREASURE_ID]).toBeDefined()
+        end)
+    end)
+
+    describe("given the box is not linked to any hidden stash", function()
+        it("is ignored", function()
+            boot()
+            local unrelated = H.world.container("unrelated_box", { id = 9999 })
+            expect(function() use_box(unrelated) end).never.toThrow()
+            expect(soulslike.get_soulslike_state().hidden_stashes[TREASURE_ID]).toBeDefined()
+        end)
+    end)
+
+    describe("given the box is not an invbox at all", function()
+        it("is ignored", function()
+            boot()
+            local not_a_box = B.make_stalker{ name = "passerby" }
+            expect(function() use_box(not_a_box) end).never.toThrow()
+        end)
+    end)
+end)
+
+return true

--- a/tests/e2e/save_load_level_change.spec.lua
+++ b/tests/e2e/save_load_level_change.spec.lua
@@ -232,13 +232,11 @@ describe("e2e: a death across a level change", function()
         end)
     end)
 
-    -- Regression: HiddenStashSoulslikeScenarioLogic used to spawn its stash at
-    -- the death position and rely entirely on this relocation to move it to
-    -- where the PDA marker actually points (the linked treasure box). The bug
-    -- was in the fallback itself: it force-onlined the linked box (se_box),
-    -- not the hidden stash holding the items (soulslike.script:834-836) --
-    -- so the actual item container's online status was left to the engine's
-    -- default distance-based logic even after being teleported.
+    -- The relocation fallback must online the hidden stash holding the
+    -- items, not the linked box (se_box) it's being moved to match --
+    -- onlining the wrong one leaves the actual item container's online
+    -- status to the engine's default distance-based logic even after being
+    -- teleported.
     describe("on_game_load: hidden stash relocation", function()
         local BOX_ID, STASH_ID = 9001, 9002
 
@@ -281,6 +279,54 @@ describe("e2e: a death across a level change", function()
             SendScriptCallback("on_game_load")
             expect(H.world.server(STASH_ID).position.x).toBe(300)
             expect(H.world.server(STASH_ID).position.z).toBe(400)
+        end)
+    end)
+
+    -- A save carrying a hidden stash still at the death position (not yet
+    -- relocated to the treasure position its marker points at) has to
+    -- recover across a real level change, not just an in-place on_game_load
+    -- call: the fallback runs, then the player has to actually be able to
+    -- open the box and get their items.
+    describe("a hidden stash still at the wrong position, across a real level change", function()
+        local BOX_ID, STASH_ID = 9201, 9202
+
+        local function register_far_side_objects()
+            H.world.container("treasure_box", {
+                id = BOX_ID,
+                position = B.make_vector{ x = 300, y = 0, z = 400 },
+                online = true,
+            })
+            H.world.container("hidden_box", {
+                id = STASH_ID,
+                position = B.make_vector{ x = 0, y = 0, z = 0 },
+            })
+            H.world.give("hidden_box", "wpn_ak74")
+            H.world.hide(STASH_ID)
+        end
+
+        it("lets the player retrieve their items after the level changes", function()
+            boot_on_level("zaton")
+            register_far_side_objects()
+            soulslike.get_soulslike_state().hidden_stashes[BOX_ID] = { stash_id = STASH_ID }
+
+            SendScriptCallback("save_state", {})
+            change_level_to("jupiter")
+
+            -- The real engine reconstructs every alife object from the save
+            -- on load (m_flags survives, m_bOnline does not -- xray-monolith
+            -- xrServer_Objects_ALife.cpp:366/427-476). The harness's world
+            -- model only carries the mod's own game_state across H.reboot,
+            -- so the stale objects are rebuilt here to model that reload.
+            register_far_side_objects()
+
+            SendScriptCallback("load_state", {})
+            SendScriptCallback("on_game_load")
+
+            local box = H.world.object(BOX_ID)
+            SendScriptCallback("physic_object_on_use_callback", box, nil)
+            H.tick()
+
+            expect(H.world.contents("treasure_box")).toEqual({ "wpn_ak74" })
         end)
     end)
 

--- a/tests/e2e/save_load_level_change.spec.lua
+++ b/tests/e2e/save_load_level_change.spec.lua
@@ -232,6 +232,58 @@ describe("e2e: a death across a level change", function()
         end)
     end)
 
+    -- Regression: HiddenStashSoulslikeScenarioLogic used to spawn its stash at
+    -- the death position and rely entirely on this relocation to move it to
+    -- where the PDA marker actually points (the linked treasure box). The bug
+    -- was in the fallback itself: it force-onlined the linked box (se_box),
+    -- not the hidden stash holding the items (soulslike.script:834-836) --
+    -- so the actual item container's online status was left to the engine's
+    -- default distance-based logic even after being teleported.
+    describe("on_game_load: hidden stash relocation", function()
+        local BOX_ID, STASH_ID = 9001, 9002
+
+        local function set_up_hidden_stash()
+            H.world.container("treasure_box", {
+                id = BOX_ID,
+                position = B.make_vector{ x = 300, y = 0, z = 400 },
+                online = true,
+            })
+            H.world.container("hidden_box", {
+                id = STASH_ID,
+                position = B.make_vector{ x = 0, y = 0, z = 0 },
+            })
+            H.world.hide(STASH_ID)
+            soulslike.get_soulslike_state().hidden_stashes[BOX_ID] = { stash_id = STASH_ID }
+        end
+
+        beforeEach(function()
+            boot_on_level("zaton")
+            set_up_hidden_stash()
+        end)
+
+        it("forces the hidden stash itself online, not the linked box", function()
+            SendScriptCallback("on_game_load")
+
+            local onlined = {}
+            for _, call in ipairs(H.fakes.calls_to("alife.set_switch_online")) do
+                onlined[call[2]] = true
+            end
+
+            expect(onlined[STASH_ID]).toBe(true)
+        end)
+
+        it("makes the hidden stash findable via level.object_by_id afterwards", function()
+            SendScriptCallback("on_game_load")
+            expect(level.object_by_id(STASH_ID)).toBeDefined()
+        end)
+
+        it("moves the hidden stash to the linked box's position", function()
+            SendScriptCallback("on_game_load")
+            expect(H.world.server(STASH_ID).position.x).toBe(300)
+            expect(H.world.server(STASH_ID).position.z).toBe(400)
+        end)
+    end)
+
     describe("given the save has no scenario in progress", function()
         it("loads cleanly on the far side", function()
             boot_on_level("zaton")

--- a/tests/e2e/scenario_variants.spec.lua
+++ b/tests/e2e/scenario_variants.spec.lua
@@ -6,8 +6,13 @@
 --
 --   Default      backpack dropped where they died, marked straight on the PDA
 --   RFDetector   gear hidden in a treasure stash, located by radio frequency
---   HiddenStash  gear hidden at the death site, marked on the PDA
+--   HiddenStash  gear hidden in a treasure stash, marked straight on the PDA
 --   NoLoss       nothing taken at all
+--
+-- HiddenStash used to spawn its stash at the death position instead, with the
+-- PDA marker pointing at the treasure location -- two different places. Fixed
+-- to match RFDetector: both now spawn (and force online) at the treasure's own
+-- alife position, so the marker and the loot are never in different places.
 --
 -- Both hidden variants monkey-patch treasure_manager.box_in_same_map and
 -- restore it (:1414-1421, :1500-1508). The restore runs BEFORE the nil check,
@@ -111,7 +116,10 @@ describe("e2e: scenario variants", function()
         end)
 
         it("forces the stash online", function()
-            expect(se_stash).toBeDefined()
+            expect(H.fakes.call_count("alife.set_switch_online")).toBe(1)
+            local call = H.fakes.last_call("alife.set_switch_online")
+            expect(call[2]).toBe(se_stash.id)
+            expect(call[3]).toBe(true)
         end)
 
         it("wires the hidden stash to its radio", function()
@@ -177,6 +185,25 @@ describe("e2e: scenario variants", function()
 
         it("creates a hidden box", function()
             expect(H.world.created[1].section).toBe("hidden_box")
+        end)
+
+        -- Was spawned at the actor's death position instead: the PDA marker
+        -- (ApplyTransferItemsPostConditions, below) points at the treasure
+        -- location, so a stash sitting at the death spot was simply the wrong
+        -- place -- independent of the online/offline bug this also caused.
+        it("places it at the treasure, not at the body", function()
+            expect(H.world.created[1].container).toBeDefined()
+            expect(s.logic_state.treasure_stash_id).toBe(TREASURE_ID)
+            local treasure_pos = H.world.server(TREASURE_ID).position
+            expect(se_stash.position.x).toBeCloseTo(treasure_pos.x)
+            expect(se_stash.position.z).toBeCloseTo(treasure_pos.z)
+        end)
+
+        it("forces the stash online", function()
+            expect(H.fakes.call_count("alife.set_switch_online")).toBe(1)
+            local call = H.fakes.last_call("alife.set_switch_online")
+            expect(call[2]).toBe(se_stash.id)
+            expect(call[3]).toBe(true)
         end)
 
         it("registers the stash in the save", function()

--- a/tests/e2e/scenario_variants.spec.lua
+++ b/tests/e2e/scenario_variants.spec.lua
@@ -9,10 +9,8 @@
 --   HiddenStash  gear hidden in a treasure stash, marked straight on the PDA
 --   NoLoss       nothing taken at all
 --
--- HiddenStash used to spawn its stash at the death position instead, with the
--- PDA marker pointing at the treasure location -- two different places. Fixed
--- to match RFDetector: both now spawn (and force online) at the treasure's own
--- alife position, so the marker and the loot are never in different places.
+-- Both hidden variants spawn (and force online) at the treasure's own alife
+-- position, matching where their PDA marker/radio note actually points.
 --
 -- Both hidden variants monkey-patch treasure_manager.box_in_same_map and
 -- restore it (:1414-1421, :1500-1508). The restore runs BEFORE the nil check,
@@ -187,10 +185,8 @@ describe("e2e: scenario variants", function()
             expect(H.world.created[1].section).toBe("hidden_box")
         end)
 
-        -- Was spawned at the actor's death position instead: the PDA marker
-        -- (ApplyTransferItemsPostConditions, below) points at the treasure
-        -- location, so a stash sitting at the death spot was simply the wrong
-        -- place -- independent of the online/offline bug this also caused.
+        -- The PDA marker (ApplyTransferItemsPostConditions, below) points at
+        -- the treasure location, so the stash itself has to live there too.
         it("places it at the treasure, not at the body", function()
             expect(H.world.created[1].container).toBeDefined()
             expect(s.logic_state.treasure_stash_id).toBe(TREASURE_ID)

--- a/tests/harness/world.lua
+++ b/tests/harness/world.lua
@@ -418,9 +418,30 @@ function M.install(env)
             end
         end,
 
-        -- Forces (or requests) online/offline status. Mutates M.hidden so the
-        -- effect is observable through level.object_by_id, the same primitive
-        -- M.hide/M.reveal already drive for the "stash not online yet" retry.
+        -- alife():set_switch_online/offline are pure FLAG setters in the real
+        -- engine, not immediate actions (CALifeUpdateManager::set_switch_online
+        -- /set_switch_offline, alife_update_manager.cpp:333-345 -- each just
+        -- calls can_switch_online(bool)/can_switch_offline(bool), which toggle
+        -- bits in m_flags, xrServer_Objects_ALife.cpp:603-611). Every object is
+        -- constructed with every flag on (xrServer_Objects_ALife.cpp:374), so
+        -- normal distance-based switching is the default.
+        --
+        -- The flag that matters for this mod is can_switch_offline: when it is
+        -- false, try_switch_online's fast path force-onlines the object on the
+        -- next tick with NO distance check, and try_switch_offline's first
+        -- check refuses to ever offline it again -- it stays online permanently
+        -- (CSE_ALifeDynamicObject::try_switch_online/try_switch_offline,
+        -- alife_dynamic_object.cpp:130-181). That is the mechanism
+        -- set_switch_online(id,true) + set_switch_offline(id,false) relies on
+        -- (soulslike.script:734-735, soulslike_scenarios.script:1440-1441): it
+        -- is not "reveal now", it is "pin online forever", and the harness
+        -- collapses the one-tick delay to immediate since nothing here depends
+        -- on the gap.
+        --
+        -- set_switch_offline(id,true) is the inverse -- it only re-enables
+        -- ELIGIBILITY for future distance-based offlining. It does not force
+        -- the object offline immediately, and the harness has no distance
+        -- model to act on that eligibility, so it is a recorded no-op here.
         set_switch_online = function(self, id, online)
             record_online(self, id, online)
             local se = servers[id]
@@ -432,9 +453,8 @@ function M.install(env)
         set_switch_offline = function(self, id, offline)
             record_offline(self, id, offline)
             local se = servers[id]
-            if offline ~= false then
-                if se then se.online = false end
-                M.hide(id)
+            if offline == false then
+                if se then se.pinned_online = true end
             end
         end,
         release           = function(_, o) M.queue_release(o) end,

--- a/tests/harness/world.lua
+++ b/tests/harness/world.lua
@@ -385,6 +385,11 @@ function M.install(env)
 
     env.alife = function() return M.sim end
 
+    local fakes = require("harness.fakes")
+    local record_teleport = fakes.recorder("alife.teleport_object")
+    local record_online   = fakes.recorder("alife.set_switch_online")
+    local record_offline  = fakes.recorder("alife.set_switch_offline")
+
     M.sim = {
         actor = function()
             local a = env.db and env.db.actor
@@ -399,9 +404,39 @@ function M.install(env)
         end,
         object            = function(_, id) return servers[id] end,
         level_name        = function(_, _) return M.level_name_for_gvid end,
-        teleport_object   = function() end,
-        set_switch_online = function() end,
-        set_switch_offline= function() end,
+
+        -- Server-side, offline-safe repositioning (soulslike.script:832/842).
+        -- Mutates the server object's own position/vertex fields, which is
+        -- what the mod reads back afterwards (e.g. se_box.position).
+        teleport_object = function(self, id, gvid, lvid, pos)
+            record_teleport(self, id, gvid, lvid, pos)
+            local se = servers[id]
+            if se then
+                se.m_game_vertex_id = gvid
+                se.m_level_vertex_id = lvid
+                se.position = pos
+            end
+        end,
+
+        -- Forces (or requests) online/offline status. Mutates M.hidden so the
+        -- effect is observable through level.object_by_id, the same primitive
+        -- M.hide/M.reveal already drive for the "stash not online yet" retry.
+        set_switch_online = function(self, id, online)
+            record_online(self, id, online)
+            local se = servers[id]
+            if online ~= false then
+                if se then se.online = true end
+                M.reveal(id)
+            end
+        end,
+        set_switch_offline = function(self, id, offline)
+            record_offline(self, id, offline)
+            local se = servers[id]
+            if offline ~= false then
+                if se then se.online = false end
+                M.hide(id)
+            end
+        end,
         release           = function(_, o) M.queue_release(o) end,
 
         -- register() FREES its argument and returns a NEW pointer

--- a/tests/self/world.spec.lua
+++ b/tests/self/world.spec.lua
@@ -210,12 +210,9 @@ describe("harness/world", function()
     end)
 
     describe("alife():set_switch_online() / set_switch_offline() / teleport_object()", function()
-        -- These back the online/offline fix ported from
-        -- RFDetectorSoulslikeScenarioLogic to HiddenStashSoulslikeScenarioLogic
-        -- (soulslike_scenarios.script:1440-1441) and the relocation loop in
-        -- on_game_load (soulslike.script:832). They used to be no-ops, which
-        -- made specs asserting "forces the stash online" toothless -- they only
-        -- checked the stash existed, never that onlining was requested.
+        -- Recording these calls (rather than modeling them as no-ops) is
+        -- what lets a spec assert "forces the stash online" for real, instead
+        -- of only checking the stash exists.
         describe("set_switch_online()", function()
             it("records the call", function()
                 local se = alife_create("hidden_box", actor:position(), 1, 1)
@@ -236,20 +233,39 @@ describe("harness/world", function()
         end)
 
         describe("set_switch_offline()", function()
-            it("hides the object from level.object_by_id when passed true", function()
+            -- The real engine call is a flag setter, not an immediate action
+            -- (CALifeUpdateManager::set_switch_offline,
+            -- alife_update_manager.cpp:333-345): passing true only
+            -- re-enables ELIGIBILITY for future distance-based offlining
+            -- (CSE_ALifeDynamicObject::try_switch_offline,
+            -- alife_dynamic_object.cpp:166-181), it does not force the
+            -- object offline on the spot. The harness has no distance model
+            -- to act on that eligibility, so this is a recorded no-op.
+            it("does not hide the object when passed true", function()
                 local se = alife_create("hidden_box", actor:position(), 1, 1)
                 alife():set_switch_offline(se.id, true)
-                expect(level.object_by_id(se.id)).toBeNil()
+                expect(level.object_by_id(se.id)).toBeDefined()
             end)
 
+            -- Passing false is the actual "pin online forever" mechanism: it
+            -- makes can_switch_offline() return false, so try_switch_online's
+            -- fast path force-onlines the object with no distance check, and
+            -- try_switch_offline's first check refuses to ever offline it
+            -- again (alife_dynamic_object.cpp:130-181). RFDetectorSoulslike
+            -- ScenarioLogic:CreateStash calls this right after forcing it
+            -- online (soulslike_scenarios.script:1441) -- it must not undo
+            -- the online request.
             it("leaves it visible when passed false", function()
-                -- RFDetectorSoulslikeScenarioLogic:CreateStash calls this with
-                -- false right after forcing it online (soulslike_scenarios.script:1441)
-                -- -- it must not undo the online request.
                 local se = alife_create("hidden_box", actor:position(), 1, 1)
                 alife():set_switch_online(se.id, true)
                 alife():set_switch_offline(se.id, false)
                 expect(level.object_by_id(se.id)).toBeDefined()
+            end)
+
+            it("marks the server object pinned online", function()
+                local se = alife_create("hidden_box", actor:position(), 1, 1)
+                alife():set_switch_offline(se.id, false)
+                expect(se.pinned_online).toBe(true)
             end)
         end)
 

--- a/tests/self/world.spec.lua
+++ b/tests/self/world.spec.lua
@@ -209,6 +209,62 @@ describe("harness/world", function()
         end)
     end)
 
+    describe("alife():set_switch_online() / set_switch_offline() / teleport_object()", function()
+        -- These back the online/offline fix ported from
+        -- RFDetectorSoulslikeScenarioLogic to HiddenStashSoulslikeScenarioLogic
+        -- (soulslike_scenarios.script:1440-1441) and the relocation loop in
+        -- on_game_load (soulslike.script:832). They used to be no-ops, which
+        -- made specs asserting "forces the stash online" toothless -- they only
+        -- checked the stash existed, never that onlining was requested.
+        describe("set_switch_online()", function()
+            it("records the call", function()
+                local se = alife_create("hidden_box", actor:position(), 1, 1)
+                world.hide(se.id)
+                alife():set_switch_online(se.id, true)
+                expect(H.fakes.call_count("alife.set_switch_online")).toBe(1)
+                local call = H.fakes.last_call("alife.set_switch_online")
+                expect(call[2]).toBe(se.id)
+                expect(call[3]).toBe(true)
+            end)
+
+            it("makes a hidden object findable via level.object_by_id again", function()
+                local se = alife_create("hidden_box", actor:position(), 1, 1)
+                world.hide(se.id)
+                alife():set_switch_online(se.id, true)
+                expect(level.object_by_id(se.id)).toBeDefined()
+            end)
+        end)
+
+        describe("set_switch_offline()", function()
+            it("hides the object from level.object_by_id when passed true", function()
+                local se = alife_create("hidden_box", actor:position(), 1, 1)
+                alife():set_switch_offline(se.id, true)
+                expect(level.object_by_id(se.id)).toBeNil()
+            end)
+
+            it("leaves it visible when passed false", function()
+                -- RFDetectorSoulslikeScenarioLogic:CreateStash calls this with
+                -- false right after forcing it online (soulslike_scenarios.script:1441)
+                -- -- it must not undo the online request.
+                local se = alife_create("hidden_box", actor:position(), 1, 1)
+                alife():set_switch_online(se.id, true)
+                alife():set_switch_offline(se.id, false)
+                expect(level.object_by_id(se.id)).toBeDefined()
+            end)
+        end)
+
+        describe("teleport_object()", function()
+            it("moves the server object's position and vertex ids", function()
+                local se = alife_create("hidden_box", actor:position(), 1, 1)
+                local new_pos = require("harness.builders").make_vector({ x = 10, y = 0, z = 20 })
+                alife():teleport_object(se.id, 5, 7, new_pos)
+                expect(se.m_game_vertex_id).toBe(5)
+                expect(se.m_level_vertex_id).toBe(7)
+                expect(se.position).toBe(new_pos)
+            end)
+        end)
+    end)
+
     describe("alife_create_item()", function()
         describe("given an owner", function()
             it("puts the item in that owner's container", function()

--- a/tests/unit/create_new.spec.lua
+++ b/tests/unit/create_new.spec.lua
@@ -47,6 +47,28 @@ local function boot(distance)
     return factory
 end
 
+local function give_backpack()
+    H.fakes.set_ltx("itm_actor_backpack", { kind = "i_backpack" })
+    H.world.give("actor", "itm_actor_backpack")
+end
+
+--- Configures both scenarios enabled with a weight that dominates the 0.05
+--- NoLoss slice, then picks a roll that reliably lands past it -- enough to
+--- prove the arm is reachable at all without depending on exactly which of
+--- the two (RF vs Hidden) the roll lands on.
+local function disable_rf_and_hidden()
+    H.fakes.set_mcm("scenarios/enable_rf_detector_scenario", false)
+    H.fakes.set_mcm("scenarios/enable_hidden_stash_scenario", false)
+end
+
+local function make_rf_and_hidden_reachable()
+    H.fakes.set_mcm("scenarios/enable_rf_detector_scenario", true)
+    H.fakes.set_mcm("scenarios/rf_detector_scenario_weight", 1.0)
+    H.fakes.set_mcm("scenarios/enable_hidden_stash_scenario", true)
+    H.fakes.set_mcm("scenarios/hidden_stash_scenario_weight", 1.0)
+    H.fakes.set_random_const(0.5)
+end
+
 --- One hit whose draftsman resolves to `obj`, flagged fatal.
 local function fatal_hit_from(obj)
     if obj then H.fakes.register_object(obj) end
@@ -113,27 +135,23 @@ describe("soulslike_scenario_logic_factory.create_new()", function()
         end)
     end)
 
-    -- DEAD CODE: debug_the_rf_scenario and debug_the_hidden_stash_scenario
-    -- hard-return false (soulslike_mcm.script:1138, :1142) with the real
-    -- expression commented out, so these two arms cannot be reached. Those
-    -- scenarios are only ever constructed via create_by_id on a save reload.
-    describe("DEAD CODE: the rf and hidden-stash debug flags", function()
-        it("does not reach the rf arm even with the flag set", function()
+    describe("the rf and hidden-stash debug flags", function()
+        it("forces the rf arm when the flag is set", function()
             H.fakes.set_mcm("debug/is_enabled", true)
             H.fakes.set_mcm("debug/debug_the_rf_scenario", true)
             local s = factory.create_new(fatal_hit_from(enemy_mutant))
-            expect(s.logic_state.scenario_id).never.toBe(SCENARIOS.RFDetectorStash)
+            expect(s.logic_state.scenario_id).toBe(SCENARIOS.RFDetectorStash)
         end)
 
-        it("does not reach the hidden-stash arm even with the flag set", function()
+        it("forces the hidden-stash arm when the flag is set", function()
             H.fakes.set_mcm("debug/is_enabled", true)
             H.fakes.set_mcm("debug/debug_the_hidden_stash_scenario", true)
             local s = factory.create_new(fatal_hit_from(enemy_mutant))
-            expect(s.logic_state.scenario_id).never.toBe(SCENARIOS.HiddenStash)
+            expect(s.logic_state.scenario_id).toBe(SCENARIOS.HiddenStash)
         end)
 
-        it("keeps the getters hard-returning false", function()
-            H.fakes.set_mcm("debug/is_enabled", true)
+        it("ignores both flags with debug off", function()
+            H.fakes.set_mcm("debug/is_enabled", false)
             H.fakes.set_mcm("debug/debug_the_rf_scenario", true)
             H.fakes.set_mcm("debug/debug_the_hidden_stash_scenario", true)
             expect(soulslike_mcm.debug_the_rf_scenario()).toBe(false)
@@ -236,17 +254,34 @@ describe("soulslike_scenario_logic_factory.create_new()", function()
 
         describe("and carries a backpack", function()
             it("can run the Default scenario", function()
-                H.fakes.set_ltx("itm_actor_backpack", { kind = "i_backpack" })
-                H.world.give("actor", "itm_actor_backpack")
+                give_backpack()
                 H.fakes.set_random_const(0.99)   -- weight the roll to Default
+                expect(suicide().logic_state.scenario_id).toBe(SCENARIOS.Default)
+            end)
+
+            it("excludes RF Detector and Hidden Stash regardless of weight", function()
+                give_backpack()
+                H.fakes.set_mcm("scenarios/enable_rf_detector_scenario", true)
+                H.fakes.set_mcm("scenarios/rf_detector_scenario_weight", 1.0)
+                H.fakes.set_mcm("scenarios/enable_hidden_stash_scenario", true)
+                H.fakes.set_mcm("scenarios/hidden_stash_scenario_weight", 1.0)
+                H.fakes.set_random_const(0.99)
                 expect(suicide().logic_state.scenario_id).toBe(SCENARIOS.Default)
             end)
         end)
 
         describe("and carries no backpack", function()
-            it("can only run NoLoss", function()
+            it("can only run NoLoss when RF Detector/Hidden Stash are disabled", function()
+                disable_rf_and_hidden()
                 H.fakes.set_random_const(0.99)
                 expect(suicide().logic_state.scenario_id).toBe(SCENARIOS.NoLoss)
+            end)
+
+            it("makes RF Detector/Hidden Stash reachable when enabled", function()
+                make_rf_and_hidden_reachable()
+                local id = suicide().logic_state.scenario_id
+                expect(id == SCENARIOS.RFDetectorStash or id == SCENARIOS.HiddenStash)
+                    .toBe(true)
             end)
         end)
     end)
@@ -332,6 +367,33 @@ describe("soulslike_scenario_logic_factory.create_new()", function()
             expect(s.logic_state.killer_id).toBe(killer:id())
             expect(s.logic_state.killer_type).toBe(soulslike.entity_type.Stalker)
         end)
+
+        describe("and carries no backpack", function()
+            it("can only run NoLoss when RF Detector/Hidden Stash are disabled", function()
+                disable_rf_and_hidden()
+                H.fakes.set_random_const(0.99)
+                expect(murdered().logic_state.scenario_id).toBe(SCENARIOS.NoLoss)
+            end)
+
+            it("makes RF Detector/Hidden Stash reachable when enabled", function()
+                make_rf_and_hidden_reachable()
+                local id = murdered().logic_state.scenario_id
+                expect(id == SCENARIOS.RFDetectorStash or id == SCENARIOS.HiddenStash)
+                    .toBe(true)
+            end)
+        end)
+
+        describe("and carries a backpack", function()
+            it("excludes RF Detector and Hidden Stash regardless of weight", function()
+                give_backpack()
+                H.fakes.set_mcm("scenarios/enable_rf_detector_scenario", true)
+                H.fakes.set_mcm("scenarios/rf_detector_scenario_weight", 1.0)
+                H.fakes.set_mcm("scenarios/enable_hidden_stash_scenario", true)
+                H.fakes.set_mcm("scenarios/hidden_stash_scenario_weight", 1.0)
+                H.fakes.set_random_const(0.99)
+                expect(murdered().logic_state.scenario_id).toBe(SCENARIOS.Default)
+            end)
+        end)
     end)
 
     describe("given a mutant killed the player", function()
@@ -353,6 +415,15 @@ describe("soulslike_scenario_logic_factory.create_new()", function()
         it("records the looter as a monster", function()
             expect(mauled().logic_state.looter_type).toBe(soulslike.entity_type.Monster)
         end)
+
+        describe("and carries no backpack", function()
+            it("makes RF Detector/Hidden Stash reachable when enabled", function()
+                make_rf_and_hidden_reachable()
+                local id = mauled().logic_state.scenario_id
+                expect(id == SCENARIOS.RFDetectorStash or id == SCENARIOS.HiddenStash)
+                    .toBe(true)
+            end)
+        end)
     end)
 
     describe("given an anomaly killed the player", function()
@@ -368,6 +439,33 @@ describe("soulslike_scenario_logic_factory.create_new()", function()
         it("takes the looter from the generic enemy finder", function()
             burned()
             expect(B.finder_count("enemy")).toBe(1)
+        end)
+
+        describe("and carries no backpack", function()
+            it("can only run NoLoss when RF Detector/Hidden Stash are disabled", function()
+                disable_rf_and_hidden()
+                H.fakes.set_random_const(0.99)
+                expect(burned().logic_state.scenario_id).toBe(SCENARIOS.NoLoss)
+            end)
+
+            it("makes RF Detector/Hidden Stash reachable when enabled", function()
+                make_rf_and_hidden_reachable()
+                local id = burned().logic_state.scenario_id
+                expect(id == SCENARIOS.RFDetectorStash or id == SCENARIOS.HiddenStash)
+                    .toBe(true)
+            end)
+        end)
+
+        describe("and carries a backpack", function()
+            it("excludes RF Detector and Hidden Stash regardless of weight", function()
+                give_backpack()
+                H.fakes.set_mcm("scenarios/enable_rf_detector_scenario", true)
+                H.fakes.set_mcm("scenarios/rf_detector_scenario_weight", 1.0)
+                H.fakes.set_mcm("scenarios/enable_hidden_stash_scenario", true)
+                H.fakes.set_mcm("scenarios/hidden_stash_scenario_weight", 1.0)
+                H.fakes.set_random_const(0.99)
+                expect(burned().logic_state.scenario_id).toBe(SCENARIOS.Default)
+            end)
         end)
     end)
 

--- a/tests/unit/mcm_defaults.spec.lua
+++ b/tests/unit/mcm_defaults.spec.lua
@@ -286,24 +286,54 @@ describe("soulslike_mcm defaults", function()
         end)
     end)
 
-    describe("DEAD CODE: the disabled scenario weights", function()
-        -- These three hard-return 0.0 with the real get_config call commented
-        -- out (:961-971), and the two debug scenario getters hard-return false
-        -- (:1138, :1142). The RF Detector and Hidden Stash scenarios are
-        -- therefore unreachable through create_new; they exist only for saves
-        -- that already selected them.
-        it("keeps the weights at zero whatever is configured", function()
-            H.fakes.set_mcm("scenarios/rf_detector_scenario_weight", 1.0)
-            H.fakes.set_mcm("scenarios/hidden_stash_scenario_weight", 1.0)
+    describe("DEAD CODE: the scattered stash weight", function()
+        -- Hard-returns 0.0 with the real get_config call commented out
+        -- (:986-988). Unlike RF Detector/Hidden Stash, this scenario has no
+        -- SCENARIOS enum entry and nothing in the factory ever reads it --
+        -- out of scope for the RF Detector/Hidden Stash re-enable.
+        it("keeps the weight at zero whatever is configured", function()
             H.fakes.set_mcm("scenarios/scattered_stash_scenario_weight", 1.0)
+            expect(soulslike_mcm.scattered_stash_scenario_weight()).toBe(0.0)
+        end)
+    end)
+
+    describe("the RF Detector and Hidden Stash scenario options", function()
+        it("weight defaults to 0.10 with its enable flag left at the default", function()
+            expect(soulslike_mcm.rf_detector_scenario_weight()).toBeCloseTo(0.10)
+            expect(soulslike_mcm.hidden_stash_scenario_weight()).toBeCloseTo(0.10)
+        end)
+
+        it("reads the configured weight when enabled", function()
+            H.fakes.set_mcm("scenarios/enable_rf_detector_scenario", true)
+            H.fakes.set_mcm("scenarios/rf_detector_scenario_weight", 0.5)
+            H.fakes.set_mcm("scenarios/enable_hidden_stash_scenario", true)
+            H.fakes.set_mcm("scenarios/hidden_stash_scenario_weight", 0.75)
+
+            expect(soulslike_mcm.rf_detector_scenario_weight()).toBeCloseTo(0.5)
+            expect(soulslike_mcm.hidden_stash_scenario_weight()).toBeCloseTo(0.75)
+        end)
+
+        it("forces the weight to zero when its enable flag is off", function()
+            H.fakes.set_mcm("scenarios/enable_rf_detector_scenario", false)
+            H.fakes.set_mcm("scenarios/rf_detector_scenario_weight", 0.5)
+            H.fakes.set_mcm("scenarios/enable_hidden_stash_scenario", false)
+            H.fakes.set_mcm("scenarios/hidden_stash_scenario_weight", 0.75)
 
             expect(soulslike_mcm.rf_detector_scenario_weight()).toBe(0.0)
             expect(soulslike_mcm.hidden_stash_scenario_weight()).toBe(0.0)
-            expect(soulslike_mcm.scattered_stash_scenario_weight()).toBe(0.0)
         end)
 
-        it("keeps the debug scenario flags false even with debug on", function()
+        it("reads the debug scenario flags when debug is on", function()
             H.fakes.set_mcm("debug/is_enabled", true)
+            H.fakes.set_mcm("debug/debug_the_rf_scenario", true)
+            H.fakes.set_mcm("debug/debug_the_hidden_stash_scenario", true)
+
+            expect(soulslike_mcm.debug_the_rf_scenario()).toBe(true)
+            expect(soulslike_mcm.debug_the_hidden_stash_scenario()).toBe(true)
+        end)
+
+        it("ignores the debug scenario flags when debug is off", function()
+            H.fakes.set_mcm("debug/is_enabled", false)
             H.fakes.set_mcm("debug/debug_the_rf_scenario", true)
             H.fakes.set_mcm("debug/debug_the_hidden_stash_scenario", true)
 

--- a/tests/unit/mcm_options.spec.lua
+++ b/tests/unit/mcm_options.spec.lua
@@ -395,23 +395,18 @@ describe("soulslike_mcm.on_mcm_load()", function()
         -- a control that does nothing; a key read by a getter but absent from
         -- the tree is a setting the player cannot reach.
 
-        -- DEAD CODE. Two getters read keys that the tree does not declare, so
-        -- neither can ever be anything but its default. Both belong to the
-        -- disabled scenario cluster and are listed rather than ignored, so
-        -- re-enabling that cluster surfaces them as part of the work.
-        --
-        --   debug/debug_hidden_stashes
-        --     Tree entry commented out at soulslike_mcm.script:872. Its only
-        --     consumer is RFDetectorSoulslikeScenarioLogic
-        --     :ApplyTransferItemsPostConditions (soulslike_scenarios.script
-        --     :1473), and that scenario is unreachable through create_new --
-        --     its weight and debug flag both hard-return zero/false.
+        -- DEAD CODE. One getter reads a key the tree does not declare, so it
+        -- can never be anything but its default.
         --
         --   scenarios/nearby_dead_stalker_scenario_weight
         --     Getter defined at soulslike_mcm.script:973 and called by nothing
         --     at all: a scenario that was never built.
+        --
+        -- debug/debug_hidden_stashes used to be listed here too -- its tree
+        -- entry was commented out, alongside the rest of the RF Detector/
+        -- Hidden Stash cluster. Both are live now (soulslike_mcm.script's
+        -- scenarios/debug groups), so this key is reachable again.
         local KNOWN_UNREACHABLE = {
-            ["debug/debug_hidden_stashes"] = true,
             ["scenarios/nearby_dead_stalker_scenario_weight"] = true,
         }
 

--- a/tests/unit/mcm_options.spec.lua
+++ b/tests/unit/mcm_options.spec.lua
@@ -401,11 +401,6 @@ describe("soulslike_mcm.on_mcm_load()", function()
         --   scenarios/nearby_dead_stalker_scenario_weight
         --     Getter defined at soulslike_mcm.script:973 and called by nothing
         --     at all: a scenario that was never built.
-        --
-        -- debug/debug_hidden_stashes used to be listed here too -- its tree
-        -- entry was commented out, alongside the rest of the RF Detector/
-        -- Hidden Stash cluster. Both are live now (soulslike_mcm.script's
-        -- scenarios/debug groups), so this key is reachable again.
         local KNOWN_UNREACHABLE = {
             ["scenarios/nearby_dead_stalker_scenario_weight"] = true,
         }


### PR DESCRIPTION
## Summary

- Re-enables the `RFDetectorStash` and `HiddenStash` death scenarios (gear hidden in a stash instead of dropped in a backpack), disabled since `e76de16` (2025-01-10) as a side effect of an unrelated fix. Both were fully implemented but unreachable in normal play.
- Fixes `HiddenStash`'s online/offline handling, which never received the fix `RFDetectorStash` got in 2023 (`7c76a8a`). It spawned its loot box at the death position while its PDA marker pointed at the treasure location — two different places — and its `on_game_load` fallback relocation onlined the wrong object (the marker box, not the item container).
- Restricts both scenarios to deaths where the player has no backpack equipped (`find_backpack()`, already present in the factory), with real MCM enable checkboxes and weight sliders, plus eng/rus localization for the new options.
- Verified the online/offline model against the actual engine source (`xray-monolith`) and the shipped Anomaly scripts, not just plausible-looking Lua. That surfaced two more bugs, fixed here too: the test harness modeled `set_switch_offline(id, true)` as an immediate hide, when the real engine only re-enables future distance-based eligibility; and the mod called `se_obj:switch_online()` directly on inventory-box server objects in two places — that method exists for items/monsters/stalkers but not inventory boxes, so it was a latent crash risk. Both replaced with the confirmed-safe `alife():set_switch_online` API.

## Root cause

`RFDetectorSoulslikeScenarioLogic:CreateStash` spawns its `hidden_box` at the treasure stash's own alife position and force-switches it online (`sim:set_switch_online`/`set_switch_offline`). `HiddenStashSoulslikeScenarioLogic:CreateStash` never got this treatment — it spawned at `actor:position()` and relied on `on_game_load` to relocate it later, but that callback only fires on an actual save/load cycle (not on ordinary level transitions), and even then it called `switch_online()` on the linked marker box instead of the hidden stash holding the items.

Per the engine source: `set_switch_offline(id, false)` is what actually pins an object online — it disables the engine's distance-based offline check permanently, and that pin survives a level change (a level change is a full alife save/reload; the pin flag is serialized, only the live online state resets and gets restored on the next tick). This confirms the fix is sound, not just plausible.

## Changes

- `soulslike_scenarios.script`: `HiddenStashSoulslikeScenarioLogic:CreateStash` now spawns at the treasure's own position and forces it online, mirroring `RFDetectorSoulslikeScenarioLogic`.
- `soulslike.script`: `on_game_load`'s defensive relocation fallback now onlines the hidden stash itself, not the linked box. Also replaced two `se_obj:switch_online()` calls (in `physic_object_on_use_callback` and the item-relocation loop) with the confirmed-safe simulator API.
- `soulslike_scenario_logic_factory.script`: uncommented the RF/Hidden weighting branches in `create_new`, gated on `has_backpack` (restructured three branches that previously had no `else`).
- `soulslike_mcm.script`: restored real MCM getters/tree entries for the scenario weights, debug flags, and added new `enable_rf_detector_scenario`/`enable_hidden_stash_scenario` checkboxes.
- `ui_st_mcm_soulslite.xml` (eng + rus): added the 7 new localized strings. The Russian file stays windows-1251 (edited via a codepage-aware script, not the normal editor, per this repo's known mojibake footgun).
- `tests/harness/world.lua`: `set_switch_online`/`set_switch_offline`/`teleport_object` were no-op stubs — now record calls and mutate online/offline state to match the real engine's flag semantics (verified against `xray-monolith`).
- New: `tests/e2e/rf_hidden_stash_recovery.spec.lua` — end-to-end coverage for `physic_object_on_use_callback` (previously untested anywhere in the suite), including the still-offline warn-and-bail path.
- New/updated specs: regression coverage for the online/offline relocation path, a full round trip proving a hidden stash recovers correctly across a real level change, backpack-gating across multiple death-cause branches, and updated stale `DEAD CODE` markers now that these getters/branches are live.

## Test plan

- [x] `tests\run.bat` — 673 passing
- [x] `tests\locals.bat` — clean, no missing/orphan/duplicate/parity gaps
- [x] `tests\tools\luajit.exe tests\probe.lua` — 72 reachable, 0 unreachable
- [x] Online/offline semantics cross-checked against `xray-monolith` engine source and the shipped Anomaly 1.5.3 scripts, not just plausible-looking Lua
- [ ] Manual in-game check: die with no backpack, leave the level, return later, confirm the stash and its items load in correctly (not run — this PR exercises the harness's model of `alife`'s switch/teleport semantics, not a live Anomaly session)
